### PR TITLE
Various improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,6 +65,8 @@ IncludeCategories:
   # net/if.h needs to be included BEFORE linux/if.h to avoid conflicts
   - Regex: '<net/if.h>'
     Priority: 1
+  - Regex: '<arpa/inet.h>'
+    Priority: 1
   - Regex: '^<linux/'
     Priority: 2
   - Regex: '^"external/.*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/generator/stub.h ${CMAKE_SOURCE_DIR}/src/generator/stub.c
     ${CMAKE_SOURCE_DIR}/src/generator/fixup.h ${CMAKE_SOURCE_DIR}/src/generator/fixup.c
     ${CMAKE_SOURCE_DIR}/src/generator/tc.h ${CMAKE_SOURCE_DIR}/src/generator/tc.c
+    ${CMAKE_SOURCE_DIR}/src/generator/xdp.h ${CMAKE_SOURCE_DIR}/src/generator/xdp.c
 
     ${CMAKE_SOURCE_DIR}/src/xlate/front.h ${CMAKE_SOURCE_DIR}/src/xlate/front.c
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/helpers.h

--- a/shared/include/bpfilter/shared/response.h
+++ b/shared/include/bpfilter/shared/response.h
@@ -57,6 +57,20 @@ struct bf_response
 };
 
 /**
+ * @brief Allocate a response without copying data.
+ *
+ * Space will be allocated in the response for @p data_len bytes of data, but
+ * no data will be copied, nor will the response's data be initialized.
+ *
+ * The response's type will be set to BF_RES_SUCCESS.
+ *
+ * @param response Pointer to the response to allocate. Must be non-NULL.
+ * @param data_len Size of the data to allocate.
+ * @return 0 on success, or negative errno code on failure.
+ */
+int bf_response_new_raw(struct bf_response **response, size_t data_len);
+
+/**
  * @brief Allocate and initialise a new successful response.
  *
  * @param response Pointer to the response to allocate. Must be non-NULL.

--- a/shared/src/response.c
+++ b/shared/src/response.c
@@ -11,6 +11,19 @@
 
 #include "shared/helper.h"
 
+int bf_response_new_raw(struct bf_response **response, size_t data_len)
+{
+    bf_assert(response);
+
+    *response = malloc(sizeof(**response) + data_len);
+    if (!*response)
+        return -ENOMEM;
+
+    (*response)->type = BF_RES_SUCCESS;
+
+    return 0;
+}
+
 int bf_response_new_success(struct bf_response **response, const char *data,
                             size_t data_len)
 {

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -166,6 +166,26 @@ int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
     return 0;
 }
 
+int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
+                           enum bf_xdp_attach_mode mode)
+{
+    union bpf_attr attr = {};
+    int r;
+
+    attr.link_create.prog_fd = prog_fd;
+    attr.link_create.target_fd = ifindex;
+    attr.link_create.attach_type = BPF_XDP;
+    attr.link_create.flags = mode;
+
+    r = _bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    *link_fd = r;
+
+    return 0;
+}
+
 int bf_bpf_link_detach(int link_fd)
 {
     union bpf_attr attr = {

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -5,9 +5,18 @@
 
 #pragma once
 
+#include <linux/if_link.h>
+
 #include <stddef.h>
 
 #include "core/hook.h"
+
+enum bf_xdp_attach_mode
+{
+    BF_XDP_MODE_SKB = XDP_FLAGS_SKB_MODE,
+    BF_XDP_MODE_DRV = XDP_FLAGS_DRV_MODE,
+    BF_XDP_MODE_HW = XDP_FLAGS_HW_MODE,
+};
 
 /**
  * @brief Load a BPF program.
@@ -81,6 +90,19 @@ int bf_bpf_obj_get(const char *path, int *fd);
  */
 int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
                           int *link_fd);
