### PR TITLE
generator: add support for local BPF jump contexts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(bpfilter_daemon_srcs
 
     ${CMAKE_SOURCE_DIR}/src/generator/codegen.h ${CMAKE_SOURCE_DIR}/src/generator/codegen.c
     ${CMAKE_SOURCE_DIR}/src/generator/dump.h ${CMAKE_SOURCE_DIR}/src/generator/dump.c
+    ${CMAKE_SOURCE_DIR}/src/generator/jmp.h ${CMAKE_SOURCE_DIR}/src/generator/jmp.c
     ${CMAKE_SOURCE_DIR}/src/generator/nf.h ${CMAKE_SOURCE_DIR}/src/generator/nf.c
     ${CMAKE_SOURCE_DIR}/src/generator/program.h ${CMAKE_SOURCE_DIR}/src/generator/program.c
     ${CMAKE_SOURCE_DIR}/src/generator/reg.h

--- a/doc/developers/generation.rst
+++ b/doc/developers/generation.rst
@@ -1,0 +1,7 @@
+Programs generation
+===================
+
+Error handling
+--------------
+
+.. doxygenfile:: jmp.h

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@
 .. toctree::
    :hidden:
    :maxdepth: 2
-   :caption: Usage
+   :caption: Users
 
    overview
    sources
@@ -13,8 +13,9 @@
 .. toctree::
    :hidden:
    :maxdepth: 2
-   :caption: Development
+   :caption: Developers
 
+   developers/generation
    reference
 
 ``bpfilter`` is a BPF-based packet filtering framework. It is composed of a shared library (``libbpfilter``) and a daemon (``bpfilter``).

--- a/src/generator/jmp.c
+++ b/src/generator/jmp.c
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/jmp.h"
+
+#include "generator/program.h"
+
+void bf_jmpctx_cleanup(struct bf_jmpctx *ctx)
+{
+    struct bpf_insn *insn = &ctx->program->img[ctx->insn_idx];
+    insn->off = ctx->program->img_size - ctx->insn_idx - 1U;
+}

--- a/src/generator/jmp.h
+++ b/src/generator/jmp.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+
+#include <stddef.h>
+
+/**
+ * @file jmp.h
+ *
+ * @ref bf_jmpctx is a helper structure to manage jump instructions in the
+ * program. It is used to emit a jump instruction and automatically clean it up
+ * when the scope is exited, thanks to GCC's @c cleanup attribute.
+ *
+ * Example:
+ * @code{.c}
+ *  // Within a function body
+ *  {
+ *      _cleanup_bf_jmpctx_ struct bf_jmpctx ctx =
+ *          bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 0));
+ *
+ *      EMIT(program,
+ *          BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
+ *              BF_VERDICT_ACCEPT)));
+ *      EMIT(program, BPF_EXIT_INSN());
+ *  }
+ * @endcode
+ * \c ctx is a variable local to the scope, marked with \c _cleanup_bf_jmpctx_ .
+ * The second argument to \c bf_jmpctx_get is the jump instruction to emit, with
+ * the correct condition. When the scope is exited, the jump instruction is
+ * automatically updated to point to the current instruction, which is after the
+ * scope.
+ *
+ * Hence, all the instructions emitted within the scope will be executed if the
+ * condition is not met. If the condition is met, then the program execution
+ * will continue with the first instruction after the scope.
+ */
+
+struct bf_program;
+
+/**
+ * Cleanup attribute for a @ref bf_jmpctx variable.
+ */
+#define _cleanup_bf_jmpctx_ __attribute__((cleanup(bf_jmpctx_cleanup)))
+
+/**
+ * Create a new @ref bf_jmpctx variable.
+ *
+ * @param program The program to emit the jump instruction to. It must be
+ * non-NULL.
+ * @param insn The jump instruction to emit.
+ * @return A new @ref bf_jmpctx variable.
+ */
+#define bf_jmpctx_get(program, insn)                                           \
+    ({                                                                         \
+        size_t __idx = program->img_size;                                      \
+        int __r = bf_program_emit((program), (insn));                          \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        (struct bf_jmpctx) {.program = program, .insn_idx = __idx};            \
+    })
+
+/**
+ * A helper structure to manage jump instructions in the program.
+ *
+ * @var bf_jmpctx::program
+ *  The program to emit the jump instruction to.
+ * @var bf_jmpctx::insn_idx
+ *  The index of the jump instruction in the program's image.
+ */
+struct bf_jmpctx
+{
+    struct bf_program *program;
+    size_t insn_idx;
+};
+
+/**
+ * Cleanup function for @ref bf_jmpctx.
+ *
+ * @param ctx The @ref bf_jmpctx variable to clean up.
+ */
+void bf_jmpctx_cleanup(struct bf_jmpctx *ctx);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -88,6 +88,7 @@ set(bf_test_srcs
     src/core/marsh.c
     src/core/verdict.c
     src/generator/codegen.c
+    src/generator/jmp.c
     src/generator/nf.c
     src/generator/program.c
 )

--- a/tests/unit/src/generator/jmp.c
+++ b/tests/unit/src/generator/jmp.c
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/jmp.c"
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+/**
+ * Create a context and emit a given number of instructions.
+ *
+ * EMIT_*() macros can't be called directly from the test, as they return an
+ * error code on failure. This function is a workaround to test EMIT_*() macros
+ * and return a negative value on error. This negative value can then be
+ * asserted by the tests.
+ *
+ * @param program The program to emit the instructions in.
+ * @param ctx The context to create.
+ * @param n_insn The number of instructions to emit.
+ * @return 0 on success, or negative errno value on failure.
+ */
+static int emit_in_ctx(struct bf_program *program, struct bf_jmpctx *ctx,
+                       size_t n_insn)
+{
+    *ctx = bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 0));
+
+    for (size_t i = 0; i < n_insn; i++)
+        EMIT(program, BPF_MOV64_IMM(BF_REG_RET, 0));
+
+    return 0;
+}
+
+Test(jmp, create_and_close)
+{
+    _cleanup_bf_program_ struct bf_program *program = NULL;
+
+    assert_int_equal(bf_program_new(&program, 1, 0, 0), 0);
+
+    {
+        // Managing context manually
+        struct bf_jmpctx ctx;
+        assert_int_equal(emit_in_ctx(program, &ctx, 0), 0);
+        bf_jmpctx_cleanup(&ctx);
+        assert_int_equal(program->img[ctx.insn_idx].off, 0);
+
+        assert_int_equal(emit_in_ctx(program, &ctx, 1), 0);
+        bf_jmpctx_cleanup(&ctx);
+        assert_int_equal(program->img[ctx.insn_idx].off, 1);
+
+        assert_int_equal(emit_in_ctx(program, &ctx, 2), 0);
+        bf_jmpctx_cleanup(&ctx);
+        assert_int_equal(program->img[ctx.insn_idx].off, 2);
+    }
+
+    {
+        // Check if the context is automatically cleaned up
+        size_t idx;
+
+        {
+            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            assert_int_equal(emit_in_ctx(program, &_, 0), 0);
+            idx = _.insn_idx;
+        }
+
+        assert_int_equal(program->img[idx].off, 0);
+
+        {
+            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            assert_int_equal(emit_in_ctx(program, &_, 1), 0);
+            idx = _.insn_idx;
+        }
+
+        assert_int_equal(program->img[idx].off, 1);
+
+        {
+            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            assert_int_equal(emit_in_ctx(program, &_, 2), 0);
+            idx = _.insn_idx;
+        }
+
+        assert_int_equal(program->img[idx].off, 2);
+    }
+}


### PR DESCRIPTION
`bpfilter` emits jump instructions to the BPF programs. These jumps are relative to the current instruction pointer. This means that the jump offset need to be carefully updated if the program is generated differently:

```
EMIT(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 2)); EMIT(program,
    BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
        BF_VERDICT_ACCEPT)));
EMIT(program, BPF_EXIT_INSN())
```

The jump instruction is used to jump after the `BPF_EXIT_INSN()` call if if condition is true. However, if any instruction is added before `BPF_EXIT_INSN()`, the jump offset needs to be updated. This type of code prone to error is common in bpfilter for error management.

Local BPF jump contexts are introduced to handle this issue. A context define a scope-bound set of instructions to be executed if the condition is false, with the context automatically updating the jump offsets:

```c
{
    _cleanup_bf_jmpctx_ struct bf_jmpctx ctx =
        bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 0));

    EMIT(program,
        BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
            BF_VERDICT_ACCEPT)));
    EMIT(program, BPF_EXIT_INSN());
}
```

A context is defined first thing in the scope, with a jump instruction. Some instructions are added to the program from the scope. When the scope closes, the context is destroyed and the jump offsets is updated. Calling `EMIT_*` from the scope won't require any update to the jump offsets, as it will automatically be handled by the context.