### PR TITLE
Add support for Netfilter BPF programs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -67,6 +67,8 @@ IncludeCategories:
     Priority: 1
   - Regex: '^<linux/'
     Priority: 2
+  - Regex: '^"external/.*'
+    Priority: 5
   - Regex: '^"'
     Priority: 4
   - Regex: '.*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set(bpfilter_daemon_srcs
 
     ${CMAKE_SOURCE_DIR}/src/generator/codegen.h ${CMAKE_SOURCE_DIR}/src/generator/codegen.c
     ${CMAKE_SOURCE_DIR}/src/generator/dump.h ${CMAKE_SOURCE_DIR}/src/generator/dump.c
+    ${CMAKE_SOURCE_DIR}/src/generator/nf.h ${CMAKE_SOURCE_DIR}/src/generator/nf.c
     ${CMAKE_SOURCE_DIR}/src/generator/program.h ${CMAKE_SOURCE_DIR}/src/generator/program.c
     ${CMAKE_SOURCE_DIR}/src/generator/reg.h
     ${CMAKE_SOURCE_DIR}/src/generator/stub.h ${CMAKE_SOURCE_DIR}/src/generator/stub.c

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,7 +18,7 @@ add_custom_target(doc
 
 add_custom_target(coverage
 	COMMAND ${LCOV_BIN} --capture --directory ${CMAKE_BINARY_DIR} --output-file lcov.out
-	COMMAND ${LCOV_BIN} --output-file lcov.out --remove lcov.out "${CMAKE_SOURCE_DIR}/tests/unit/src/*/*"
+	COMMAND ${LCOV_BIN} --output-file lcov.out --remove lcov.out "${CMAKE_SOURCE_DIR}/tests/unit/\\*"
 	COMMAND ${GENHTML_BIN} -o coverage lcov.out
 	BYPRODUCTS coverage
 	COMMENT "Generate coverage report"

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -30,7 +30,11 @@
  */
 static int _bpf(enum bpf_cmd cmd, union bpf_attr *attr)
 {
-    return (int)syscall(__NR_bpf, cmd, attr, sizeof(*attr));
+    int r = (int)syscall(__NR_bpf, cmd, attr, sizeof(*attr));
+    if (r < 0)
+        return -errno;
+
+    return r;
 }
 
 int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
@@ -130,7 +134,7 @@ int bf_bpf_obj_get(const char *path, int *fd)
 
     r = _bpf(BPF_OBJ_GET, &attr);
     if (r < 0)
-        return -errno;
+        return r;
 
     *fd = r;
 

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -68,8 +68,8 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
 
     r = _bpf(BPF_PROG_LOAD, &attr);
     if (r < 0) {
-        return bf_err_code(r, "failed to load BPF program: %s\n%s",
-                           bf_strerror(errno), log_buf);
+        return bf_err_code(r, "failed to load BPF program (%lu bytes):\n%s\n",
+                           img_len, log_buf ?: "(no log buffer available)");
     }
 
     *fd = r;

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -38,7 +38,7 @@ static int _bpf(enum bpf_cmd cmd, union bpf_attr *attr)
 }
 
 int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
-                     size_t img_len, int *fd)
+                     size_t img_len, enum bpf_attach_type attach_type, int *fd)
 {
     _cleanup_free_ char *log_buf = NULL;
     union bpf_attr attr = {
@@ -46,6 +46,7 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
         .insns = _bf_ptr_to_u64(img),
         .insn_cnt = (unsigned int)img_len,
         .license = _bf_ptr_to_u64("GPL"),
+        .expected_attach_type = attach_type,
     };
     int r;
 

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -7,6 +7,8 @@
 
 #include <stddef.h>
 
+#include "core/hook.h"
+
 /**
  * @brief Load a BPF program.
  *
@@ -14,12 +16,15 @@
  * @param prog_type BPF program type.
  * @param img BPF program itself. Can't be NULL.
  * @param img_len Size of the BPF program, as a number of instructions.
+ * @param expected_attach_type Expected attach type of the BPF program. Use
+ *  @ref bf_hook_to_attach_type to get the proper attach type. 0 is a valid
+ *  value.
  * @param fd If the call succeed, this parameter will contain the loaded
  * program's file descriptor.
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
-                     size_t img_len, int *fd);
+                     size_t img_len, enum bpf_attach_type attach_type, int *fd);
 
 /**
  * @brief Create a BPF map.

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -68,3 +68,24 @@ int bf_bpf_obj_pin(const char *path, int fd);
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_bpf_obj_get(const char *path, int *fd);
+
+/**
+ * @brief Create a Netfilter BPF link.
+ *
+ * @param prog_fd File descriptor of the program to attach to the link.
+ * @param hook Netfilter hook to attach the program to.
+ * @param priority Priority of the program on the hook.
+ * @param link_fd Link file descriptor, only valid if the return value of the
+ *  function is 0.
+ * @return 0 on success or negative errno value on failure.
+ */
+int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
+                          int *link_fd);
+
+/**
+ * @brief Detach a BPF link using its file descriptor.
+ * @param link_fd File descriptor of the link to detach. You can get a file
+ *  descriptor using @ref bf_bpf_obj_get.
+ * @return 0 on success or negative errno value on failure.
+ */
+int bf_bpf_link_detach(int link_fd);