+
+/**
+ * @brief Create a XDP BPF link.
+ *
+ * @param prog_fd File descriptor of the program to attach to the link.
+ * @param ifindex Interface index to attach the program to.
+ * @param link_fd Link file descriptor, only valid if the return value of the
+ *  function is 0.
+ * @param mode XDP program attach mode. See @ref bf_xdp_attach_mode.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
+                           enum bf_xdp_attach_mode mode);
 
 /**
  * @brief Detach a BPF link using its file descriptor.

--- a/src/core/dump.c
+++ b/src/core/dump.c
@@ -8,6 +8,10 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "opts.h"
+
+#define _DUMP_HEXDUMP_LEN 8
+
 void bf_dump_prefix_push(prefix_t *prefix)
 {
     char *_prefix = *prefix;
@@ -51,4 +55,24 @@ void bf_dump_prefix_pop(prefix_t *prefix)
     // Ensure we have a branch to the next item.
     if (len - 4)
         strncpy(&_prefix[len - 8], "|-- ", 5);
+}
+
+void bf_dump_hex(prefix_t *prefix, const void *data, size_t len)
+{
+    // 5 characters per byte (0x%02x) + 1 for the null terminator.
+    char buf[_DUMP_HEXDUMP_LEN * 5 + 1];
+    const void *end = data + len;
+
+    /* DUMP() won't print anything if we're not verbose, so we might as well
+     * skip the dump generation too. */
+    if (!bf_opts_verbose())
+        return;
+
+    while (data < end) {
+        char *line = buf;
+        for (size_t i = 0; i < _DUMP_HEXDUMP_LEN && data < end; ++i, ++data)
+            line += sprintf(line, "0x%02x ", *(unsigned char *)data);
+
+        DUMP((data == end ? bf_dump_prefix_last(prefix) : prefix), "%s", buf);
+    }
 }

--- a/src/core/dump.h
+++ b/src/core/dump.h
@@ -70,3 +70,14 @@ prefix_t *bf_dump_prefix_last(prefix_t *prefix);
  * @param prefix Prefix string.
  */
 void bf_dump_prefix_pop(prefix_t *prefix);
+
+/**
+ * @brief Dump the data buffer in hexedecimal format.
+ *
+ * Each byte in @p data will be printed as 0x%02x, with 8 bytes on each row.
+ *
+ * @param prefix Prefix string.
+ * @param data Data buffer to print.
+ * @param len Size of the data buffer.
+ */
+void bf_dump_hex(prefix_t *prefix, const void *data, size_t len);

--- a/src/core/flavor.c
+++ b/src/core/flavor.c
@@ -7,6 +7,7 @@
 
 #include "generator/nf.h"
 #include "generator/tc.h"
+#include "generator/xdp.h"
 #include "shared/helper.h"
 
 const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
@@ -14,6 +15,7 @@ const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
     static const struct bf_flavor_ops *flavor_ops[] = {
         [BF_FLAVOR_TC] = &bf_flavor_ops_tc,
         [BF_FLAVOR_NF] = &bf_flavor_ops_nf,
+        [BF_FLAVOR_XDP] = &bf_flavor_ops_xdp,
     };
 
     bf_assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);
@@ -28,6 +30,7 @@ const char *bf_flavor_to_str(enum bf_flavor flavor)
     static const char *flavor_str[] = {
         [BF_FLAVOR_TC] = "BF_FLAVOR_TC",
         [BF_FLAVOR_NF] = "BF_FLAVOR_NF",
+        [BF_FLAVOR_XDP] = "BF_FLAVOR_XDP",
     };
 
     bf_assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -34,6 +34,7 @@ enum bf_flavor
 {
     BF_FLAVOR_TC,
     BF_FLAVOR_NF,
+    BF_FLAVOR_XDP,
     _BF_FLAVOR_MAX,
 };
 

--- a/src/core/list.h
+++ b/src/core/list.h
@@ -168,9 +168,10 @@ static inline size_t bf_list_size(const bf_list *list)
  * @param list Initialised list. Must be non-NULL.
  * @return True if the list is empty, false otherwise.
  */
-static inline bool bf_list_empty(bf_list *list)
+static inline bool bf_list_is_empty(const bf_list *list)
 {
     bf_assert(list);
+
     return list->len == 0;
 }
 

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -5,9 +5,9 @@
 
 #include "generator/stub.h"
 
-#include <linux/bpf.h>
-
 #include <arpa/inet.h>
+
+#include <linux/bpf.h>
 
 #include "core/flavor.h"
 #include "generator/program.h"

--- a/src/generator/stub.h
+++ b/src/generator/stub.h
@@ -27,17 +27,27 @@ struct bf_program;
  */
 int bf_stub_memclear(struct bf_program *program, enum bf_reg addr_reg,
                      size_t size);
