### PR TITLE
generator: grow instructions buffer when `bpfilter emits a fixup call

### DIFF
--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -571,8 +571,9 @@ int bf_program_emit_fixup_call(struct bf_program *program,
     bf_assert(program);
 
     if (program->img_size == program->img_cap) {
-        bf_err("Codegen buffer overflow");
-        return -EOVERFLOW;
+        r = bf_program_grow_img(program);
+        if (r)
+            return r;
     }
 
     r = bf_fixup_new(&fixup);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -89,6 +89,7 @@ set(bf_test_srcs
     src/core/verdict.c
     src/generator/codegen.c
     src/generator/nf.c
+    src/generator/program.c
 )
 
 add_executable(tests_unit

--- a/tests/unit/src/generator/program.c
+++ b/tests/unit/src/generator/program.c
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/program.c"
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+Test(program, emit_fixup_call)
+{
+    expect_assert_failure(bf_program_emit_fixup_call(
+        NULL, BF_CODEGEN_FIXUP_FUNCTION_ADD_COUNTER));
+
+    {
+        // Instructions buffer should grow
+        _cleanup_bf_program_ struct bf_program *program = NULL;
+        size_t start_cap;
+
+        assert_int_equal(
+            0, bf_program_new(&program, 1, BF_HOOK_IPT_FORWARD, BF_FRONT_IPT));
+
+        start_cap = program->img_cap;
+
+        // Instructions buffer is empty after initialisation, ensure it grows.
+        assert_int_equal(0,
+                         bf_program_emit_fixup_call(
+                             program, BF_CODEGEN_FIXUP_FUNCTION_ADD_COUNTER));
+        assert_int_not_equal(program->img_cap, start_cap);
+    }
+}


### PR DESCRIPTION
When `bpfilter` emit an instruction, the instructions buffer in the program might be too small. In such a case, `bf_program_grow_img()` is called to grow the buffer size.

`bf_program_emit_fixup_call()` wasn't growing the buffer but returning `-EOVERFLOW` instead, this change fix this behaviour.