### PR TITLE
`nftables` support: add `bf_nfmsg` to represent Netfilter Netlink messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,7 @@ jobs:
             lcov \
             libasan \
             libbpf-devel \
+            libnl3-devel \
             libubsan \
             python3-breathe \
             python3-furo \
@@ -82,6 +83,7 @@ jobs:
             lcov \
             libasan \
             libbpf-devel \
+            libnl3-devel \
             libubsan \
             python3-breathe \
             python3-furo \
@@ -100,6 +102,7 @@ jobs:
             lcov \
             libbpf-dev \
             libcmocka-dev \
+            libnl-3-dev \
             python3-breathe \
             python3-pip \
             python3-sphinx \

--- a/.github/workflows/fork.yaml
+++ b/.github/workflows/fork.yaml
@@ -34,6 +34,7 @@ jobs:
             lcov \
             libasan \
             libbpf-devel \
+            libnl3-devel \
             libubsan \
             python3-breathe \
             python3-furo \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(bpf REQUIRED IMPORTED_TARGET libbpf)
 pkg_check_modules(elf REQUIRED IMPORTED_TARGET libelf)
 pkg_check_modules(cmocka REQUIRED IMPORTED_TARGET cmocka)
+pkg_check_modules(nl REQUIRED IMPORTED_TARGET libnl-3.0)
 
 # Required to get CMake to pass PIE flags to the compiler/linker
 include(CheckPIESupported)