+/**
+ * @brief Emit instructions to get a dynptr for an XDP program.
+ *
+ * Prepare arguments and call bpf_dynptr_from_xdp(). If the return value is
+ * different from 0, jump to the end of the program and accept the packet.
+ *
+ * The initialised dynptr is stored in the program's runtime context.
+ *
+ * @param program Program to emit instructions into.
+ * @param md_reg Scratch register containing the pointer to the xdp_md.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_stub_make_ctx_xdp_dynptr(struct bf_program *program, enum bf_reg md_reg);
 
 /**
- * @brief Emit instructions to initialise the context's dynptr on the packet.
+ * @brief Emit instructions to get a dynptr for an XDP program.
  *
- * Store bpf_dynptr_from_skb argument into:
- * - BF_ARG_1: pointer to the @p skb. This is the address provided by @p
- *   skb_reg. If @p skb_reg is already BF_ARG_1, skip this instruction.
- * - BF_ARG_2: flags, 0.
- * - BF_ARG_3: address to the dynptr structure located in the context.
- * Then, call bpf_dynptr_from_skb(). If the return value is different from 0,
- * jump to the end of the program.
+ * Prepare arguments and call bpf_dynptr_from_skb(). If the return value is
+ * different from 0, jump to the end of the program and accept the packet.
+ *
+ * The initialised dynptr is stored in the program's runtime context.
  *
  * @param program Program to emit instructions into.
  * @param skb_reg Scratch register containing the pointer to the skb.

--- a/src/generator/tc.c
+++ b/src/generator/tc.c
@@ -5,9 +5,10 @@
 
 #include "generator/tc.h"
 
+#include <arpa/inet.h>
+
 #include <linux/pkt_cls.h>
 
-#include <arpa/inet.h>
 #include <bpf/libbpf.h>
 #include <errno.h>
 

--- a/src/generator/xdp.c
+++ b/src/generator/xdp.c
@@ -1,0 +1,167 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+
+#include <stddef.h>
+#include <unistd.h>
+
+#include "core/bpf.h"
+#include "core/flavor.h"
+#include "core/logger.h"
+#include "core/verdict.h"
+#include "generator/program.h"
+#include "generator/reg.h"
+#include "generator/stub.h"
+#include "shared/helper.h"
+
+#include "external/filter.h"
+
+static int _xdp_gen_inline_prologue(struct bf_program *program);
+static int _xdp_gen_inline_epilogue(struct bf_program *program);
+static int _xdp_get_verdict(enum bf_verdict verdict);
+static int _xdp_attach_prog_pre_unload(struct bf_program *program, int *prog_fd,
+                                       union bf_flavor_attach_attr *attr);
+static int _xdp_attach_prog_post_unload(struct bf_program *program,
+                                        int *prog_fd,
+                                        union bf_flavor_attach_attr *attr);
+static int _xdp_detach_prog(struct bf_program *program);
+
+const struct bf_flavor_ops bf_flavor_ops_xdp = {
+    .gen_inline_prologue = _xdp_gen_inline_prologue,
+    .gen_inline_epilogue = _xdp_gen_inline_epilogue,
+    .get_verdict = _xdp_get_verdict,
+    .attach_prog_pre_unload = _xdp_attach_prog_pre_unload,
+    .attach_prog_post_unload = _xdp_attach_prog_post_unload,
+    .detach_prog = _xdp_detach_prog,
+};
+
+/**
+ * @brief Generate XDP program prologue.
+ *
+ * @warning @ref bf_stub_get_l2_eth_hdr will check for L3 protocol. If L3 is
+ *  not IPv4, the program will be terminated.
+ *
+ * @param program Program to generate the prologue for. Must not be NULL.
+ * @return 0 on success, or negative errno value on error.
+ */
+static int _xdp_gen_inline_prologue(struct bf_program *program)
+{
+    int r;
+
+    bf_assert(program);
+
+    r = bf_stub_make_ctx_xdp_dynptr(program, BF_REG_1);
+    if (r)
+        return r;
+
+    // Copy xdp_md pointer into BF_REG_1
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(arg)));
+
+    // Copy xdp_md.data into BF_REG_2
+    EMIT(program,
+         BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, offsetof(struct xdp_md, data)));
+
+    // Copy xdp_md.data_end into BF_REG_3
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_3, BF_REG_1,
+                              offsetof(struct xdp_md, data_end)));
+
+    // Calculate packet size
+    EMIT(program, BPF_ALU64_REG(BPF_SUB, BF_REG_3, BF_REG_2));
+
+    // Copy packet size into context
+    EMIT(program,
+         BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
+
+    r = bf_stub_get_l2_eth_hdr(program);
+    if (r)
+        return r;
+
+    r = bf_stub_get_l3_ipv4_hdr(program);
+    if (r)
+        return r;
+
+    r = bf_stub_get_l4_hdr(program);
+    if (r)
+        return r;
+
+    return 0;
+}
+
+static int _xdp_gen_inline_epilogue(struct bf_program *program)
+{
+    UNUSED(program);
+
+    return 0;
+}
+
+static int _xdp_get_verdict(enum bf_verdict verdict)
+{
+    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+
+    static const int verdicts[] = {
+        [BF_VERDICT_ACCEPT] = XDP_PASS,
+        [BF_VERDICT_DROP] = XDP_DROP,
+    };
+
+    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+
+    return verdicts[verdict];
+}
+
+static int _xdp_attach_prog_pre_unload(struct bf_program *program, int *prog_fd,
+                                       union bf_flavor_attach_attr *attr)
+{
+    UNUSED(program);
+    UNUSED(prog_fd);
+    UNUSED(attr);
+
+    return 0;
+}
+
+/**
+ * @brief Post unload attach callback.
+ *
+ * See @ref bf_flavor_ops::attach_prog_post_unload for more details.
+ *
+ * @warning At this point, the previous XDP program has been detached already.
+ *  Meaning that no packet will be filtering until the function completes.
+ *
+ * @param program Program to unload. Must not be NULL.
+ * @param prog_fd File descriptor of the program to unload.
+ * @param attr Flavor-specific attributes. Unused for XDP.
+ * @return 0 on success, or negative errno value on failure.
+ */
+static int _xdp_attach_prog_post_unload(struct bf_program *program,
+                                        int *prog_fd,
+                                        union bf_flavor_attach_attr *attr)
+{
+    UNUSED(attr);
+
+    int fd;
+    int r;
+
+    bf_assert(program);
+    bf_assert(prog_fd);
+
+    r = bf_bpf_xdp_link_create(*prog_fd, program->ifindex, &fd,
+                               BF_XDP_MODE_SKB);
+    if (r)
+        return bf_err_code(r, "Failed to attach XDP program to interface");
+
+    close(*prog_fd);
+    *prog_fd = fd;
+
+    return 0;
+}
+
+static int _xdp_detach_prog(struct bf_program *program)
+{
+    bf_assert(program);
+
+    return bf_bpf_link_detach(program->runtime.prog_fd);
+}

