### PR TITLE
build: set minimum CMake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project(bpfilter
     VERSION 0.0.1


### PR DESCRIPTION
CentOS 9 Stream ships CMake 3.20. Update required CMake version to 3.20 so bpfilter can be build on CentOS 9 Stream.

Lowering CMake version to 3.20 doesn't trigger any CMake policy message.