@@ -95,6 +96,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/helpers.h
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.h ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.c
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/ipt.c
+    ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.h ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.c
 )
 
 set(bpfilter_library_srcs

--- a/doc/developers/fronts/index.rst
+++ b/doc/developers/fronts/index.rst
@@ -1,0 +1,9 @@
+Front-ends
+==========
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :caption: Front
+
+   nftables

--- a/doc/developers/fronts/nftables.rst
+++ b/doc/developers/fronts/nftables.rst
@@ -1,0 +1,7 @@
+``nftables``
+============
+
+Netlink messages
+----------------
+
+.. doxygenfile:: nfmsg.h

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,6 +16,7 @@
    :caption: Developers
 
    developers/generation
+   developers/fronts/index
    reference
 
 ``bpfilter`` is a BPF-based packet filtering framework. It is composed of a shared library (``libbpfilter``) and a daemon (``bpfilter``).

--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -10,10 +10,10 @@ Required dependencies on Fedora and Ubuntu:
 .. code-block:: shell
 
     # Fedora 38 / 39
-    clang-tools-extra cmake libcmocka-devel doxygen lcov libasan libbpf-devel libubsan python3-breathe python3-furo python3-sphinx pkgconf
+    clang-tools-extra cmake libcmocka-devel doxygen lcov libasan libbpf-devel libnl3-devel libubsan python3-breathe python3-furo python3-sphinx pkgconf
 
     # Ubuntu 23.10
-    clang-format clang-tidy cmake doxygen furo lcov libbpf-dev libcmocka-dev python3-breathe python3-pip python3-sphinx pkgconf
+    clang-format clang-tidy cmake doxygen furo lcov libbpf-dev libcmocka-dev libnl-3-dev python3-breathe python3-pip python3-sphinx pkgconf
 
 You can then use CMake to generate the build system:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_options(bpfilter
 
 target_link_libraries(bpfilter
     PUBLIC
-        bpf
+        PkgConfig::bpf
 )
 
 install(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_options(bpfilter
 target_link_libraries(bpfilter
     PUBLIC
         PkgConfig::bpf
+        PkgConfig::nl
 )
 
 install(

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -95,3 +95,38 @@ void bf_nfmsg_free(struct bf_nfmsg **msg)
     free(*msg);
     *msg = NULL;
 }
+
+struct nlmsghdr *bf_nfmsg_hdr(const struct bf_nfmsg *msg)
+{
+    bf_assert(msg);
+
+    return nlmsg_hdr(msg->msg);
+}
+
+size_t bf_nfmsg_data_len(const struct bf_nfmsg *msg)
+{
+    bf_assert(msg);
+
+    return nlmsg_datalen(bf_nfmsg_hdr(msg));
+}
+
+size_t bf_nfmsg_len(const struct bf_nfmsg *msg)
+{
+    bf_assert(msg);
+
+    return nlmsg_total_size(bf_nfmsg_data_len(msg));
+}
+
+uint8_t bf_nfmsg_command(const struct bf_nfmsg *msg)
+{
+    bf_assert(msg);
+
+    return bf_nfmsg_hdr(msg)->nlmsg_type & 0xff;
+}
+
+uint32_t bf_nfmsg_seqnr(const struct bf_nfmsg *msg)
+{
+    bf_assert(msg);
+
+    return bf_nfmsg_hdr(msg)->nlmsg_seq;
+}

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -130,3 +130,12 @@ uint32_t bf_nfmsg_seqnr(const struct bf_nfmsg *msg)
 
     return bf_nfmsg_hdr(msg)->nlmsg_seq;
 }
+
+int bf_nfmsg_attr_push(struct bf_nfmsg *msg, uint16_t type, const void *data,
+                       size_t len)
+{
+    bf_assert(msg);
+    bf_assert(data);
+
+    return nla_put(msg->msg, type, len, data);
+}

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "xlate/nft/nfmsg.h"
+
+#include <linux/netfilter/nfnetlink.h>
+#include <linux/netlink.h>
+
+#include <errno.h>
+#include <netlink/msg.h>
+
+#include "core/logger.h"
+#include "shared/helper.h"
+
+struct bf_nfmsg
+{
+    struct nl_msg *msg;
+};
+
+int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr)
+{
+    bf_assert(msg);
+
+    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    struct nlmsghdr *nlh;
+    struct nfgenmsg extra_hdr = {
+        .nfgen_family = AF_INET,
+        .version = NFNETLINK_V0,
+        .res_id = 0,
+    };
+    int r;
+
+    _msg = calloc(1, sizeof(*_msg));
+    if (!_msg)
+        return -ENOMEM;
+
+    _msg->msg = nlmsg_alloc();
+    if (!_msg->msg)
+        return -ENOMEM;
+
+    nlh = nlmsg_put(_msg->msg, 0, seqnr, NFNL_SUBSYS_NFTABLES << 8 | command, 0,
+                    0);
+    if (!nlh)
+        return bf_err_code(-ENOMEM, "failed to insert Netlink header");
+
+    r = nlmsg_append(_msg->msg, &extra_hdr, sizeof(extra_hdr), NLMSG_ALIGNTO);
+    if (r)
+        return bf_err_code(r, "failed to insert Netfilter extra header");
+
+    *msg = TAKE_PTR(_msg);
+
+    return 0;
+}
+
+int bf_nfmsg_new_from_nlmsghdr(struct bf_nfmsg **msg, struct nlmsghdr *nlh)
+{
+    bf_assert(msg);
+    bf_assert(nlh);
+
+    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+
+    if (nlh->nlmsg_type >> 8 != NFNL_SUBSYS_NFTABLES) {
+        return bf_err_code(-EINVAL, "invalid Netlink message type: %u",
+                           nlh->nlmsg_type);
+    }
+
+    if ((size_t)nlmsg_datalen(nlh) < sizeof(struct nfgenmsg)) {
+        return bf_err_code(-EINVAL, "invalid Netlink message payload size: %d",
+                           nlmsg_datalen(nlh));
+    }
+
+    _msg = calloc(1, sizeof(*_msg));
+    if (!_msg)
+        return -ENOMEM;
+
+    _msg->msg = nlmsg_convert(nlh);
+    if (!_msg->msg)
+        return -ENOMEM;
+
+    *msg = TAKE_PTR(_msg);
+
+    return 0;
+}
+
+void bf_nfmsg_free(struct bf_nfmsg **msg)
+{
+    bf_assert(msg);
+
+    if (!*msg)
+        return;
+
+    nlmsg_free((*msg)->msg);
+    free(*msg);
+    *msg = NULL;
+}

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -139,3 +139,29 @@ int bf_nfmsg_attr_push(struct bf_nfmsg *msg, uint16_t type, const void *data,
 
     return nla_put(msg->msg, type, len, data);
 }
+
+int bf_nfmsg_parse(const struct bf_nfmsg *msg, bf_nfattr **attrs, int maxtype,
+                   const bf_nfpolicy *policy)
+{
+    bf_assert(msg);
+    bf_assert(attrs);
+
+    return nlmsg_parse(bf_nfmsg_hdr(msg), sizeof(struct nfgenmsg), attrs,
+                       maxtype - 1, policy);
+}
+
+int bf_nfattr_parse(bf_nfattr *attr, bf_nfattr **attrs, int maxtype,
+                    const bf_nfpolicy *policy)
+{
+    bf_assert(attr);
+    bf_assert(attrs);
+
+    return nla_parse_nested(attrs, maxtype - 1, attr, policy);
+}
+
+void *bf_nfattr_data(bf_nfattr *attr)
+{
+    bf_assert(attr);
+
+    return nla_data(attr);
+}

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -5,6 +5,7 @@
 
 #include "xlate/nft/nfmsg.h"
 
+#include <linux/netfilter/nf_tables.h>
 #include <linux/netfilter/nfnetlink.h>
 #include <linux/netlink.h>
 
@@ -18,6 +19,99 @@ struct bf_nfmsg
 {
     struct nl_msg *msg;
 };
+
+static const struct nla_policy _bf_nf_table_policy[__NFTA_TABLE_MAX] = {
+    [NFTA_TABLE_NAME] = {.type = NLA_STRING},
+    [NFTA_TABLE_FLAGS] = {.type = NLA_U32},
+    [NFTA_TABLE_HANDLE] = {.type = NLA_U64},
+    [NFTA_TABLE_USERDATA] = {.type = NLA_BINARY},
+};
+const bf_nfpolicy *bf_nf_table_policy = _bf_nf_table_policy;
+
+static const struct nla_policy _bf_nf_chain_policy[__NFTA_CHAIN_MAX] = {
+    [NFTA_CHAIN_TABLE] = {.type = NLA_STRING},
+    [NFTA_CHAIN_HANDLE] = {.type = NLA_U64},
+    [NFTA_CHAIN_NAME] = {.type = NLA_STRING},
+    [NFTA_CHAIN_HOOK] = {.type = NLA_NESTED},
+    [NFTA_CHAIN_POLICY] = {.type = NLA_U32},
+    [NFTA_CHAIN_TYPE] = {.type = NLA_STRING},
+    [NFTA_CHAIN_COUNTERS] = {.type = NLA_NESTED},
+    [NFTA_CHAIN_FLAGS] = {.type = NLA_U32},
+    [NFTA_CHAIN_ID] = {.type = NLA_U32},
+    [NFTA_CHAIN_USERDATA] = {.type = NLA_BINARY},
+};
+const bf_nfpolicy *bf_nf_chain_policy = _bf_nf_chain_policy;
+
+static const struct nla_policy _bf_nf_hook_policy[__NFTA_HOOK_MAX] = {
+    [NFTA_HOOK_HOOKNUM] = {.type = NLA_U32},
+    [NFTA_HOOK_PRIORITY] = {.type = NLA_U32},
+    [NFTA_HOOK_DEV] = {.type = NLA_STRING},
+};
+const bf_nfpolicy *bf_nf_hook_policy = _bf_nf_hook_policy;
+
+static const struct nla_policy _bf_nf_rule_policy[__NFTA_RULE_MAX] = {
+    [NFTA_RULE_TABLE] = {.type = NLA_STRING},
+    [NFTA_RULE_CHAIN] = {.type = NLA_STRING},
+    [NFTA_RULE_HANDLE] = {.type = NLA_U64},
+    [NFTA_RULE_EXPRESSIONS] = {.type = NLA_NESTED},
+    [NFTA_RULE_COMPAT] = {.type = NLA_NESTED},
+    [NFTA_RULE_POSITION] = {.type = NLA_U64},
+    [NFTA_RULE_USERDATA] = {.type = NLA_BINARY},
+    [NFTA_RULE_ID] = {.type = NLA_U32},
+    [NFTA_RULE_POSITION_ID] = {.type = NLA_U32},
+    [NFTA_RULE_CHAIN_ID] = {.type = NLA_U32},
+};
+const bf_nfpolicy *bf_nf_rule_policy = _bf_nf_rule_policy;
+
+static const struct nla_policy _bf_nf_expr_policy[__NFTA_EXPR_MAX] = {
+    [NFTA_EXPR_NAME] = {.type = NLA_STRING},
+    [NFTA_EXPR_DATA] = {.type = NLA_NESTED},
+};
+const bf_nfpolicy *bf_nf_expr_policy = _bf_nf_expr_policy;
+
+static const struct nla_policy _bf_nf_counter_policy[NFTA_COUNTER_MAX + 1] = {
+    [NFTA_COUNTER_PACKETS] = {.type = NLA_U64},
+    [NFTA_COUNTER_BYTES] = {.type = NLA_U64},
+};
+const bf_nfpolicy *bf_nf_counter_policy = _bf_nf_counter_policy;
+
+static const struct nla_policy _bf_nf_payload_policy[__NFTA_PAYLOAD_MAX] = {
+    [NFTA_PAYLOAD_SREG] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_DREG] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_BASE] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_OFFSET] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_LEN] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_CSUM_TYPE] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_CSUM_OFFSET] = {.type = NLA_U32},
+    [NFTA_PAYLOAD_CSUM_FLAGS] = {.type = NLA_U32},
+};
+const bf_nfpolicy *bf_nf_payload_policy = _bf_nf_payload_policy;
+
+static const struct nla_policy _bf_nf_cmp_policy[__NFTA_CMP_MAX] = {
+    [NFTA_CMP_SREG] = {.type = NLA_U32},
+    [NFTA_CMP_OP] = {.type = NLA_U32},
+    [NFTA_CMP_DATA] = {.type = NLA_NESTED},
+};
+const bf_nfpolicy *bf_nf_cmp_policy = _bf_nf_cmp_policy;
+
+static const struct nla_policy _bf_nf_immediate_policy[__NFTA_IMMEDIATE_MAX] = {
+    [NFTA_IMMEDIATE_DREG] = {.type = NLA_U32},
+    [NFTA_IMMEDIATE_DATA] = {.type = NLA_NESTED},
+};
+const bf_nfpolicy *bf_nf_immediate_policy = _bf_nf_immediate_policy;
+
+static const struct nla_policy _bf_nf_data_policy[__NFTA_DATA_MAX] = {
+    [NFTA_DATA_VALUE] = {.type = NLA_BINARY},
+    [NFTA_DATA_VERDICT] = {.type = NLA_NESTED},
+};
+const bf_nfpolicy *bf_nf_data_policy = _bf_nf_data_policy;
+
+static const struct nla_policy _bf_nf_verdict_policy[__NFTA_VERDICT_MAX] = {
+    [NFTA_VERDICT_CODE] = {.type = NLA_U32},
+    [NFTA_VERDICT_CHAIN] = {.type = NLA_STRING},
+    [NFTA_VERDICT_CHAIN_ID] = {.type = NLA_U32},
+};
+const bf_nfpolicy *bf_nf_verdict_policy = _bf_nf_verdict_policy;
 
 int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr)
 {

--- a/src/xlate/nft/nfmsg.c
+++ b/src/xlate/nft/nfmsg.c
@@ -165,3 +165,28 @@ void *bf_nfattr_data(bf_nfattr *attr)
 
     return nla_data(attr);
 }