--- a/src/core/flavor.c
+++ b/src/core/flavor.c
@@ -7,6 +7,7 @@
 
 #include <assert.h>
 
+#include "generator/nf.h"
 #include "generator/tc.h"
 #include "shared/helper.h"
 
@@ -14,6 +15,7 @@ const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
 {
     static const struct bf_flavor_ops *flavor_ops[] = {
         [BF_FLAVOR_TC] = &bf_flavor_ops_tc,
+        [BF_FLAVOR_NF] = &bf_flavor_ops_nf,
     };
 
     assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);
@@ -27,6 +29,7 @@ const char *bf_flavor_to_str(enum bf_flavor flavor)
 {
     static const char *flavor_str[] = {
         [BF_FLAVOR_TC] = "BF_FLAVOR_TC",
+        [BF_FLAVOR_NF] = "BF_FLAVOR_NF",
     };
 
     assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -27,10 +27,13 @@ struct bf_program;
  *
  * @var bf_flavor::BF_FLAVOR_TC
  *  TC flavor.
+ * @var bf_flavor::BF_FLAVOR_NF
+ *  For BPF_PROG_TYPE_NETFILTER programs. Expects a struct bpf_nf_ctx argument.
  */
 enum bf_flavor
 {
     BF_FLAVOR_TC,
+    BF_FLAVOR_NF,
     _BF_FLAVOR_MAX,
 };
 

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -67,3 +67,22 @@ enum bf_flavor bf_hook_to_flavor(enum bf_hook hook)
 
     return flavors[hook];
 }
