### PR TITLE
Add transient mode

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,7 +60,7 @@ EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: Always
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
-ForEachMacros: ['bf_list_foreach', 'bf_list_foreach_rev']
+ForEachMacros: ['bf_list_foreach', 'bf_list_foreach_rev', 'bf_context_foreach_codegen']
 IncludeBlocks: Regroup
 IncludeCategories:
   # net/if.h needs to be included BEFORE linux/if.h to avoid conflicts

--- a/src/core/context.c
+++ b/src/core/context.c
@@ -253,7 +253,7 @@ static struct bf_codegen *_bf_context_take_codegen(struct bf_context *context,
     assert(context);
 
     /* Use bf_list_foreach() instead of bf_context-specific functions so the
-     * node can be deleted while iterating. the node can be */
+     * node can be deleted while iterating. */
     bf_list_foreach (&context->hooks[hook], codegen_node) {
         struct bf_codegen *codegen = bf_list_node_get_data(codegen_node);
         if (codegen->front != front)

--- a/src/core/context.c
+++ b/src/core/context.c
@@ -417,8 +417,14 @@ int bf_context_setup(void)
     return 0;
 }
 
-void bf_context_teardown(void)
+void bf_context_teardown(bool clear)
 {
+    if (clear) {
+        bf_context_foreach_codegen (codegen) {
+            bf_codegen_unload(codegen);
+        }
+    }
+
     _bf_context_free(&_global_context);
 }
 

--- a/src/core/context.h
+++ b/src/core/context.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "core/dump.h"
@@ -58,8 +59,11 @@ int bf_context_setup(void);
 
 /**
  * @brief Teardown the global bpfilter context.
+ *
+ * @param clear If true, all the BPF programs will be unloaded before clearing
+ * the context.
  */
-void bf_context_teardown(void);
+void bf_context_teardown(bool clear);
 
 /**
  * @brief Dump content of the context.


### PR DESCRIPTION
Transient mode ensure `bpfilter` won't load `/run/bpfilter.blob` at startup, nor will it save its runtime context into `/run/bpfilter.blob`. Additionally, all the generated BPF program will be detached and unloaded when `bpfilter` stops.

