### PR TITLE
generator: fix IP header protocol field size

### DIFF
--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -115,7 +115,7 @@ struct bf_program_context
 
     /** Layer 4 protocol. Set when the L3 header is processed. Used to define
      * how many bytes to read when processing the packet. */
-    uint16_t l4_proto;
+    uint8_t l4_proto;
 
     /** Layer 2 header. */
     union

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -183,7 +183,7 @@ int bf_stub_get_l3_ipv4_hdr(struct bf_program *program)
 
     // Store the L4 protocol into the context.
     EMIT(program,
-         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_STX_MEM(BPF_B, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l4_proto)));
 
     return 0;
 }
@@ -206,7 +206,7 @@ int bf_stub_get_l4_hdr(struct bf_program *program)
 
     // Load L4 protocol from the context.
     EMIT(program,
-         BPF_LDX_MEM(BPF_W, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
 
     {
         // If L4 protocol is TCP.


### PR DESCRIPTION
The protocol field in the IPv4 header is 8 bits, not 16.