### PR TITLE
README: detail how to change the interface used

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ make \
 	M=$PATH_TO_BPFILTER_SOURCES
 ```
 
+At present, the code statically sets the interface to which bpfilter is attached. However, there are plans to enhance this functionality in the future. As of now, you will need to make changes to `PROG_IFINDEX` in `codegen.c` if you want to modify the interface.
 
 ## License
 

--- a/codegen.c
+++ b/codegen.c
@@ -29,6 +29,8 @@
 #include "rule.h"
 #include "table.h"
 
+#define PROG_IFINDEX 2
+
 enum fixup_insn_type {
 	FIXUP_INSN_OFF,
 	FIXUP_INSN_IMM,
@@ -533,7 +535,7 @@ static int tc_load_img(struct codegen *codegen)
 	}
 
 	img_ctx->hook.sz = sizeof(img_ctx->hook);
-	img_ctx->hook.ifindex = 2;
+	img_ctx->hook.ifindex = PROG_IFINDEX;
 	img_ctx->hook.attach_point = codegen->bpf_tc_hook;
 
 	fd = load_img(codegen);


### PR DESCRIPTION
Currently, bpfilter statically defined which interface it's attached to. While this will change in the future, it can be confusing for the users.

Added a comment in the README.md to explain how to change which interface bpfilter is attached to.