+
+int bf_nfmsg_nest_init(struct bf_nfnest *nest, struct bf_nfmsg *parent,
+                       uint16_t type)
+{
+    bf_assert(nest);
+    bf_assert(parent);
+
+    bf_nfattr *attr;
+
+    attr = nla_nest_start(parent->msg, type);
+    if (!attr)
+        return -ENOMEM;
+
+    nest->attr = attr;
+    nest->parent = parent;
+
+    return 0;
+}
+
+void bf_nfnest_cleanup(struct bf_nfnest *nest)
+{
+    bf_assert(nest);
+
+    nla_nest_end(nest->parent->msg, nest->attr);
+}

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @file nfmsg.h
+ *
+ * @c nftables communicates with the kernel using Netlink messages. To reduce
+ * the work needed by @c nftables to support @c bpfilter the same communication
+ * mechanism is used. Hence, @c bpfilter will receive Netlink messages from
+ * @c nftables and will send Netlink messages to @c nftables.
+ *
+ * This file provides a set of functions to create, parse, and manipulate
+ * Netlink messages. It also provides a set of Netlink validation policies for
+ * the different Netlink attributes used by @c nftables.
+ *
+ * All the functions defined in this file are dedicated to Netfilter Netlink
+ * messages and are not suitable for generic Netlink communication.
+ */
+
+struct nlmsghdr;
+struct bf_nfmsg;
+
+/**
+ * Cleanup attribute for a @ref bf_nfmsg variable.
+ */
+#define _cleanup_bf_nfmsg_ __attribute__((__cleanup__(bf_nfmsg_free)))
+
+/**
+ * Create a new Netfilter Netlink message.
+ *
+ * @param msg The new message to allocate and initialise. Can't be NULL.
+ * @param command Command to send, can be any of @c nf_tables_msg_types.
+ * @param seqnr Sequence number for the message.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr);
+
+/**
+ * Create a new Netfilter Netlink message from an existing Netlink message.
+ *
+ * The provided @p nlmsghdr must be a valid Netlink message targeted to the
+ * @c NFNL_SUBSYS_NFTABLES subsystem, and containing a @c nfgenmsg
+ * header.
+ *
+ * @param msg The new message to allocate and initialise. Can't be NULL.
+ * @param nlh Netlink message to create the Netfilter Netlink message from.
+ * Can't be NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfmsg_new_from_nlmsghdr(struct bf_nfmsg **msg, struct nlmsghdr *nlh);
+
+/**
+ * Free a Netfilter Netlink message.
+ *
+ * If @c msg is NULL, this function has no effect. Before returning, @c msg is
+ * set to NULL.
+ *
+ * @param msg Message to free. Must be non-NULL.
+ */
+void bf_nfmsg_free(struct bf_nfmsg **msg);

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -56,6 +56,20 @@ extern const bf_nfpolicy *bf_nf_data_policy;
 extern const bf_nfpolicy *bf_nf_verdict_policy;
 
 /**
+ * @file nfmsg.h
+ * @section nfmsg_section Messages
+ *
+ * @ref bf_nfmsg is a structure used to represent Netlink messages. It is an
+ * opaque structure, so the user must go through the dedicated API to create,
+ * parse, and manipulate Netlink messages.
+ *
+ * Netlink attributes can be pushed into the message using the generic function
+ * @ref bf_nfmsg_attr_push. However, for common types, convenience macros are
+ * provided to push a string, a @c uint8_t, a @c uint16_t, a @c uint32_t, or a
+ * @c uint64_t attribute.
+ */
+
+/**
  * Cleanup attribute for a @ref bf_nfmsg variable.
  */
 #define _cleanup_bf_nfmsg_ __attribute__((__cleanup__(bf_nfmsg_free)))

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -105,3 +105,108 @@ uint8_t bf_nfmsg_command(const struct bf_nfmsg *msg);
  * @return The message's sequence number.
  */
 uint32_t bf_nfmsg_seqnr(const struct bf_nfmsg *msg);