+
+enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook)
+{
+    static const enum bpf_attach_type hooks[] = {
+        [BF_HOOK_TC_INGRESS] = 0,
+        [BF_HOOK_IPT_PRE_ROUTING] = 0,
+        [BF_HOOK_IPT_LOCAL_IN] = BPF_NETFILTER,
+        [BF_HOOK_IPT_FORWARD] = BPF_NETFILTER,
+        [BF_HOOK_IPT_LOCAL_OUT] = BPF_NETFILTER,
+        [BF_HOOK_IPT_POST_ROUTING] = 0,
+        [BF_HOOK_TC_EGRESS] = 0,
+    };
+
+    assert(0 <= hook && hook < _BF_HOOK_MAX);
+    static_assert(ARRAY_SIZE(hooks) == _BF_HOOK_MAX,
+                  "missing entries in hooks array");
+
+    return hooks[hook];
+}

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -34,11 +34,11 @@ unsigned int bf_hook_to_bpf_prog_type(enum bf_hook hook)
 {
     static const unsigned int prog_type[] = {
         [BF_HOOK_TC_INGRESS] = BPF_PROG_TYPE_SCHED_CLS,
-        [BF_HOOK_IPT_PRE_ROUTING] = BPF_PROG_TYPE_SCHED_CLS,
-        [BF_HOOK_IPT_LOCAL_IN] = BPF_PROG_TYPE_SCHED_CLS,
-        [BF_HOOK_IPT_FORWARD] = BPF_PROG_TYPE_SCHED_CLS,
-        [BF_HOOK_IPT_LOCAL_OUT] = BPF_PROG_TYPE_SCHED_CLS,
-        [BF_HOOK_IPT_POST_ROUTING] = BPF_PROG_TYPE_SCHED_CLS,
+        [BF_HOOK_IPT_PRE_ROUTING] = BPF_PROG_TYPE_NETFILTER,
+        [BF_HOOK_IPT_LOCAL_IN] = BPF_PROG_TYPE_NETFILTER,
+        [BF_HOOK_IPT_FORWARD] = BPF_PROG_TYPE_NETFILTER,
+        [BF_HOOK_IPT_LOCAL_OUT] = BPF_PROG_TYPE_NETFILTER,
+        [BF_HOOK_IPT_POST_ROUTING] = BPF_PROG_TYPE_NETFILTER,
         [BF_HOOK_TC_EGRESS] = BPF_PROG_TYPE_SCHED_CLS,
     };
 
@@ -53,11 +53,11 @@ enum bf_flavor bf_hook_to_flavor(enum bf_hook hook)
 {
     static const enum bf_flavor flavors[] = {
         [BF_HOOK_TC_INGRESS] = BF_FLAVOR_TC,
-        [BF_HOOK_IPT_PRE_ROUTING] = BF_FLAVOR_TC,
-        [BF_HOOK_IPT_LOCAL_IN] = BF_FLAVOR_TC,
-        [BF_HOOK_IPT_FORWARD] = BF_FLAVOR_TC,
-        [BF_HOOK_IPT_LOCAL_OUT] = BF_FLAVOR_TC,
-        [BF_HOOK_IPT_POST_ROUTING] = BF_FLAVOR_TC,
+        [BF_HOOK_IPT_PRE_ROUTING] = BF_FLAVOR_NF,
+        [BF_HOOK_IPT_LOCAL_IN] = BF_FLAVOR_NF,
+        [BF_HOOK_IPT_FORWARD] = BF_FLAVOR_NF,
+        [BF_HOOK_IPT_LOCAL_OUT] = BF_FLAVOR_NF,
+        [BF_HOOK_IPT_POST_ROUTING] = BF_FLAVOR_NF,
         [BF_HOOK_TC_EGRESS] = BF_FLAVOR_TC,
     };
 

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -49,3 +49,11 @@ unsigned int bf_hook_to_bpf_prog_type(enum bf_hook hook);
  * @return bpfilter flavor corresponding to @p hook.
  */
 enum bf_flavor bf_hook_to_flavor(enum bf_hook hook);
+
+/**
+ * @brief Convert a bpfilter hook to a BPF attach type.
+ *
+ * @param hook The hook to convert. Must be a valid hook.
+ * @return The BPF attach type corresponding to @p hook.
+ */
+enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook);

--- a/src/core/target.c
+++ b/src/core/target.c
@@ -13,11 +13,12 @@
 
 #include "core/flavor.h"
 #include "core/hook.h"
-#include "external/filter.h"
 #include "generator/codegen.h"
 #include "generator/program.h"
 #include "generator/reg.h"
 #include "shared/helper.h"
+
+#include "external/filter.h"
 
 const char *bf_target_type_to_str(enum bf_target_type type)
 {

--- a/src/external/nf_bpf_link.h
+++ b/src/external/nf_bpf_link.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+
+#include <stdint.h>
+
+struct sk_buff;
+struct sock;
+struct net;
+struct netdev_name_node;
+typedef unsigned int __u32;
+
+typedef __u32 u32;
+typedef u32 xdp_features_t;
+
+struct list_head
+{
+    struct list_head *next;
+    struct list_head *prev;
+};
+
+struct bpf_nf_ctx
+{
+    const struct nf_hook_state *state;
+    struct sk_buff *skb;
+};
+
+struct nf_hook_state
+{
+    uint8_t hook;
+    uint8_t pf;
+    struct net_device *in;
+    struct net_device *out;
+    struct sock *sk;
+    struct net *net;
+    int (*okfn)(struct net *, struct sock *, struct sk_buff *);
+};
+
+struct net_device
+{
+    char name[16];
+    struct netdev_name_node *name_node;
+    struct dev_ifalias *ifalias;
+    long unsigned int mem_end;
+    long unsigned int mem_start;
+    long unsigned int base_addr;
+    long unsigned int state;
+    struct list_head dev_list;
+    struct list_head napi_list;
+    struct list_head unreg_list;
+    struct list_head close_list;
+    struct list_head ptype_all;
+    struct list_head ptype_specific;
+
+    struct
+    {
+        struct list_head upper;
+        struct list_head lower;
+    } adj_list;
+
+    unsigned int flags;
+    xdp_features_t xdp_features;
+    long long unsigned int priv_flags;
+    const struct net_device_ops *netdev_ops;
+    const struct xdp_metadata_ops *xdp_metadata_ops;
+    int ifindex;
+    short unsigned int gflags;
+};

--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -315,3 +315,15 @@ void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix)
 
     bf_dump_prefix_pop(prefix);
 }
+
+struct bf_program *bf_codegen_get_program(const struct bf_codegen *codegen,
+                                          uint32_t ifindex)
+{
+    bf_list_foreach (&codegen->programs, program_node) {
+        struct bf_program *program = bf_list_node_get_data(program_node);
+        if (program->ifindex == ifindex)
+            return program;
+    }
+
+    return NULL;
+}

