### PR TITLE
Fix `bpfilter.pc` debug link flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,13 @@ set(bpfilter_ldflags_debug
     -fsanitize=address -fsanitize=undefined
 )
 
-configure_file(resources/bpfilter.pc.in ${CMAKE_BINARY_DIR}/bpfilter.pc @ONLY)
+configure_file(resources/bpfilter.pc.in ${CMAKE_BINARY_DIR}/bpfilter.pc.in @ONLY)
+file(
+  GENERATE
+  OUTPUT ${CMAKE_BINARY_DIR}/bpfilter.pc
+  INPUT ${CMAKE_BINARY_DIR}/bpfilter.pc.in
+)
+
 install(
     FILES ${CMAKE_BINARY_DIR}/bpfilter.pc
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig

--- a/resources/bpfilter.pc.in
+++ b/resources/bpfilter.pc.in
@@ -6,5 +6,5 @@ Name: bpfilter
 Description: BPF-based packet filtering framework
 URL: https://github.com/facebook/bpfilter
 Version: 0.0.1
-Libs: -Wl,-rpath,${libdir} -L${libdir} -lbpfilter
+Libs: -Wl,-rpath,${libdir} -L${libdir} -lbpfilter $<$<CONFIG:Debug>:-fsanitize=address -fsanitize=undefined>
 Cflags: -I${includedir}


### PR DESCRIPTION
When building in debug mode, bpfilter (and libbpfilter) is linked to asan and ubsan. However, those link flags are not reflected in `bpfilter.pc`, leading to build failure in downstream projects.

Use a generator expression to add `-fsanitize=address` and `-fsanitize=undefined` to `bpfilter.pc` in debug mode.