### PR TITLE
core: make rule counter optional

### DIFF
--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -67,6 +67,8 @@ int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
                                 sizeof(rule->dst_mask));
     r |= bf_marsh_add_child_raw(&_marsh, &rule->protocol,
                                 sizeof(rule->protocol));
+    r |= bf_marsh_add_child_raw(&_marsh, &rule->counters,
+                                sizeof(rule->counters));
     r |= bf_marsh_add_child_raw(&_marsh, &rule->verdict,
                                 sizeof(enum bf_verdict));
     if (r)
@@ -124,6 +126,10 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
 
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
+    memcpy(&_rule->counters, child->data, sizeof(_rule->counters));
+
+    if (!(child = bf_marsh_next_child(marsh, child)))
+        return -EINVAL;
     memcpy(&_rule->verdict, child->data, sizeof(_rule->verdict));
 
     if (bf_marsh_next_child(marsh, child))
@@ -152,6 +158,7 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
     DUMP(prefix, "dst_mask: " IP4_FMT, IP4_SPLIT(rule->dst_mask));
     DUMP(prefix, "protocol: %u", rule->protocol);
     DUMP(prefix, "matches: %lu", bf_list_size(&rule->matches));
+    DUMP(prefix, "counters: %s", rule->counters ? "yes" : "no");
     DUMP(bf_dump_prefix_last(prefix), "verdict: %s",
          bf_verdict_to_str(rule->verdict));
 

--- a/src/core/rule.h
+++ b/src/core/rule.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "core/dump.h"
@@ -34,6 +35,7 @@ struct bf_rule
     uint32_t dst_mask;
     uint16_t protocol;
     bf_list matches;
+    bool counters;
     enum bf_verdict verdict;
 };
 

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -347,16 +347,19 @@ static int _bf_program_generate_rule(struct bf_program *program,
     /// @todo do matches too!
 
     // BF_ARG_1: counters map file descriptor.
-    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_MAP_FD, BPF_MOV64_IMM(BF_ARG_1, 0));
+    if (rule->counters) {
+        EMIT_FIXUP(program, BF_CODEGEN_FIXUP_MAP_FD,
+                   BPF_MOV64_IMM(BF_ARG_1, 0));
 
     // BF_ARG_2: index of the current rule in counters map.
     EMIT(program, BPF_MOV32_IMM(BF_ARG_2, rule->index));
 
     // BF_ARG_3: packet size, from the context.
-    EMIT(program,
-         BPF_LDX_MEM(BPF_DW, BF_ARG_3, BF_REG_CTX, BF_PROG_CTX_OFF(pkt_size)));
+        EMIT(program, BPF_LDX_MEM(BPF_DW, BF_ARG_3, BF_REG_CTX,
+                                  BF_PROG_CTX_OFF(pkt_size)));
 
     EMIT_FIXUP_CALL(program, BF_CODEGEN_FIXUP_FUNCTION_ADD_COUNTER);
+    }
 
     EMIT(program, BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
                                                 rule->verdict)));

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -291,6 +291,7 @@ static int _bf_ipt_to_rule(const struct ipt_entry *ipt_rule,
     _rule->dst = ipt_rule->ip.dst.s_addr;
     _rule->dst_mask = ipt_rule->ip.dmsk.s_addr;
     _rule->protocol = ipt_rule->ip.proto;
+    _rule->counters = true;
 
     while (offset < ipt_rule->target_offset) {
         r = _bf_ipt_to_match(ipt_get_match(ipt_rule, offset), &match);


### PR DESCRIPTION
In order to prepare `bpfilter` for `nftables` support, the rule counter should be optional. `nftables` doesn't add a counter for every rule unless it is explicitly requested.

The counter is enabled by default for `iptables`.