### PR TITLE
tests: use __COUNTER__ for TestAssert

### DIFF
--- a/tests/unit/src/core/context.c
+++ b/tests/unit/src/core/context.c
@@ -19,4 +19,4 @@ Test(src_core_context, new)
     cr_assert_eq(context, NULL);
 }
 
-TestAssert(src_core_context, _bf_context_new, 0, (NULL));
+TestAssert(src_core_context, _bf_context_new, (NULL));

--- a/tests/unit/src/core/flavor.c
+++ b/tests/unit/src/core/flavor.c
@@ -9,10 +9,10 @@
 
 #include "test.h"
 
-TestAssert(src_core_flavor, bf_flavor_ops_get, 0, (-1));
-TestAssert(src_core_flavor, bf_flavor_ops_get, 1, (_BF_FLAVOR_MAX));
-TestAssert(src_core_flavor, bf_flavor_to_str, 0, (-1));
-TestAssert(src_core_flavor, bf_flavor_to_str, 1, (_BF_FLAVOR_MAX));
+TestAssert(src_core_flavor, bf_flavor_ops_get, (-1));
+TestAssert(src_core_flavor, bf_flavor_ops_get, (_BF_FLAVOR_MAX));
+TestAssert(src_core_flavor, bf_flavor_to_str, (-1));
+TestAssert(src_core_flavor, bf_flavor_to_str, (_BF_FLAVOR_MAX));
 
 Test(src_core_flavor, can_get_flavor_ops)
 {

--- a/tests/unit/src/core/helper.c
+++ b/tests/unit/src/core/helper.c
@@ -17,11 +17,11 @@ static const char content[] =
     "Elle change de main, il a beau dire que ses parents n'ont pas un sou"
     "Au fond, tout le monde s'en fout, les trois types, les gens autour";
 
-TestAssert(src_core_helper, bf_read_file, 0, (NULL, NOT_NULL, NOT_NULL));
-TestAssert(src_core_helper, bf_read_file, 1, (NOT_NULL, NULL, NOT_NULL));
-TestAssert(src_core_helper, bf_read_file, 2, (NOT_NULL, NOT_NULL, NULL));
-TestAssert(src_core_helper, bf_write_file, 0, (NULL, NOT_NULL, 0));
-TestAssert(src_core_helper, bf_write_file, 1, (NOT_NULL, NULL, 0));
+TestAssert(src_core_helper, bf_read_file, (NULL, NOT_NULL, NOT_NULL));
+TestAssert(src_core_helper, bf_read_file, (NOT_NULL, NULL, NOT_NULL));
+TestAssert(src_core_helper, bf_read_file, (NOT_NULL, NOT_NULL, NULL));
+TestAssert(src_core_helper, bf_write_file, (NULL, NOT_NULL, 0));
+TestAssert(src_core_helper, bf_write_file, (NOT_NULL, NULL, 0));
 
 Test(src_core_helper, write_and_read_file)
 {

--- a/tests/unit/src/core/hook.c
+++ b/tests/unit/src/core/hook.c
@@ -9,12 +9,12 @@
 
 #include "test.h"
 
-TestAssert(src_core_hook, bf_hook_to_str, 0, (-1));
-TestAssert(src_core_hook, bf_hook_to_str, 1, (_BF_HOOK_MAX));
-TestAssert(src_core_hook, bf_hook_to_bpf_prog_type, 0, (-1));
-TestAssert(src_core_hook, bf_hook_to_bpf_prog_type, 1, (_BF_HOOK_MAX));
-TestAssert(src_core_hook, bf_hook_to_flavor, 0, (-1));
-TestAssert(src_core_hook, bf_hook_to_flavor, 1, (_BF_HOOK_MAX));
+TestAssert(src_core_hook, bf_hook_to_str, (-1));
+TestAssert(src_core_hook, bf_hook_to_str, (_BF_HOOK_MAX));
+TestAssert(src_core_hook, bf_hook_to_bpf_prog_type, (-1));
+TestAssert(src_core_hook, bf_hook_to_bpf_prog_type, (_BF_HOOK_MAX));
+TestAssert(src_core_hook, bf_hook_to_flavor, (-1));
+TestAssert(src_core_hook, bf_hook_to_flavor, (_BF_HOOK_MAX));
 
 Test(src_core_hook, can_get_str_from_hook)
 {

--- a/tests/unit/src/core/list.c
+++ b/tests/unit/src/core/list.c
@@ -76,21 +76,21 @@ static void init_and_fill(bf_list *l, size_t count, const bf_list_ops *ops,
 static bf_list_ops noop_ops = {.free = noop_free};
 static bf_list_ops dummy_ops = {.free = dummy_free};
 
-TestAssert(src_core_list, bf_list_new, 0, (NULL, NOT_NULL));
-TestAssert(src_core_list, bf_list_new, 1, (NOT_NULL, NULL));
-TestAssert(src_core_list, bf_list_free, 0, (NULL));
-TestAssert(src_core_list, bf_list_init, 0, (NULL, NOT_NULL));
-TestAssert(src_core_list, bf_list_init, 1, (NOT_NULL, NULL));
-TestAssert(src_core_list, bf_list_clean, 0, (NULL));
-TestAssert(src_core_list, bf_list_size, 0, (NULL));
-TestAssert(src_core_list, bf_list_add_head, 0, (NULL, NOT_NULL));
-TestAssert(src_core_list, bf_list_add_tail, 0, (NULL, NOT_NULL));
-TestAssert(src_core_list, bf_list_get_head, 0, (NULL));
-TestAssert(src_core_list, bf_list_get_tail, 0, (NULL));
-TestAssert(src_core_list, bf_list_node_next, 0, (NULL));
-TestAssert(src_core_list, bf_list_node_prev, 0, (NULL));
-TestAssert(src_core_list, bf_list_node_get_data, 0, (NULL));
-TestAssert(src_core_list, bf_list_node_take_data, 0, (NULL));
+TestAssert(src_core_list, bf_list_new, (NULL, NOT_NULL));
+TestAssert(src_core_list, bf_list_new, (NOT_NULL, NULL));
+TestAssert(src_core_list, bf_list_free, (NULL));
+TestAssert(src_core_list, bf_list_init, (NULL, NOT_NULL));
+TestAssert(src_core_list, bf_list_init, (NOT_NULL, NULL));
+TestAssert(src_core_list, bf_list_clean, (NULL));
+TestAssert(src_core_list, bf_list_size, (NULL));
+TestAssert(src_core_list, bf_list_add_head, (NULL, NOT_NULL));
+TestAssert(src_core_list, bf_list_add_tail, (NULL, NOT_NULL));
+TestAssert(src_core_list, bf_list_get_head, (NULL));
+TestAssert(src_core_list, bf_list_get_tail, (NULL));
+TestAssert(src_core_list, bf_list_node_next, (NULL));
+TestAssert(src_core_list, bf_list_node_prev, (NULL));
+TestAssert(src_core_list, bf_list_node_get_data, (NULL));
+TestAssert(src_core_list, bf_list_node_take_data, (NULL));
 
 Test(src_core_list, new_and_free)
 {

--- a/tests/unit/src/core/marsh.c
+++ b/tests/unit/src/core/marsh.c
@@ -190,14 +190,14 @@ Test(src_core_marsh, child_is_valid)
     }
 }
 
-TestAssert(src_core_marsh, bf_marsh_new, 0, (NULL, NOT_NULL, 0));
-TestAssert(src_core_marsh, bf_marsh_new, 1, (NOT_NULL, NULL, 1));
-TestAssert(src_core_marsh, bf_marsh_add_child_obj, 0, (NULL, NOT_NULL));
-TestAssert(src_core_marsh, bf_marsh_add_child_raw, 0, (NULL, NOT_NULL, 0));
-TestAssert(src_core_marsh, bf_marsh_next_child, 0, (NULL, NOT_NULL));
-TestAssert(src_core_marsh, bf_marsh_child_is_valid, 0, (NULL, NOT_NULL));
+TestAssert(src_core_marsh, bf_marsh_new, (NULL, NOT_NULL, 0));
+TestAssert(src_core_marsh, bf_marsh_new, (NOT_NULL, NULL, 1));
+TestAssert(src_core_marsh, bf_marsh_add_child_obj, (NULL, NOT_NULL));
+TestAssert(src_core_marsh, bf_marsh_add_child_raw, (NULL, NOT_NULL, 0));
+TestAssert(src_core_marsh, bf_marsh_next_child, (NULL, NOT_NULL));
+TestAssert(src_core_marsh, bf_marsh_child_is_valid, (NULL, NOT_NULL));
 
-Test(src_core_marsh, bf_marsh_add_child_obj_1, .signal = SIGABRT)
+TestAssertManual(src_core_marsh, bf_marsh_add_child_obj)
 {
     // TestAssert() can't be used here because bf_marsh_add_child_obj() will
     // call assert() on *marsh, so it needs to point to valid memory.
@@ -208,7 +208,7 @@ Test(src_core_marsh, bf_marsh_add_child_obj_1, .signal = SIGABRT)
     bf_marsh_add_child_obj(&marsh, NULL);
 }
 
-Test(src_core_marsh, bf_marsh_add_child_raw_1, .signal = SIGABRT)
+TestAssertManual(src_core_marsh, bf_marsh_add_child_raw)
 {
     // TestAssert() can't be used here because bf_marsh_add_child_obj() will
     // call assert() on *marsh, so it needs to point to valid memory.

--- a/tests/unit/src/core/target.c
+++ b/tests/unit/src/core/target.c
@@ -9,13 +9,13 @@
 
 #include "test.h"
 
-TestAssert(src_core_target, bf_target_type_to_str, 0, (-1));
-TestAssert(src_core_target, bf_target_type_to_str, 1, (_BF_TARGET_TYPE_MAX));
-TestAssert(src_core_target, bf_target_standard_verdict_to_str, 0, (-1));
-TestAssert(src_core_target, bf_target_standard_verdict_to_str, 1,
+TestAssert(src_core_target, bf_target_type_to_str, (-1));
+TestAssert(src_core_target, bf_target_type_to_str, (_BF_TARGET_TYPE_MAX));
+TestAssert(src_core_target, bf_target_standard_verdict_to_str, (-1));
+TestAssert(src_core_target, bf_target_standard_verdict_to_str,
            (_BF_TARGET_STANDARD_MAX));
-TestAssert(src_core_target, bf_target_ops_get, 0, (-1));
-TestAssert(src_core_target, bf_target_ops_get, 1, (_BF_TARGET_TYPE_MAX));
+TestAssert(src_core_target, bf_target_ops_get, (-1));
+TestAssert(src_core_target, bf_target_ops_get, (_BF_TARGET_TYPE_MAX));
 
 Test(src_core_target, can_get_target_type_str)
 {

--- a/tests/unit/test.h
+++ b/tests/unit/test.h
@@ -9,8 +9,46 @@
 
 #define NOT_NULL ((void *)0xdeadbeef)
 
-#define TestAssert(suite, function, id, params)                                \
+/**
+ * @brief Generate a test for `assert()` calls in a function.
+ *
+ * Requirements on a function's arguments are check by `assert()`. This macro
+ * generates a test that calls the function with the given arguments and
+ * expects the process to abort with `SIGABRT`.
+ *
+ * @param suite The test suite to add the test to.
+ * @param function The function to test.
+ * @param params The parameters to pass to the function. This must be a
+ *  parenthesized list of arguments.
+ */
+#define TestAssert(suite, function, params)                                    \
+    _TestAssert(suite, function, __COUNTER__, params)
+
+#define _TestAssert(suite, function, id, params)                               \
+    __TestAssert(suite, function, id, params)
+
+#define __TestAssert(suite, function, id, params)                              \
     Test(suite, function##_##id, .signal = SIGABRT)                            \
     {                                                                          \
         function params;                                                       \
     }
+
+/**
+ * @brief Generate a manual test for `assert()` calls in a function.
+ *
+ * Similar to @ref TestAssert, but the test is not automatically defined.
+ * Instead, the test is generated with a unique name and must be defined
+ * manually. This is useful when the test needs to be customized, e.g. to
+ * define a valid pointer to NULL.
+ *
+ * @param suite The test suite to add the test to.
+ * @param function The function to test.
+ */
+#define TestAssertManual(suite, function)                                      \
+    _TestAssertManual(suite, function, __COUNTER__)
+
+#define _TestAssertManual(suite, function, id)                                 \
+    __TestAssertManual(suite, function, id)
+
+#define __TestAssertManual(suite, function, id)                                \
+    Test(suite, function##_##id, .signal = SIGABRT)


### PR DESCRIPTION
`TestAssert()` is used to check `assert()` requirements on a function's
paramters: some function require an argument to be non-NULL to behave
properly, `TestAssert()` allows to ensure the function will `assert()` on
this argument's value, to prevent buggy behaviour.

Instead of passing an ID to `TestAssert()` to concatenate to the function
name and allow multiple `TestAssert()` on the same function, use
`__COUNTER__` to automatically assign an ID to the test.