### PR TITLE
Update `bpfilter` runtime directory and prevent BPF objects pinning on `--transient` run

### DIFF
--- a/shared/include/bpfilter/shared/generic.h
+++ b/shared/include/bpfilter/shared/generic.h
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#define BF_SOCKET_PATH "/run/bpfilter.sock"
+#define BF_RUNTIME_DIR "/run/bpfilter"
+#define BF_SOCKET_PATH BF_RUNTIME_DIR "/daemon.sock"
 
 struct bf_request;
 struct bf_response;

--- a/src/generator/nf.c
+++ b/src/generator/nf.c
@@ -183,18 +183,9 @@ static int _nf_attach_prog_post_unload(struct bf_program *program, int *prog_fd,
  */
 static int _nf_detach_prog(struct bf_program *program)
 {
-    int fd;
-    int r;
-
     assert(program);
 
-    r = bf_bpf_obj_get(program->prog_pin_path, &fd);
-    if (r < 0) {
-        return bf_err_code(r, "failed to open pinned object at %s: %s)",
-                           program->prog_pin_path, bf_strerror(r));
-    }
-
-    return bf_bpf_link_detach(fd);
+    return bf_bpf_link_detach(program->runtime.prog_fd);
 }
 
 enum nf_inet_hooks bf_hook_to_nf_hook(enum bf_hook hook)

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -161,6 +161,16 @@ struct bf_program
     size_t img_size;
     size_t img_cap;
     bf_list fixups;
+
+    /** Runtime data used to interact with the program and cache information.
+     * This data is not serialized. */
+    struct
+    {
+        /** File descriptor of the program. */
+        int prog_fd;
+        /** File descriptor of the counters map. */
+        int map_fd;
+    } runtime;
 };
 
 #define _cleanup_bf_program_ __attribute__((__cleanup__(bf_program_free)))

--- a/src/opts.c
+++ b/src/opts.c
@@ -20,15 +20,15 @@ static struct bf_options
      * bpfilter is stopped, everything is cleaned up. */
     bool transient;
 
-    /** If true, print debug log messages (bf_debug). */
-    bool verbose;
-
     /** Size of the log buffer when loading a BPF program, as a power of 2. */
     unsigned int bpf_log_buf_len_pow;
+
+    /** If true, print debug log messages (bf_debug). */
+    bool verbose;
 } _opts = {
     .transient = false,
-    .verbose = false,
     .bpf_log_buf_len_pow = 16,
+    .verbose = false,
 };
 
 static struct argp_option options[] = {
@@ -77,11 +77,6 @@ int bf_opts_init(int argc, char *argv[])
     return argp_parse(&argp, argc, argv, 0, 0, &_opts);
 }
 
-bool bf_opts_verbose(void)
-{
-    return _opts.verbose;
-}
-
 bool bf_opts_transient(void)
 {
     return _opts.transient;
@@ -90,4 +85,9 @@ bool bf_opts_transient(void)
 unsigned int bf_opts_bpf_log_buf_len_pow(void)
 {
     return _opts.bpf_log_buf_len_pow;
+}
+
+bool bf_opts_verbose(void)
+{
+    return _opts.verbose;
 }

--- a/src/opts.h
+++ b/src/opts.h
@@ -8,6 +8,6 @@
 #include <stdbool.h>
 
 int bf_opts_init(int argc, char *argv[]);
-bool bf_opts_verbose(void);
 bool bf_opts_transient(void);
 unsigned int bf_opts_bpf_log_buf_len_pow(void);
+bool bf_opts_verbose(void);


### PR DESCRIPTION
This PR contains two different changes, aiming to allow `bpfilter` to be run from a Docker container.

First of all, use `/run/bpfilter` as runtime directory for `bpfilter` instead of `/run`. The serialised data and the socket will now be created in this directory.

Also, even with `--transient` enabled, `bpfilter` would pin the various programs and maps into `/sys/fs/bpf` during runtime (and remove before stopping). This would prevent `bpfilter` to be run with a read-only `/sys/fs/bpf` directory (in a container for example). This change prevent pinning of programs and maps is transient mode is used, and keep the programs and maps file descriptors within `struct bf_program` to ensure we can still access them.