### PR TITLE
generator: add support for codegen update

### DIFF
--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -365,3 +365,19 @@ int bf_codegen_get_counter(const struct bf_codegen *codegen,
 
     return 0;
 }
+
+int bf_codegen_update(struct bf_codegen *codegen)
+{
+    int r;
+
+    bf_assert(codegen);
+
+    bf_list_foreach (&codegen->programs, program_node) {
+        struct bf_program *program = bf_list_node_get_data(program_node);
+        r = bf_program_update(program, &codegen->rules, codegen->policy);
+        if (r)
+            return bf_err_code(r, "failed to refresh program");
+    }
+
+    return 0;
+}

--- a/src/generator/codegen.h
+++ b/src/generator/codegen.h
@@ -78,6 +78,14 @@ void bf_codegen_free(struct bf_codegen **codegen);
 int bf_codegen_generate(struct bf_codegen *codegen);
 
 /**
+ * @brief Update the BPF programs for a codegen.
+ *
+ * @param codegen Codegen to update. Can't be NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_codegen_update(struct bf_codegen *codegen);
+
+/**
  * @brief Load the BPF program stored in a codegen.
  *
  * Each program within the codegen will be loaded and attached to its interface.

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -201,6 +201,27 @@ int bf_program_generate(struct bf_program *program, bf_list *rules,
                         enum bf_verdict policy);
 
 /**
+ * @brief Update the program's bytecode.
+ *
+ * This function will regenerate the BPF bytecode for @p program based on the
+ * given rules. The new bytecode will be loaded into the kernel to replace the
+ * current program. The program's metadata (ifindex, hook, front) will not be
+ * modified.
+ *
+ * @note This function purposefully update the bytecode and the program in
+ * one step. This is to ensure that the program is always in a consistent
+ * state.
+ *
+ * @param program Program to regenerate. Can not be NULL.
+ * @param rules List of rules to use to regenerate the program. Can not be NULL.
+ * @param policy Verdict to use when no rule matches. Must be one of @ref
+ * bf_verdict.
+ * @return 0 on success, negative errno code on failure.
+ */
+int bf_program_update(struct bf_program *program, bf_list *rules,
+                      enum bf_verdict policy);
+
+/**
  * @brief Load the program into the kernel.
  * @param program Program to load. Can not be NULL.
  * @param prev_program Previous program to unload. Can be NULL. If not NULL,


### PR DESCRIPTION
Introduce `bf_program_update()` and `bf_codegen_update()` to update the bytecode of a `bf_program` and reload it. This change improve support for fast reload of the bytecode, without downtime.