### PR TITLE
Logging from bpf programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/generator/dump.h ${CMAKE_SOURCE_DIR}/src/generator/dump.c
     ${CMAKE_SOURCE_DIR}/src/generator/jmp.h ${CMAKE_SOURCE_DIR}/src/generator/jmp.c
     ${CMAKE_SOURCE_DIR}/src/generator/nf.h ${CMAKE_SOURCE_DIR}/src/generator/nf.c
+    ${CMAKE_SOURCE_DIR}/src/generator/print.h ${CMAKE_SOURCE_DIR}/src/generator/print.c
     ${CMAKE_SOURCE_DIR}/src/generator/program.h ${CMAKE_SOURCE_DIR}/src/generator/program.c
     ${CMAKE_SOURCE_DIR}/src/generator/reg.h
     ${CMAKE_SOURCE_DIR}/src/generator/stub.h ${CMAKE_SOURCE_DIR}/src/generator/stub.c

--- a/doc/developers/generation.rst
+++ b/doc/developers/generation.rst
@@ -5,3 +5,8 @@ Error handling
 --------------
 
 .. doxygenfile:: jmp.h
+
+Printing debug messages
+-----------------------
+
+.. doxygenfile:: print.h

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -81,13 +81,15 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
 }
 
 int bf_bpf_map_create(const char *name, unsigned int type, size_t key_size,
-                      size_t value_size, size_t max_entries, int *fd)
+                      size_t value_size, size_t max_entries, uint32_t flags,
+                      int *fd)
 {
     union bpf_attr attr = {
         .map_type = type,
         .key_size = key_size,
         .value_size = value_size,
         .max_entries = max_entries,
+        .map_flags = flags,
     };
     int r;
 
@@ -102,6 +104,15 @@ int bf_bpf_map_create(const char *name, unsigned int type, size_t key_size,
     return 0;
 }
 
+int bf_bpf_map_freeze(int fd)
+{
+    union bpf_attr attr = {
+        .map_fd = fd,
+    };
+
+    return _bpf(BPF_MAP_FREEZE, &attr);
+}
+
 int bf_bpf_map_lookup_elem(int fd, const void *key, void *value)
 {
     union bpf_attr attr = {
@@ -114,6 +125,18 @@ int bf_bpf_map_lookup_elem(int fd, const void *key, void *value)
     bf_assert(value);
 
     return _bpf(BPF_MAP_LOOKUP_ELEM, &attr);
+}
+
+int bf_bpf_map_update_elem(int fd, const void *key, void *value)
+{
+    union bpf_attr attr = {
+        .map_fd = fd,
+        .key = _bf_ptr_to_u64(key),
+        .value = _bf_ptr_to_u64(value),
+        .flags = BPF_ANY,
+    };
+
+    return _bpf(BPF_MAP_UPDATE_ELEM, &attr);
 }
 
 int bf_bpf_obj_pin(const char *path, int fd)

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -8,6 +8,7 @@
 #include <linux/if_link.h>
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "core/hook.h"
 
@@ -43,12 +44,24 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
  * @param key_size Size of a key.
  * @param value_size Size of a value.
  * @param max_entries Number of entries in the map.
+ * @param flags Map creation flags.
  * @param fd If the call succeed, this parameter will contain the map's
  * file descriptor.
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_bpf_map_create(const char *name, unsigned int type, size_t key_size,
-                      size_t value_size, size_t max_entries, int *fd);
+                      size_t value_size, size_t max_entries, uint32_t flags,
+                      int *fd);
+
+/**
+ * @brief Freeze a BPF map.
+ *
+ * A frozen map can't be modified from userspace.
+ *
+ * @param fd File descriptor of the map.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_map_freeze(int fd);
 
 /**
  * @brief Get an element from a map.
@@ -59,6 +72,16 @@ int bf_bpf_map_create(const char *name, unsigned int type, size_t key_size,
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_bpf_map_lookup_elem(int fd, const void *key, void *value);
+
+/**
+ * @brief Update (or insert) an element in a map.
+ *
+ * @param fd File descriptor of the map to search in.
+ * @param key Key to get the value for. Can't be NULL.
+ * @param value Pointer to the value.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_map_update_elem(int fd, const void *key, void *value);
 
 /**
  * @brief Pin a BPF object to a given path.

--- a/src/generator/dump.c
+++ b/src/generator/dump.c
@@ -135,8 +135,9 @@ static const char *_bf_jmp_op(const struct bpf_insn *insn)
 static const char *_bpf_helper(const struct bpf_insn *insn)
 {
     static const char *funcs[] = {
-        [BPF_FUNC_map_lookup_elem] = "map_lookup_elem",
-        [BPF_FUNC_map_update_elem] = "map_update_elem",
+        [BPF_FUNC_map_lookup_elem] = "bpf_map_lookup_elem",
+        [BPF_FUNC_map_update_elem] = "bpf_map_update_elem",
+        [BPF_FUNC_trace_printk] = "bpf_trace_printk",
     };
 
     return funcs[insn->imm];

--- a/src/generator/print.c
+++ b/src/generator/print.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/print.h"
+
+#include <linux/bpf.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/bpf.h"
+#include "core/logger.h"
+#include "opts.h"
+#include "shared/helper.h"
+
+#define make_print_str(id, str) [id] = {0, 0, "%d: " str}
+
+static struct
+{
+    size_t offset;
+    size_t len;
+    const char *str;
+} _bf_print_strings[] = {
+    make_print_str(BF_PRINT_NO_DYNPTR, "failed to create a dynamic pointer"),
+    make_print_str(BF_PRINT_NO_SLICE,
+                   "failed to create a dynamic pointer slice"),
+    make_print_str(BF_PRINT_NO_L2, "no L2 header available in packet data"),
+    make_print_str(BF_PRINT_NO_L3, "no L3 header available in packet data"),
+    make_print_str(BF_PRINT_NO_IPV4, "L3 header is not IPv4"),
+};
+
+static int _bf_fd = 1;
+static const char *_bf_print_strs_path = "/sys/fs/bpf/bf_print_strs";
+
+size_t _bf_compute_offsets(void)
+{
+    size_t next_offset = 0;
+
+    for (size_t i = 0; i < ARRAY_SIZE(_bf_print_strings); ++i) {
+        _bf_print_strings[i].offset = next_offset;
+        _bf_print_strings[i].len = strlen(_bf_print_strings[i].str + 1);
+        next_offset += _bf_print_strings[i].len;
+    }
+
+    return next_offset;
+}
+
+int bf_print_setup(void)
+{
+    _cleanup_free_ char *strings = NULL;
+    _cleanup_close_ int fd = -1;
+    size_t total_size;
+    int r;
+
+    total_size = _bf_compute_offsets();
+
+    strings = malloc(total_size);
+    if (!strings)
+        return bf_err_code(-EINVAL, "could not allocate memory");
+
+    for (size_t i = 0; i < ARRAY_SIZE(_bf_print_strings); ++i) {
+        memcpy(strings + _bf_print_strings[i].offset, _bf_print_strings[i].str,
+               _bf_print_strings[i].len);
+    }
+
+    r = bf_bpf_map_create("bf_print_strs", BPF_MAP_TYPE_ARRAY, sizeof(uint32_t),
+                          total_size, 1, BPF_F_RDONLY_PROG, &fd);
+    if (r < 0)
+        return bf_err_code(r, "failed to create strings map");
+
+    r = bf_bpf_map_update_elem(fd, (void *)(uint32_t[]) {0}, strings);
+    if (r < 0)
+        return bf_err_code(r, "failed to insert strings into the map");
+
+    r = bf_bpf_map_freeze(fd);
+    if (r < 0)
+        return bf_err_code(r, "failed to freeze strings map");
+
+    if (!bf_opts_transient()) {
+        r = bf_bpf_obj_pin(_bf_print_strs_path, _bf_fd);
+        if (r < 0)
+            return bf_err_code(r, "failed to pin strings map");
+    }
+
+    _bf_fd = TAKE_FD(fd);
+
+    return 0;
+}
+
+void bf_print_teardown(void)
+{
+    closep(&_bf_fd);
+}
+
+int bf_print_fd(void)
+{
+    bf_assert(_bf_fd >= 0);
+
+    return _bf_fd;
+}
+
+size_t bf_print_msg_size(enum bf_print_msg msg_id)
+{
+    bf_assert(0 <= msg_id && msg_id < _BF_PRINT_MAX);
+
+    return _bf_print_strings[msg_id].len;
+}
+
+size_t bf_print_msg_offset(enum bf_print_msg msg_id)
+{
+    bf_assert(0 <= msg_id && msg_id < _BF_PRINT_MAX);
+
+    return _bf_print_strings[msg_id].offset;
+}

--- a/src/generator/print.h
+++ b/src/generator/print.h
@@ -1,0 +1,159 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+/**
+ * @file print.h
+ *
+ * The \c bf_print_* functions relates to the message printing facilities
+ * provided to the generated BPF programs. \c bpfilter provides a set of
+ * predefined messages that can be printed from the BPF programs.
+ *
+ * During \c bpfilter initialization, the predefined messages are concatenated
+ * into a unique buffer or nul-separated strings. The offset of each message
+ * is saved in \c bpfilter runtime context for later use. The resulting strings
+ * buffer is then stored in a BPF map.
+ *
+ * All the log messages defined in \c bpfilter prefixed with
+ * \c "$IFINDEX:$HOOK:$FRONT: ", so log messages can be mapped back to a
+ * specific BPF program.
+ *
+ * @note All the message strings are stored in a single BPF map entry in order
+ * to benefit from \c BPF_PSEUDO_MAP_VALUE which allows lookup free direct
+ * value access for maps. Hence, using a unique instruction, \c bpfilter can
+ * load the map's file descriptor and get the address of a message in the
+ * buffer. See
+ * <https://lore.kernel.org/bpf/20190409210910.32048-2-daniel@iogearbox.net>.
+ *
+ * The file descriptor to the loaded BPF map is stored within \c bpfilter
+ * runtime context. It is not pinned and will be closed when \c bpfilter is
+ * stopped. If any BPF program refers to the map, the kernel will keep it until
+ * the last BPF program using it is unloaded. This behaviour is compatible with
+ * \c bpfilter transient mode:
+ * - If \c --transient is used, \c bpfilter will create the map at startup,
+ *   create zero or more BPF programs using it. When \c bpfilter is stopped,
+ *   the map's file descriptor will be closed and all the BPF programs created
+ *   by \c bpfilter will be unloaded. The map will be removed from the system.
+ * - If \c --transient is not used, \c bpfilter will create the map at startup,
+ *   create zero or more BPF programs using it. When \c bpfilter is stopped, the
+ *   map's file descriptor will be closed. The map will remain on the system
+ *   if any BPF program refers to it. On the next start, \c bpfilter will create
+ *   a new map and use it for new BPF programs, while existing BPF program still
+ *   refer to the old map.
+ * This mechanism prevents conflict if \c bpfilter is updated and restarted:
+ * existing programs use the old map, new programs use the new map.
+ */
+
+/**
+ * @brief Emit BPF instructions to print a predefined message.
+ *
+ * This function will insert mulitple instruction into the BPF program to: load
+ * the messages map's file descriptor, copy into the argument registers: the
+ * message's length, the program's ifindex, hook and front. Then it will call
+ * \c bpf_trace_printk() to print the message.
+ *
+ * @warning As every \c EMIT_* macro, \c EMIT_PRINT() will call \c return if
+ * an error occurs. Hence, it must be used within a function that returns an
+ * integer.
+ *
+ * @param program Program to emit the instructions to. Must not be NULL.
+ * @param msg_id Identifier of the message to print. See @ref bf_print_msg for
+ * the list of predefined messages.
+ */
+#define EMIT_PRINT(program, msg_id)                                            \
+    ({                                                                         \
+        int __r;                                                               \
+        struct bpf_insn __ld_insn[2] = {                                       \
+            BPF_LD_MAP_FD(BF_ARG_1, bf_print_fd()),                            \
+        };                                                                     \
+        __ld_insn[0].src_reg = BPF_PSEUDO_MAP_VALUE;                           \
+        __ld_insn[0].imm = bf_print_fd();                                      \
+        __ld_insn[1].imm = bf_print_msg_offset(msg_id);                        \
+        __r = bf_program_emit((program), __ld_insn[0]);                        \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit((program), __ld_insn[1]);                        \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit(                                                 \
+            (program), BPF_MOV64_IMM(BF_ARG_2, bf_print_msg_size(msg_id)));    \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit((program),                                       \
+                              BPF_MOV64_IMM(BF_ARG_3, program->ifindex));      \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit((program),                                       \
+                              BPF_MOV64_IMM(BF_ARG_4, program->hook));         \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit((program),                                       \
+                              BPF_MOV64_IMM(BF_ARG_5, program->front));        \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+        __r = bf_program_emit_kfunc_call((program), "bpf_trace_printk");       \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+    })
+
+/**
+ * @brief Identifiers of the predefined printable messages.
+ */
+enum bf_print_msg
+{
+    BF_PRINT_NO_DYNPTR,
+    BF_PRINT_NO_SLICE,
+    BF_PRINT_NO_L2,
+    BF_PRINT_NO_L3,
+    BF_PRINT_NO_IPV4,
+    _BF_PRINT_MAX,
+};
+
+/**
+ * @brief Setup context to allow generated BPF programs to print messages.
+ *
+ * The various printable messages are stored in an array of strings, this
+ * function will concatenate them into a unique nul-separated buffer of string
+ * and store it in a BPF map.
+ *
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_print_setup(void);
+
+/**
+ * @brief Teardown the printing context.
+ *
+ * The file descriptor of the BPF map containing the printable messages will be
+ * closed. The map will remain on the system until the last BPF program using it
+ * is unloaded.
+ */
+void bf_print_teardown(void);
+
+/**
+ * @brief Get the file descriptor of the BPF map containing the printable
+ * messages.
+ *
+ * @return File descriptor of the BPF map containing the printable messages.
+ */
+int bf_print_fd(void);
+
+/**
+ * @brief Get the size of a printable message.
+ *
+ * @param msg_id ID of the message to get the size of.
+ * @return Size of the message.
+ */
+size_t bf_print_msg_size(enum bf_print_msg msg_id);
+
+/**
+ * @brief Get the offset of a printable message in the BPF map.
+ * @param msg_id ID of the message to get the offset of.
+ *
+ * @return Offset of the message in the BPF map.
+ */
+size_t bf_print_msg_offset(enum bf_print_msg msg_id);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -477,7 +477,7 @@ static int _bf_program_load_counters_map(struct bf_program *program, int *fd)
 
     r = bf_bpf_map_create(program->map_name, BPF_MAP_TYPE_ARRAY,
                           sizeof(uint32_t), sizeof(struct bf_counter),
-                          program->num_counters, &_fd);
+                          program->num_counters, 0, &_fd);
     if (r < 0)
         return bf_err_code(errno, "failed to create counters map");
 

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -22,6 +22,7 @@
 #include "core/list.h"
 #include "core/verdict.h"
 #include "generator/fixup.h"