+
+/**
+ * Push a new attribute into a Netfilter Netlink message.
+ *
+ * @param msg Message to push the attribute to. Can't be NULL.
+ * @param type Attribute type.
+ * @param data Attribute data. Can't be NULL.
+ * @param len Attribute data length.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfmsg_attr_push(struct bf_nfmsg *msg, uint16_t type, const void *data,
+                       size_t len);
+
+/**
+ * Convenience macro to push a new attribute into a Netfilter Netlink message,
+ * but jump to a label on failure.
+ *
+ * If the attribute push fails, this macro jumps to the label
+ * @c bf_nfmsg_push_failure.
+ *
+ * @param msg Message to push the attribute to. Can't be NULL.
+ * @param type Attribute type.
+ * @param data Attribute data. Can't be NULL.
+ * @param size Attribute data length.
+ */
+#define bf_nfmsg_attr_push_or_jmp(msg, type, data, size)                       \
+    ({                                                                         \
+        if (bf_nfmsg_attr_push(msg, type, data, size) < 0)                     \
+            goto bf_nfmsg_push_failure;                                        \
+    })
+
+/**
+ * Convenience macro to push a new string attribute into a Netfilter Netlink
+ * message. See @ref bf_nfmsg_attr_push for more details.
+ */
+#define bf_nfmsg_push_str(msg, attr, data)                                     \
+    bf_nfmsg_attr_push(msg, attr, data, strlen(data) + 1)
+
+/**
+ * Convenience macro to push a new string attribute into a Netfilter Netlink
+ * message, and jump to a label on failure. See @ref bf_nfmsg_attr_push_or_jmp
+ * for more details.
+ */
+#define bf_nfmsg_push_str_or_jmp(part, attr, value)                            \
+    bf_nfmsg_attr_push_or_jmp(part, attr, value, strlen(value) + 1)
+
+/**
+ * Convenience macro to push a new uint8_t attribute into a Netfilter Netlink
+ * message. See @ref bf_nfmsg_attr_push for more details.
+ */
+#define bf_nfmsg_push_u8(msg, attr, data)                                      \
+    bf_nfmsg_attr_push(msg, attr, (&(uint8_t) {data}), sizeof(uint8_t))
+
+/**
+ * Convenience macro to push a new uint8_t attribute into a Netfilter Netlink
+ * message, and jump to a label on failure. See @ref bf_nfmsg_attr_push_or_jmp
+ * for more details.
+ */
+#define bf_nfmsg_push_u8_or_jmp(msg, attr, data)                               \
+    bf_nfmsg_attr_push_or_jmp(msg, attr, (&(uint8_t) {data}), sizeof(uint8_t))
+
+/**
+ * Convenience macro to push a new uint16_t attribute into a Netfilter Netlink
+ * message. See @ref bf_nfmsg_attr_push for more details.
+ */
+#define bf_nfmsg_push_u16(msg, attr, data)                                     \
+    bf_nfmsg_attr_push(msg, attr, (&(uint16_t) {data}), sizeof(uint16_t))
+
+/**
+ * Convenience macro to push a new uint16_t attribute into a Netfilter Netlink
+ * message, and jump to a label on failure. See @ref bf_nfmsg_attr_push_or_jmp
+ * for more details.
+ */
+#define bf_nfmsg_push_u16_or_jmp(msg, attr, data)                              \
+    bf_nfmsg_attr_push_or_jmp(msg, attr, (&(uint16_t) {data}), sizeof(uint16_t))
+
+/**
+ * Convenience macro to push a new uint32_t attribute into a Netfilter Netlink
+ * message. See @ref bf_nfmsg_attr_push for more details.
+ */
+#define bf_nfmsg_push_u32(msg, attr, data)                                     \
+    bf_nfmsg_attr_push(msg, attr, (&(uint32_t) {data}), sizeof(uint32_t))
+
+/**
+ * Convenience macro to push a new uint32_t attribute into a Netfilter Netlink
+ * message, and jump to a label on failure. See @ref bf_nfmsg_attr_push_or_jmp
+ * for more details.
+ */
+#define bf_nfmsg_push_u32_or_jmp(msg, attr, data)                              \
+    bf_nfmsg_attr_push_or_jmp(msg, attr, (&(uint32_t) {data}), sizeof(uint32_t))
+
+/**
+ * Convenience macro to push a new uint64_t attribute into a Netfilter Netlink
+ * message. See @ref bf_nfmsg_attr_push for more details.
+ */
+#define bf_nfmsg_push_u64(msg, attr, data)                                     \
+    bf_nfmsg_attr_push(msg, attr, (&(uint64_t) {data}), sizeof(uint64_t))
+
+/**
+ * Convenience macro to push a new uint64_t attribute into a Netfilter Netlink
+ * message, and jump to a label on failure. See @ref bf_nfmsg_attr_push_or_jmp
+ * for more details.
+ */
+#define bf_nfmsg_push_u64_or_jmp(msg, attr, data)                              \
+    bf_nfmsg_attr_push_or_jmp(msg, attr, (&(uint64_t) {data}), sizeof(uint64_t))

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -65,3 +65,43 @@ int bf_nfmsg_new_from_nlmsghdr(struct bf_nfmsg **msg, struct nlmsghdr *nlh);
  * @param msg Message to free. Must be non-NULL.
  */
 void bf_nfmsg_free(struct bf_nfmsg **msg);