--- a/src/generator/xdp.h
+++ b/src/generator/xdp.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/flavor.h"
+
+extern const struct bf_flavor_ops bf_flavor_ops_xdp;

--- a/src/opts.h
+++ b/src/opts.h
@@ -7,7 +7,10 @@
 
 #include <stdbool.h>
 
+#include "shared/front.h"
+
 int bf_opts_init(int argc, char *argv[]);
 bool bf_opts_transient(void);
 unsigned int bf_opts_bpf_log_buf_len_pow(void);
+bool bf_opts_is_front_enabled(enum bf_front front);
 bool bf_opts_verbose(void);

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -676,29 +676,25 @@ static int _bf_ipt_request_handler(struct bf_request *request,
 
 static int _bf_ipt_marsh(struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
-    int r;
+    int r = 0;
 
     bf_assert(marsh);
 
-    r = bf_marsh_new(&_marsh, NULL, 0);
-    if (r < 0)
-        return r;
+    if (!_cache)
+        return 0;
 
-    r |= bf_marsh_add_child_raw(&_marsh, &_cache->valid_hooks,
+    r |= bf_marsh_add_child_raw(marsh, &_cache->valid_hooks,
                                 sizeof(_cache->valid_hooks));
-    r |= bf_marsh_add_child_raw(&_marsh, &_cache->hook_entry,
+    r |= bf_marsh_add_child_raw(marsh, &_cache->hook_entry,
                                 sizeof(_cache->hook_entry));
-    r |= bf_marsh_add_child_raw(&_marsh, &_cache->underflow,
+    r |= bf_marsh_add_child_raw(marsh, &_cache->underflow,
                                 sizeof(_cache->underflow));
-    r |= bf_marsh_add_child_raw(&_marsh, &_cache->num_entries,
+    r |= bf_marsh_add_child_raw(marsh, &_cache->num_entries,
                                 sizeof(_cache->num_entries));
-    r |= bf_marsh_add_child_raw(&_marsh, &_cache->size, sizeof(_cache->size));
-    r |= bf_marsh_add_child_raw(&_marsh, _cache->entries, _cache->size);
+    r |= bf_marsh_add_child_raw(marsh, &_cache->size, sizeof(_cache->size));
+    r |= bf_marsh_add_child_raw(marsh, _cache->entries, _cache->size);
     if (r)
         return r;
-
-    *marsh = TAKE_PTR(_marsh);
 
     bf_dbg("Saved bf_ipt_cache at %p:", _cache);
     bf_dbg("  valid_hooks: %u", _cache->valid_hooks);
@@ -715,6 +711,9 @@ static int _bf_ipt_unmarsh(struct bf_marsh *marsh)
     int r;
 
     bf_assert(marsh);
+
+    if (marsh->data_len == 0)
+        return 0;
 
     r = _bf_ipt_cache_new(&cache);
     if (r < 0)


### PR DESCRIPTION
Multiple improvements to the codebase derived from `nftables` support:
- Add `bf_dump_hex()` to perform hexdump of a buffer.
- Refactor `bf_list_empty()`.
- Add `bf_response_new_raw()`.
- Add XDP support.
- Add option to disable `iptables` front.