--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -100,13 +100,20 @@ int bf_codegen_generate(struct bf_codegen *codegen)
     return 0;
 }
 
-int bf_codegen_load(struct bf_codegen *codegen)
+int bf_codegen_load(struct bf_codegen *codegen, struct bf_codegen *prev_codegen)
 {
     int r;
 
     bf_list_foreach (&codegen->programs, program_node) {
+        struct bf_program *prev_program = NULL;
         struct bf_program *program = bf_list_node_get_data(program_node);
-        r = bf_program_load(program);
+
+        if (prev_codegen) {
+            prev_program =
+                bf_codegen_get_program(prev_codegen, program->ifindex);
+        }
+
+        r = bf_program_load(program, prev_program);
         if (r) {
             bf_program_dump(program, NULL);
             bf_program_dump_bytecode(program, false);

--- a/src/generator/codegen.h
+++ b/src/generator/codegen.h
@@ -77,9 +77,13 @@ int bf_codegen_generate(struct bf_codegen *codegen);
  * Each program within the codegen will be loaded and attached to its interface.
  *
  * @param codegen Codegen containing the BPF program to load. Can't be NULL.
+ * @param prev_codegen Codegen to replace. Can be NULL. @ref bf_codegen_load
+ *  is responsible for unloading the previous codegen. @ref bf_codegen_load
+ *  doesn't own @p prev_codegen, and won't free it.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_codegen_load(struct bf_codegen *codegen);
+int bf_codegen_load(struct bf_codegen *codegen,
+                    struct bf_codegen *prev_codegen);
 
 /**
  * @brief Unload a codegen's BPF programs.

--- a/src/generator/codegen.h
+++ b/src/generator/codegen.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include "core/dump.h"
 #include "core/hook.h"
 #include "core/list.h"
@@ -93,3 +95,13 @@ int bf_codegen_unmarsh(const struct bf_marsh *marsh,
                        struct bf_codegen **codegen);
 
 void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix);
+
+/**
+ * @brief Get a codegen's BPF program for a given interface.
+ *
+ * @param codegen Codegen containing the BPF program to get. Can't be NULL.
+ * @param ifindex Interface to get the BPF program for.
+ * @return BPF program for the given interface, or NULL if not found.
+ */
+struct bf_program *bf_codegen_get_program(const struct bf_codegen *codegen,
+                                          uint32_t ifindex);

--- a/src/generator/nf.c
+++ b/src/generator/nf.c
@@ -5,10 +5,6 @@
 
 #include "generator/nf.h"
 
-#include <net/if.h>
-
-#include <linux/netfilter.h>
-
 #include <assert.h>
 #include <errno.h>
 
@@ -91,4 +87,19 @@ static int _nf_unload_img(struct bf_program *program)
     assert(program);
 
     return -ENOTSUP;
+}
+
+enum nf_inet_hooks bf_hook_to_nf_hook(enum bf_hook hook)
+{
+    assert(hook >= BF_HOOK_IPT_PRE_ROUTING || hook <= BF_HOOK_IPT_POST_ROUTING);
+
+    enum nf_inet_hooks hooks[] = {
+        [BF_HOOK_IPT_PRE_ROUTING] = NF_INET_PRE_ROUTING,
+        [BF_HOOK_IPT_LOCAL_IN] = NF_INET_LOCAL_IN,
+        [BF_HOOK_IPT_FORWARD] = NF_INET_FORWARD,
+        [BF_HOOK_IPT_LOCAL_OUT] = NF_INET_LOCAL_OUT,
+        [BF_HOOK_IPT_POST_ROUTING] = NF_INET_POST_ROUTING,
+    };
+
+    return hooks[hook];
 }

--- a/src/generator/nf.c
+++ b/src/generator/nf.c
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/nf.h"
+
+#include <net/if.h>
+
+#include <linux/netfilter.h>
+
+#include <assert.h>
+#include <errno.h>
+
+#include "generator/program.h"
+#include "shared/helper.h"
+
+static int _nf_gen_inline_prologue(struct bf_program *program);
+static int _nf_gen_inline_epilogue(struct bf_program *program);
+static int _nf_convert_return_code(enum bf_target_standard_verdict verdict);
+static int _nf_load_img(struct bf_program *program, int fd);
+static int _nf_unload_img(struct bf_program *program);
+
+const struct bf_flavor_ops bf_flavor_ops_nf = {
+    .gen_inline_prologue = _nf_gen_inline_prologue,
+    .gen_inline_epilogue = _nf_gen_inline_epilogue,
+    .convert_return_code = _nf_convert_return_code,
+    .load_img = _nf_load_img,
+    .unload_img = _nf_unload_img,
+};
+
+static int _nf_gen_inline_prologue(struct bf_program *program)
+{
+    assert(program);
+
+    return -ENOTSUP;
+}
+
+static int _nf_gen_inline_epilogue(struct bf_program *program)
+{
+    UNUSED(program);
+
+    EMIT(program, BPF_EXIT_INSN());
+
+    return -ENOTSUP;
+}
+
+/**
+ * @brief Convert a standard verdict into a return value.
+ * @param verdict Verdict to convert. Must be valid.
+ * @return TC return code corresponding to the verdict, as an integer.
+ */
+static int _nf_convert_return_code(enum bf_target_standard_verdict verdict)
+{
+    assert(0 <= verdict && verdict < _BF_TARGET_STANDARD_MAX);
+
+    static const int verdicts[] = {
+        [BF_TARGET_STANDARD_ACCEPT] = NF_ACCEPT,
+        [BF_TARGET_STANDARD_DROP] = NF_DROP,
+    };
+
+    static_assert(ARRAY_SIZE(verdicts) == _BF_TARGET_STANDARD_MAX);
+
+    return verdicts[verdict];
+}
+
+/**
+ * @brief Load the Netfilter BPF bytecode image.
+ *
+ * @param program Codegen containing the image to load. Can't be NULL, image
+ *  must have been previously generated.
+ * @param fd File descriptor of the loaded BPF program. Can't be negative.
+ * @return 0 on success, negative error code on failure.
+ */
+static int _nf_load_img(struct bf_program *program, int fd)
+{
+    assert(program);
+    assert(fd >= 0);
+
+    return -ENOTSUP;
+}
+
+/**
+ * @brief Unload the Netfilter BPF bytecode image.
+ *
+ * @param codegen Codegen containing the image to unload. Can't be NULL.
+ * @return 0 on success, negative error code on failure.
+ */
+static int _nf_unload_img(struct bf_program *program)
+{
+    assert(program);
+
+    return -ENOTSUP;
+}

--- a/src/generator/nf.c
+++ b/src/generator/nf.c
@@ -14,15 +14,19 @@
 static int _nf_gen_inline_prologue(struct bf_program *program);
 static int _nf_gen_inline_epilogue(struct bf_program *program);
 static int _nf_convert_return_code(enum bf_target_standard_verdict verdict);
-static int _nf_load_img(struct bf_program *program, int fd);
-static int _nf_unload_img(struct bf_program *program);
+static int _nf_attach_prog_pre_unload(struct bf_program *program, int *prog_fd,
+                                      union bf_flavor_attach_attr *attr);
+static int _nf_attach_prog_post_unload(struct bf_program *program, int *prog_fd,
+                                       union bf_flavor_attach_attr *attr);
+static int _nf_detach_prog(struct bf_program *program);
 
 const struct bf_flavor_ops bf_flavor_ops_nf = {
     .gen_inline_prologue = _nf_gen_inline_prologue,
     .gen_inline_epilogue = _nf_gen_inline_epilogue,
     .convert_return_code = _nf_convert_return_code,
-    .load_img = _nf_load_img,
-    .unload_img = _nf_unload_img,
+    .attach_prog_pre_unload = _nf_attach_prog_pre_unload,
+    .attach_prog_post_unload = _nf_attach_prog_post_unload,
+    .detach_prog = _nf_detach_prog,
 };
 
 static int _nf_gen_inline_prologue(struct bf_program *program)
@@ -60,20 +64,25 @@ static int _nf_convert_return_code(enum bf_target_standard_verdict verdict)
     return verdicts[verdict];
 }
 
-/**
- * @brief Load the Netfilter BPF bytecode image.
- *
- * @param program Codegen containing the image to load. Can't be NULL, image
- *  must have been previously generated.
- * @param fd File descriptor of the loaded BPF program. Can't be negative.
- * @return 0 on success, negative error code on failure.
- */
-static int _nf_load_img(struct bf_program *program, int fd)
+static int _nf_attach_prog_pre_unload(struct bf_program *program, int *prog_fd,
+                                      union bf_flavor_attach_attr *attr)
 {
     assert(program);
-    assert(fd >= 0);
+    assert(*prog_fd >= 0);
+    assert(attr);
 
-    return -ENOTSUP;
+    return 0;
+}
+
+static int _nf_attach_prog_post_unload(struct bf_program *program, int *prog_fd,
+                                       union bf_flavor_attach_attr *attr)
+{
+    assert(program);
+    assert(*prog_fd >= 0);
+
+    UNUSED(attr);
+
+    return 0;
 }
 
 /**
@@ -82,11 +91,11 @@ static int _nf_load_img(struct bf_program *program, int fd)
  * @param codegen Codegen containing the image to unload. Can't be NULL.
  * @return 0 on success, negative error code on failure.
  */
-static int _nf_unload_img(struct bf_program *program)
+static int _nf_detach_prog(struct bf_program *program)
 {
     assert(program);
 
-    return -ENOTSUP;
+    return 0;
 }
 
 enum nf_inet_hooks bf_hook_to_nf_hook(enum bf_hook hook)

--- a/src/generator/nf.h
+++ b/src/generator/nf.h
@@ -5,7 +5,13 @@
 
 #pragma once
 
+#include <net/if.h>
+
+#include <linux/netfilter.h>
+
 #include "core/flavor.h"
 #include "core/hook.h"
 
 extern const struct bf_flavor_ops bf_flavor_ops_nf;
+
+enum nf_inet_hooks bf_hook_to_nf_hook(enum bf_hook hook);

--- a/src/generator/nf.h
+++ b/src/generator/nf.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/flavor.h"
+#include "core/hook.h"
+
+extern const struct bf_flavor_ops bf_flavor_ops_nf;

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -472,7 +472,6 @@ static int _bf_program_load_counters_map(struct bf_program *program, int *fd)
 
     assert(program);
 
-    /// @todo: remove conditional on num_rules
     r = bf_bpf_map_create(program->map_name, BPF_MAP_TYPE_ARRAY,
                           sizeof(uint32_t), sizeof(struct bf_counter),
                           program->num_rules_total, &_fd);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -687,7 +687,8 @@ int bf_program_load(struct bf_program *program)
 
     r = bf_bpf_prog_load(program->prog_name,
                          bf_hook_to_bpf_prog_type(program->hook), program->img,
-                         program->img_size, &fd);
+                         program->img_size,
+                         bf_hook_to_attach_type(program->hook), &fd);
     if (r < 0)
         return r;
 

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -27,9 +27,10 @@
 #include "core/marsh.h"
 #include "core/rule.h"
 #include "core/target.h"