+
+/**
+ * Get the Netlink message header for a Netfilter Netlink message.
+ *
+ * @param msg Message to get the header from. Must be non-NULL.
+ * @return The Netlink message header.
+ */
+struct nlmsghdr *bf_nfmsg_hdr(const struct bf_nfmsg *msg);
+
+/**
+ * Get a Netfilter Netlink message's size, including header and padding.
+ *
+ * @param msg Message to get the size of. Can't be NULL.
+ * @return Message's size, including header and padding.
+ */
+size_t bf_nfmsg_len(const struct bf_nfmsg *msg);
+
+/**
+ * Get a Netfilter Netlink message's payload size, including padding.
+ *
+ * @param msg Message to get the payload size of. Can't be NULL.
+ * @return Message's payload size, including padding.
+ */
+size_t bf_nfmsg_data_len(const struct bf_nfmsg *msg);
+
+/**
+ * Get a Netfilter Netlink message's command.
+ *
+ * @param msg Message to get the command from. Can't be NULL.
+ * @return The message's command.
+ */
+uint8_t bf_nfmsg_command(const struct bf_nfmsg *msg);
+
+/**
+ * Get a Netfilter Netlink message's sequence number.
+ *
+ * @param msg Message to get the sequence number from. Can't be NULL.
+ * @return The message's sequence number.
+ */
+uint32_t bf_nfmsg_seqnr(const struct bf_nfmsg *msg);

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -32,6 +32,29 @@ struct nla_policy;
 typedef struct nlattr bf_nfattr;
 typedef struct nla_policy bf_nfpolicy;
 