+#include "generator/print.h"
 #include "generator/reg.h"
 #include "shared/front.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "core/helper.h"
 #include "core/logger.h"
 #include "core/marsh.h"
+#include "generator/print.h"
 #include "opts.h"
 #include "shared/front.h"
 #include "shared/generic.h"
@@ -257,6 +258,10 @@ static int _bf_init(int argc, char *argv[])
     if (r < 0)
         return bf_err_code(r, "failed to parse command line arguments");
 
+    r = bf_print_setup();
+    if (r < 0)
+        return bf_err_code(r, "failed to initialise messages map");
+
     // Either load context, or initialize it from scratch.
     if (!bf_opts_transient())
         r = _bf_load(context_path);
@@ -311,6 +316,7 @@ static int _bf_clean(void)
         }
     }
 
+    bf_print_teardown();
     bf_context_teardown(bf_opts_transient());
 
     return 0;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -90,6 +90,7 @@ set(bf_test_srcs
     src/generator/codegen.c
     src/generator/jmp.c
     src/generator/nf.c
+    src/generator/print.c
     src/generator/program.c
 )
 

--- a/tests/unit/src/generator/print.c
+++ b/tests/unit/src/generator/print.c
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/print.c"
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+/* bf_print_* function are not easy to unit test as a standard user. root
+ * permission are required to use the bpf() syscall.
+ */
+
+Test(print, setup_fails_malloc)
+{
+    _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
+
+    assert_int_equal(ARRAY_SIZE(_bf_print_strings), _BF_PRINT_MAX);
+    assert_int_not_equal(bf_print_setup(), 0);
+}


### PR DESCRIPTION
This patch introduces a new set of functions to allow the BPF programs to print messages. The messages are predefined and stored in a BPF map. The BPF programs can then load the map and print the messages using the `bpf_trace_printk()` helper.

A new `EMIT_PRINT()` macro is introduced to emit the BPF instructions to load the map, the message's length, the program's ifindex, hook and front and call `bpf_trace_printk()`.