-#include "external/filter.h"
 #include "generator/stub.h"
 #include "shared/helper.h"
+
+#include "external/filter.h"
 
 #define _BF_PROGRAM_DEFAULT_IMG_SIZE (1 << 6)
 

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -260,6 +260,12 @@ static int _bf_program_fixup(struct bf_program *program,
         case BF_CODEGEN_FIXUP_END_OF_CHAIN:
             insn_type = BF_CODEGEN_FIXUP_INSN_OFF;
             v = (int)(program->img_size - fixup->insn - 2U);
+            if (v > SHRT_MAX) {
+                // Jump offset is a s16, so we cut short program generation
+                // before the verifier complains.
+                bf_err("Fixup jump is too far away");
+                return -ERANGE;
+            }
             break;
         case BF_CODEGEN_FIXUP_MAP_FD:
             insn_type = BF_CODEGEN_FIXUP_INSN_IMM;

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -181,7 +181,18 @@ int bf_program_emit_fixup(struct bf_program *program, enum bf_fixup_type type,
 int bf_program_emit_fixup_call(struct bf_program *program,
                                enum bf_fixup_function function);
 int bf_program_generate(struct bf_program *program, bf_list *rules);
-int bf_program_load(struct bf_program *program);
+
+/**
+ * @brief Load the program into the kernel.
+ * @param program Program to load. Can not be NULL.
+ * @param prev_program Previous program to unload. Can be NULL. If not NULL,
+ *  @ref bf_program_load will unload @p prev_program between @ref
+ *  attach_prog_pre_unload and @ref attach_prog_post_unload calls.
+ * @return 0 on success, negative errno code on failure.
+ */
+int bf_program_load(struct bf_program *program,
+                    struct bf_program *prev_program);
+
 int bf_program_unload(struct bf_program *program);
 
 int bf_program_get_counters(const struct bf_program *program,

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -20,10 +20,11 @@
 #include "core/dump.h"
 #include "core/hook.h"
 #include "core/list.h"
-#include "external/filter.h"
 #include "generator/fixup.h"
 #include "generator/reg.h"
 #include "shared/front.h"
+
+#include "external/filter.h"
 
 #define PIN_PATH_LEN 64
 

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -10,8 +10,9 @@
 #include <arpa/inet.h>
 #include <assert.h>
 
-#include "external/filter.h"
 #include "generator/program.h"
+
+#include "external/filter.h"
 
 int bf_stub_memclear(struct bf_program *program, enum bf_reg addr_reg,
                      size_t size)

--- a/src/generator/tc.c
+++ b/src/generator/tc.c
@@ -14,13 +14,14 @@
 
 #include "core/context.h"
 #include "core/logger.h"
-#include "external/filter.h"
 #include "generator/codegen.h"
 #include "generator/program.h"
 #include "generator/reg.h"
 #include "generator/stub.h"
 #include "shared/front.h"
 #include "shared/helper.h"
+
+#include "external/filter.h"
 
 static int _tc_gen_inline_prologue(struct bf_program *program);
 static int _tc_gen_inline_epilogue(struct bf_program *program);

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -402,12 +402,6 @@ static int _ipt_xlate_set_rules(struct ipt_replace *ipt,
             first_rule = ipt_get_next_rule(first_rule);
         }
 
-        if (i != NF_INET_LOCAL_IN && i != NF_INET_LOCAL_OUT) {
-            bf_warn(
-                "discarding all chains which are neither NF_INET_LOCAL_IN nor NF_INET_LOCAL_OUT");
-            continue;
-        }
-
         bf_dbg("created codegen for %s::%s", bf_front_to_str(codegen->front),
                bf_hook_to_str(codegen->hook));
 
@@ -571,9 +565,8 @@ int _bf_ipt_get_entries_handler(struct bf_request *request,
         struct bf_list_node *rule_node = NULL;
         enum bf_hook hook = _bf_ipt_hook_to_bf_hook(i);
 
-        if (i != NF_INET_LOCAL_IN && i != NF_INET_LOCAL_OUT) {
-            bf_warn(
-                "skipping all chains which are neither NF_INET_LOCAL_IN nor NF_INET_LOCAL_OUT");
+        if (!(_cache->valid_hooks & (1 << i))) {
+            bf_dbg("ipt hook %d is not enabled, skipping", i);
             continue;
         }
 

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -154,12 +154,15 @@ static enum bf_hook _bf_ipt_hook_to_bf_hook(enum nf_inet_hooks ipt_hook)
 
     switch (ipt_hook) {
     case NF_INET_PRE_ROUTING:
+        return BF_HOOK_IPT_PRE_ROUTING;
     case NF_INET_LOCAL_IN:
+        return BF_HOOK_IPT_LOCAL_IN;
     case NF_INET_FORWARD:
-        return BF_HOOK_TC_INGRESS;
+        return BF_HOOK_IPT_FORWARD;
     case NF_INET_LOCAL_OUT:
+        return BF_HOOK_IPT_LOCAL_OUT;
     case NF_INET_POST_ROUTING:
-        return BF_HOOK_TC_EGRESS;
+        return BF_HOOK_IPT_POST_ROUTING;
     default:
         bf_abort("invalid ipt_hook: %d", ipt_hook);
     }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,6 +4,7 @@
 enable_testing()
 
 add_executable(tests_unit
+    test.c
     src/core/context.c
     src/core/flavor.c
     src/core/hook.c
@@ -11,6 +12,7 @@ add_executable(tests_unit
     src/core/list.c
     src/core/target.c
     src/core/helper.c
+    src/generator/codegen.c
     src/generator/nf.c
     ${bpfilter_daemon_srcs} ${bpfilter_shared_srcs}
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(tests_unit
     src/core/list.c
     src/core/target.c
     src/core/helper.c
+    src/generator/nf.c
     ${bpfilter_daemon_srcs} ${bpfilter_shared_srcs}
 )
 

--- a/tests/unit/src/core/hook.c
+++ b/tests/unit/src/core/hook.c
@@ -28,7 +28,7 @@ Test(src_core_hook, can_get_prog_type_from_hook)
 
     for (int i = 0; i < _BF_HOOK_MAX; ++i) {
         prog_type = bf_hook_to_bpf_prog_type(i);
-        cr_assert(prog_type <= BPF_PROG_TYPE_SYSCALL);
+        cr_assert(prog_type <= BPF_PROG_TYPE_NETFILTER);
     }
 }
 

--- a/tests/unit/src/core/hook.c
+++ b/tests/unit/src/core/hook.c
@@ -42,3 +42,14 @@ Test(src_core_hook, can_get_flavor_from_hook)
         cr_assert(flavor < _BF_FLAVOR_MAX);
     }
 }
+
+Test(src_core_hook, can_get_attach_type_from_hook)
+{
+    enum bpf_attach_type attach_type;
+
+    for (int i = 0; i < _BF_HOOK_MAX; ++i) {
+        attach_type = bf_hook_to_attach_type(i);
+        cr_assert(0 <= attach_type);
+        cr_assert(attach_type < __MAX_BPF_ATTACH_TYPE);
+    }
+}

--- a/tests/unit/src/generator/codegen.c
+++ b/tests/unit/src/generator/codegen.c
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*                                                                             \
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.                     \
+ */
+
+#include "generator/codegen.h"
+
+#include <criterion/criterion.h>
+
+#include "generator/program.h"
+#include "test.h"
+
+Test(src_generator_codegen, get_program)
+{
+    _cleanup_bf_codegen_ struct bf_codegen *codegen = NULL;
+
+    cr_assert_eq(bf_test_make_codegen(&codegen, BF_HOOK_IPT_FORWARD, 5), 0);
+
+    {
+        // Get first program in the list
+        struct bf_program *program = bf_codegen_get_program(codegen, 1);
+        cr_assert_not_null(program);
+        cr_assert_eq(program->ifindex, 1);
+    }
+
+    {
+        // Get program from the middle of the list
+        struct bf_program *program = bf_codegen_get_program(codegen, 3);
+        cr_assert_not_null(program);
+        cr_assert_eq(program->ifindex, 3);
+    }
+
+    {
+        // Get last program of the list
+        struct bf_program *program = bf_codegen_get_program(codegen, 5);
+        cr_assert_not_null(program);
+        cr_assert_eq(program->ifindex, 5);
+    }
+
+    {
+        // Get program with an invalid interface
+        struct bf_program *program = bf_codegen_get_program(codegen, 10);
+        cr_assert_null(program);
+    }
+}

--- a/tests/unit/src/generator/nf.c
+++ b/tests/unit/src/generator/nf.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*                                                                             \
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.                     \
+ */
+
+#include <criterion/criterion.h>
+
+#include "core/flavor.h"
+#include "test.h"
+
+Test(src_generator_nf, all_verdicts_valid)
+{
+    const struct bf_flavor_ops *ops = bf_flavor_ops_get(BF_FLAVOR_NF);
+
+    cr_assert_not_null(ops);
+
+    for (int i = 0; i < _BF_TARGET_STANDARD_MAX; ++i)
+        ops->convert_return_code(i);
+}

--- a/tests/unit/test.c
+++ b/tests/unit/test.c
@@ -1,0 +1,46 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*                                                                             \
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.                     \
+ */
+
+#include "test.h"
+
+#include <assert.h>
+
+#include "core/hook.h"
+#include "core/list.h"
+#include "generator/program.h"
+
+int bf_test_make_codegen(struct bf_codegen **codegen, enum bf_hook hook,
+                         int nprogs)
+{
+    _cleanup_bf_codegen_ struct bf_codegen *c = NULL;
+    int r;
+
+    assert(codegen);
+
+    // So ifindex start a 1
+    ++nprogs;
+
+    r = bf_codegen_new(&c);
+    if (r < 0)
+        return r;
+
+    for (int i = 1; i < nprogs; ++i) {
+        _cleanup_bf_program_ struct bf_program *p = NULL;
+
+        r = bf_program_new(&p, i, hook, BF_FRONT_IPT);
+        if (r < 0)
+            return r;
+
+        r = bf_list_add_tail(&c->programs, p);
+        if (r < 0)
+            return r;
+
+        TAKE_PTR(p);
+    }
+
+    *codegen = TAKE_PTR(c);
+
+    return 0;
+}

--- a/tests/unit/test.h
+++ b/tests/unit/test.h
@@ -7,6 +7,8 @@
 
 #include <signal.h>
 
+#include "generator/codegen.h"
+
 #define NOT_NULL ((void *)0xdeadbeef)
 
 /**
@@ -52,3 +54,15 @@
 
 #define __TestAssertManual(suite, function, id)                                \
     Test(suite, function##_##id, .signal = SIGABRT)
+
+/**
+ * @brief Create a dummy @ref bf_codegen structure containing @p nprogs
+ * programs.
+ *
+ * @param codegen Codegen to allocate and initialise. Can't be NULL.
+ * @param hook Hook to attach the programs to.
+ * @param nprogs Number of programs to generate.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_test_make_codegen(struct bf_codegen **codegen, enum bf_hook hook,
+                         int nprogs);


### PR DESCRIPTION
Add a new `NF` flavor to support generation of `BPF_PROG_TYPE_NETFILTER` programs using `bpfilter`. 

Until now, `bpfilter` would generate TC programs for `iptables` (IPT front). Meaning it had to perform a routing table lookup on TC ingress to check whether the `LOCAL_IN` or `FORWARD` filtering rules should be applied to the packet.

This PR add support for `BPF_PROG_TYPE_NETFILTER` programs, giving access to `LOCAL_IN`, `FORWARD, and `LOCAL_OUT` hooks to attach programs to.