+/// Netlink validation policy for @c nft_table_attributes
+extern const bf_nfpolicy *bf_nf_table_policy;
+/// Netlink validation policy for @c nft_chain_attributes
+extern const bf_nfpolicy *bf_nf_chain_policy;
+/// Netlink validation policy for @c nft_hook_attributes
+extern const bf_nfpolicy *bf_nf_hook_policy;
+/// Netlink validation policy for @c nft_rule_attributes
+extern const bf_nfpolicy *bf_nf_rule_policy;
+/// Netlink validation policy for @c nft_expr_attributes
+extern const bf_nfpolicy *bf_nf_expr_policy;
+/// Netlink validation policy for @c nft_counter_attributes
+extern const bf_nfpolicy *bf_nf_counter_policy;
+/// Netlink validation policy for @c nft_payload_attributes
+extern const bf_nfpolicy *bf_nf_payload_policy;
+/// Netlink validation policy for @c nft_cmp_attributes
+extern const bf_nfpolicy *bf_nf_cmp_policy;
+/// Netlink validation policy for @c nft_immediate_attributes
+extern const bf_nfpolicy *bf_nf_immediate_policy;
+/// Netlink validation policy for @c nft_data_attributes
+extern const bf_nfpolicy *bf_nf_data_policy;
+/// Netlink validation policy for @c nft_verdict_attributes
+extern const bf_nfpolicy *bf_nf_verdict_policy;
+
 /**
  * Cleanup attribute for a @ref bf_nfmsg variable.
  */

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -26,6 +26,11 @@
 
 struct nlmsghdr;
 struct bf_nfmsg;
+struct nlattr;
+struct nla_policy;
+
+typedef struct nlattr bf_nfattr;
+typedef struct nla_policy bf_nfpolicy;
 
 /**
  * Cleanup attribute for a @ref bf_nfmsg variable.
@@ -210,3 +215,91 @@ int bf_nfmsg_attr_push(struct bf_nfmsg *msg, uint16_t type, const void *data,
  */
 #define bf_nfmsg_push_u64_or_jmp(msg, attr, data)                              \
     bf_nfmsg_attr_push_or_jmp(msg, attr, (&(uint64_t) {data}), sizeof(uint64_t))
