### PR TITLE
doc: remove `todo.rst`

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -5,7 +5,7 @@ configure_file(Doxyfile.in Doxyfile)
 configure_file(conf.py.in conf.py)
 
 set(doc_srcs
-	index.rst reference.rst todo.rst
+	index.rst reference.rst
 )
 
 add_custom_target(doc

--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -1,4 +1,0 @@
-ToDo
-====
-
-.. doxygenpage:: todo


### PR DESCRIPTION
`todo.rst` was used to display all the todo defined as Doxygen comment. It's not currently used in the documentation, so it can be removed.