### PR TITLE
Add CMake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ find_program(CLANG_FORMAT_BIN clang-format REQUIRED)
 
 include(GoogleTest)
 
+# Set the default install location to /usr/lib64 on 64-bit systems
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(CMAKE_INSTALL_LIBDIR lib64)
+endif()
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 17)
 
@@ -107,6 +112,9 @@ set(bpfilter_cflags_debug
 set(bpfilter_ldflags_debug
     -fsanitize=address -fsanitize=undefined
 )
+
+configure_file(resources/bpfilter.pc.in ${CMAKE_BINARY_DIR}/bpfilter.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/bpfilter.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/share/pkgconfig)
 
 add_subdirectory(src)
 add_subdirectory(lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,3 +45,11 @@ add_custom_target(libbpfilter
     DEPENDS libbpfilter_a libbpfilter_so
     COMMENT "Compound target to build libbpfilter.a and libbpfilter.so"
 )
+
+install(TARGETS libbpfilter_a libbpfilter_so)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/lib/include/bpfilter/"
+        DESTINATION "include/bpfilter"
+)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/shared/include/bpfilter/"
+        DESTINATION "include/bpfilter"
+)

--- a/resources/bpfilter.pc.in
+++ b/resources/bpfilter.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/include
+libdir=${prefix}/lib64
+
+Name: bpfilter
+Description: BPF-based packet filtering framework
+URL: https://github.com/facebook/bpfilter
+Version: 0.0.1
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lbpfilter
+Cflags: -I${includedir}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,3 +32,5 @@ target_link_libraries(bpfilter
     PUBLIC
         bpf
 )
+
+install(TARGETS bpfilter)


### PR DESCRIPTION
Add CMake install target to install locally bpfilter daemon, libbpfilter, and headers.
    
Add bpfilter.pc to use libbpfilter through pkg-config.