+
+/**
+ * Parse attributes from a Netfilter Netlink message.
+ *
+ * All the attributes contained in the message are parsed and stored in the
+ * @p attrs array. Nested attributes (attributes contained within other) are
+ * not parsed, see @ref bf_nfattr_parse instead.
+ *
+ * @param msg Message to parse the attributes from. Can't be NULL.
+ * @param attrs Array of attributes to parse. Can't be NULL.
+ * @param maxtype Maximum attribute type to parse.
+ * @param policy Netlink validation policy to use. Can't be NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfmsg_parse(const struct bf_nfmsg *msg, bf_nfattr **attrs, int maxtype,
+                   const bf_nfpolicy *policy);
+
+/**
+ * @file nfmsg.h
+ * @section nfattr_section Attributes
+ *
+ * @ref bf_nfattr is a structure used to represent Netlink attributes. It is an
+ * opaque structure, so the user must go through the dedicated API to create,
+ * parse, and manipulate Netlink attributes.
+ */
+
+/**
+ * Parse attributes nested within a Netlink attribute.
+ *
+ * All the attributes contained in the @p attr are parsed and stored in the
+ * @p attrs array.
+ *
+ * @param attr Attribute to parse the nested attributes from. Can't be NULL.
+ * @param attrs Array of attributes to parse. Can't be NULL.
+ * @param maxtype Maximum attribute type to parse.
+ * @param policy Netlink validation policy to use. Can't be NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfattr_parse(bf_nfattr *attr, bf_nfattr **attrs, int maxtype,
+                    const bf_nfpolicy *policy);
+
+/**
+ * Get the data of a Netlink attribute.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+void *bf_nfattr_data(bf_nfattr *attr);
+
+/**
+ * Get a Netlink attribute's data as a string.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+#define bf_nfattr_get_str(attr) ((char *)bf_nfattr_data(attr))
+
+/**
+ * Get a Netlink attribute's data as a @c uint8_t.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+#define bf_nfattr_get_u8(attr) (*(uint8_t *)bf_nfattr_data(attr))
+
+/**
+ * Get a Netlink attribute's data as a @c uint16_t.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+#define bf_nfattr_get_u16(attr) (*(uint16_t *)bf_nfattr_data(attr))
+
+/**
+ * Get a Netlink attribute's data as a @c uint32_t.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+#define bf_nfattr_get_u32(attr) (*(uint32_t *)bf_nfattr_data(attr))
+
+/**
+ * Get a Netlink attribute's data as a @c uint64_t.
+ *
+ * @param attr Attribute to get the data from. Can't be NULL.
+ * @return Pointer to the attribute's data.
+ */
+#define bf_nfattr_get_u64(attr) (*(uint64_t *)bf_nfattr_data(attr))

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -92,6 +92,7 @@ set(bf_test_srcs
     src/generator/nf.c
     src/generator/print.c
     src/generator/program.c
+    src/xlate/nft/nfmsg.c
 )
 
 add_executable(tests_unit
@@ -150,6 +151,7 @@ target_link_libraries(tests_unit
         gcov
         PkgConfig::cmocka
         PkgConfig::elf
+        PkgConfig::nl
 )
 
 target_link_options(tests_unit
@@ -167,6 +169,10 @@ bf_test_mock(tests_unit
         read
         write
         btf__load_vmlinux_btf
+        nlmsg_alloc
+        nlmsg_convert
+        nlmsg_put
+        nlmsg_append
 )
 
 add_custom_target(test

--- a/tests/unit/harness/mock.c
+++ b/tests/unit/harness/mock.c
@@ -92,3 +92,42 @@ bf_mock_define(struct btf *, btf__load_vmlinux_btf, (void))
     errno = -EINVAL;
     return mock_type(struct btf *);
 }
+
+bf_mock_define(struct nl_msg *, nlmsg_alloc, ())
+{
+    if (!bf_mock_nlmsg_alloc_is_enabled())
+        return bf_mock_real(nlmsg_alloc)();
+
+    errno = -EINVAL;
+    return mock_type(struct nl_msg *);
+}
+
+bf_mock_define(struct nl_msg *, nlmsg_convert, (struct nlmsghdr * hdr))
+{
+    if (!bf_mock_nlmsg_convert_is_enabled())
+        return bf_mock_real(nlmsg_convert)(hdr);
+
+    errno = -EINVAL;
+    return mock_type(struct nl_msg *);
+}
+
+bf_mock_define(struct nlmsghdr *, nlmsg_put,
+               (struct nl_msg * n, uint32_t pid, uint32_t seq, int type,
+                int payload, int flags))
+{
+    if (!bf_mock_nlmsg_put_is_enabled())
+        return bf_mock_real(nlmsg_put)(n, pid, seq, type, payload, flags);
+
+    errno = -EINVAL;
+    return mock_type(struct nlmsghdr *);
+}
+
+bf_mock_define(int, nlmsg_append,
+               (struct nl_msg * n, void *data, size_t len, int pad))
+{
+    if (!bf_mock_nlmsg_append_is_enabled())
+        return bf_mock_real(nlmsg_append)(n, data, len, pad);
+
+    errno = -EINVAL;
+    return mock_type(int);
+}

--- a/tests/unit/harness/mock.h
+++ b/tests/unit/harness/mock.h
@@ -29,6 +29,9 @@
         (bf_mock) {.disable = bf_mock_##name##_disable};                       \
     })
 
+struct nlmsghdr;
+struct nl_msg;
+
 typedef struct
 {
     void (*disable)(void);
@@ -42,3 +45,10 @@ bf_mock_declare(int, open, (const char *pathname, int flags, mode_t mode));
 bf_mock_declare(ssize_t, read, (int fd, void *buf, size_t count));
 bf_mock_declare(ssize_t, write, (int fd, const void *buf, size_t count));
 bf_mock_declare(struct btf *, btf__load_vmlinux_btf, (void));
+bf_mock_declare(struct nl_msg *, nlmsg_alloc, ());
+bf_mock_declare(struct nl_msg *, nlmsg_convert, (struct nlmsghdr * nlh));
+bf_mock_declare(struct nlmsghdr *, nlmsg_put,
+                (struct nl_msg * n, uint32_t pid, uint32_t seq, int type,
+                 int payload, int flags));
+bf_mock_declare(int, nlmsg_append,
+                (struct nl_msg * n, void *data, size_t len, int pad));

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -130,3 +130,18 @@ Test(nfmsg, new_from_nlmsghdr)
             0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 }
+
+Test(nfmsg, write_attributes)
+{
+    _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+    expect_assert_failure(bf_nfmsg_attr_push(NULL, 0, NOT_NULL, 0));
+    expect_assert_failure(bf_nfmsg_attr_push(NOT_NULL, 0, NULL, 0));
+
+    assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    assert_int_equal(0, bf_nfmsg_push_u8(msg, 0, 0));
+    assert_int_equal(0, bf_nfmsg_push_u16(msg, 1, 1));
+    assert_int_equal(0, bf_nfmsg_push_u32(msg, 2, 2));
+    assert_int_equal(0, bf_nfmsg_push_u64(msg, 3, 3));
+    assert_int_equal(0, bf_nfmsg_push_str(msg, 4, "4"));
+}

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -135,6 +135,13 @@ Test(nfmsg, write_attributes)
 {
     _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
+    const bf_nfpolicy test_policy[] = {
+        [0] = {.type = NLA_U8},     [1] = {.type = NLA_U16},
+        [2] = {.type = NLA_U32},    [3] = {.type = NLA_U64},
+        [4] = {.type = NLA_STRING}, [5] = {.type = NLA_NESTED},
+    };
+    bf_nfattr *attrs[ARRAY_SIZE(test_policy)] = {};
+
     expect_assert_failure(bf_nfmsg_attr_push(NULL, 0, NOT_NULL, 0));
     expect_assert_failure(bf_nfmsg_attr_push(NOT_NULL, 0, NULL, 0));
 
@@ -144,4 +151,12 @@ Test(nfmsg, write_attributes)
     assert_int_equal(0, bf_nfmsg_push_u32(msg, 2, 2));
     assert_int_equal(0, bf_nfmsg_push_u64(msg, 3, 3));
     assert_int_equal(0, bf_nfmsg_push_str(msg, 4, "4"));
+
+    assert_int_equal(
+        0, bf_nfmsg_parse(msg, attrs, ARRAY_SIZE(attrs), test_policy));
+    assert_int_equal(0, bf_nfattr_get_u8(attrs[0]));
+    assert_int_equal(1, bf_nfattr_get_u16(attrs[1]));
+    assert_int_equal(2, bf_nfattr_get_u32(attrs[2]));
+    assert_int_equal(3, bf_nfattr_get_u64(attrs[3]));
+    assert_string_equal("4", bf_nfattr_get_str(attrs[4]));
 }

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -15,12 +15,18 @@ Test(nfmsg, new_and_free)
 {
     expect_assert_failure(bf_nfmsg_new(NULL, 0, 0));
     expect_assert_failure(bf_nfmsg_free(NULL));
+    expect_assert_failure(bf_nfmsg_hdr(NULL));
+    expect_assert_failure(bf_nfmsg_command(NULL));
+    expect_assert_failure(bf_nfmsg_seqnr(NULL));
 
     {
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
         assert_non_null(msg);
+        assert_int_equal(NFT_MSG_GETRULE, bf_nfmsg_command(msg));
+        assert_int_equal(17, bf_nfmsg_seqnr(msg));
+        assert_int_equal(sizeof(struct nfgenmsg), bf_nfmsg_data_len(msg));
     }
 
     {
@@ -28,6 +34,9 @@ Test(nfmsg, new_and_free)
 
         assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
         assert_non_null(msg);
+        assert_int_equal(NFT_MSG_GETRULE, bf_nfmsg_command(msg));
+        assert_int_equal(17, bf_nfmsg_seqnr(msg));
+        assert_int_equal(sizeof(struct nfgenmsg), bf_nfmsg_data_len(msg));
 
         bf_nfmsg_free(&msg);
         assert_null(msg);
@@ -63,5 +72,61 @@ Test(nfmsg, new_and_free)
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    }
+}
+
+Test(nfmsg, new_from_nlmsghdr)
+{
+    expect_assert_failure(bf_nfmsg_new_from_nlmsghdr(NULL, NOT_NULL));
+    expect_assert_failure(bf_nfmsg_new_from_nlmsghdr(NOT_NULL, NULL));
+
+    {
+        // Create a bf_nfmsg from a nlmsghdr
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        assert_int_equal(0,
+                         bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+        assert_int_equal(bf_nfmsg_command(msg0), bf_nfmsg_command(msg1));
+        assert_int_equal(bf_nfmsg_seqnr(msg0), bf_nfmsg_seqnr(msg1));
+        assert_int_equal(bf_nfmsg_data_len(msg0), bf_nfmsg_data_len(msg1));
+    }
+
+    {
+        // Invalid message type
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        bf_nfmsg_hdr(msg0)->nlmsg_type = 0;
+        assert_int_not_equal(
+            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+    }
+
+    {
+        // calloc failed
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+
+        assert_int_not_equal(
+            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+    }
+
+    {
+        // nlmsg_convert failed
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_convert, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+
+        assert_int_not_equal(
+            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 }

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "xlate/nft/nfmsg.c"
+
+#include <linux/netfilter/nf_tables.h>
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+Test(nfmsg, new_and_free)
+{
+    expect_assert_failure(bf_nfmsg_new(NULL, 0, 0));
+    expect_assert_failure(bf_nfmsg_free(NULL));
+
+    {
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_non_null(msg);
+    }
+
+    {
+        struct bf_nfmsg *msg = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_non_null(msg);
+
+        bf_nfmsg_free(&msg);
+        assert_null(msg);
+    }
+
+    {
+        // calloc failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    }
+
+    {
+        // nlmsg_put failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_alloc, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    }
+
+    {
+        // nlmsg_put failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_put, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    }
+
+    {
+        // nlmsg_append failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_append, -1);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    }
+}


### PR DESCRIPTION
`nftables` uses Netlink to communicate with the kernel. In order to support `nftables` and limit the changes to `nft` itself, `bpfilter` will receive Netlink messages from `nftables`.

This change introduce `bf_nfmsg` as an abstraction over Netfilter-specific Netlink messages.