### PR TITLE
`nftables` support: add `bf_nfgroup` for multipart Netlink messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/helpers.h
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.h ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.c
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/ipt.c
+    ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfgroup.h ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfgroup.c
     ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.h ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.c
 )
 

--- a/doc/developers/fronts/nftables.rst
+++ b/doc/developers/fronts/nftables.rst
@@ -5,3 +5,8 @@ Netlink messages
 ----------------
 
 .. doxygenfile:: nfmsg.h
+
+Messages groups
+---------------
+
+.. doxygenfile:: nfgroup.h

--- a/src/xlate/nft/nfgroup.c
+++ b/src/xlate/nft/nfgroup.c
@@ -129,3 +129,27 @@ int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg)
 
     return bf_list_add_tail(&group->messages, msg);
 }
+
+int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
+                               uint16_t command, uint16_t seqnr)
+{
+    bf_assert(group);
+
+    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    int r;
+
+    r = bf_nfmsg_new(&_msg, command, seqnr);
+    if (r < 0)
+        return r;
+
+    r = bf_nfgroup_add_message(group, _msg);
+    if (r < 0)
+        return r;
+
+    if (msg)
+        *msg = TAKE_PTR(_msg);
+    else
+        TAKE_PTR(_msg);
+
+    return 0;
+}

--- a/src/xlate/nft/nfgroup.c
+++ b/src/xlate/nft/nfgroup.c
@@ -96,6 +96,32 @@ void bf_nfgroup_free(struct bf_nfgroup **group)
     *group = NULL;
 }
 
+const bf_list *bf_nfgroup_messages(const struct bf_nfgroup *group)
+{
+    bf_assert(group);
+
+    return &group->messages;
+}
+
+size_t bf_nfgroup_size(const struct bf_nfgroup *group)
+{
+    bf_assert(group);
+
+    size_t size = 0;
+
+    bf_list_foreach (&group->messages, msg_node)
+        size += bf_nfmsg_len(bf_list_node_get_data(msg_node));
+
+    return size;
+}
+
+bool bf_nfgroup_is_empty(const struct bf_nfgroup *group)
+{
+    bf_assert(group);
+
+    return bf_list_is_empty(&group->messages);
+}
+
 int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg)
 {
     bf_assert(group);

--- a/src/xlate/nft/nfgroup.c
+++ b/src/xlate/nft/nfgroup.c
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "xlate/nft/nfgroup.h"
+
+#include <linux/netfilter/nfnetlink.h>
+#include <linux/netlink.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <netlink/msg.h>
+
+#include "core/list.h"
+#include "xlate/nft/nfmsg.h"
+
+struct bf_nfgroup
+{
+    bf_list messages;
+};
+
+int bf_nfgroup_new(struct bf_nfgroup **group)
+{
+    bf_assert(group);
+
+    _cleanup_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
+
+    _group = calloc(1, sizeof(*_group));
+    if (!_group)
+        return -ENOMEM;
+
+    bf_list_init(&_group->messages, &(bf_list_ops) {
+                                        .free = (bf_list_ops_free)bf_nfmsg_free,
+                                    });
+
+    *group = TAKE_PTR(_group);
+
+    return 0;
+}
+
+int bf_nfgroup_new_from_stream(struct bf_nfgroup **group, struct nlmsghdr *nlh,
+                               size_t length)
+{
+    bf_assert(group);
+    bf_assert(nlh);
+    bf_assert(length <
+              INT_MAX); // nlmsg_ok() takes an int. length should not be larger
+                        // than INT_MAX, but we check anyway to be safe.
+
+    _cleanup_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
+    int len = (int)length;
+    int r;
+
+    r = bf_nfgroup_new(&_group);
+    if (r < 0)
+        return r;
+
+    while (nlmsg_ok(nlh, len)) {
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        if (nlh->nlmsg_type == NFNL_MSG_BATCH_BEGIN ||
+            nlh->nlmsg_type == NFNL_MSG_BATCH_END) {
+            // Skip batch messages.
+            nlh = nlmsg_next(nlh, &len);
+            continue;
+        }
+
+        r = bf_nfmsg_new_from_nlmsghdr(&msg, nlh);
+        if (r < 0)
+            return r;
+
+        r = bf_nfgroup_add_message(_group, msg);
+        if (r < 0)
+            return r;
+
+        TAKE_PTR(msg);
+
+        nlh = nlmsg_next(nlh, &len);
+    }
+
+    *group = TAKE_PTR(_group);
+
+    return 0;
+}
+
+void bf_nfgroup_free(struct bf_nfgroup **group)
+{
+    bf_assert(group);
+
+    if (!*group)
+        return;
+
+    bf_list_clean(&(*group)->messages);
+    free(*group);
+    *group = NULL;
+}
+
+int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg)
+{
+    bf_assert(group);
+    bf_assert(msg);
+
+    return bf_list_add_tail(&group->messages, msg);
+}

--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "core/list.h"
 
@@ -85,3 +86,21 @@ bool bf_nfgroup_is_empty(const struct bf_nfgroup *group);
  * @return 0 on success, or negative errno value on error.
  */
 int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg);
+
+/**
+ * Create a new Netfilter Netlink message and add it to a Netlink messages
+ * group.
+ *
+ * The new Netfilter Netlink message is owned by the messages group and should
+ * not be freed by the caller.
+ *
+ * @param group Netlink messages group to add the message to. Can't be NULL.
+ * @param msg Pointer to the new message. Once the function succeeds, this
+ * pointer will be set to the new message. Can be NULL, in which case the
+ * caller won't have access to the new message.
+ * @param command Netlink message command.
+ * @param seqnr Netlink message sequence number.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
+                               uint16_t command, uint16_t seqnr);

--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -1,0 +1,55 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+#include <stddef.h>
+struct nlmsghdr;
+struct bf_nfgroup;
+struct bf_nfmsg;
+
+/**
+ * Cleanup function for @ref bf_nfgroup.
+ */
+#define _cleanup_bf_nfgroup_ __attribute__((__cleanup__(bf_nfgroup_free)))
+
+/**
+ * Create a new Netlink messages group.
+ *
+ * @param group Pointer to the new messages group. Must not be NULL. Will be
+ * allocated and initialised by this function. Can't be NULL.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nfgroup_new(struct bf_nfgroup **group);
+
+/**
+ * Create a new Netlink messages group from a stream of @ref nlmsghdr.
+ *
+ * @param msg Pointer to the new message. Must not be NULL. Will be allocated
+ * and initialised by this function.
+ * @param nlh Pointer to the first @ref nlmsghdr in the stream. Must not be
+ * NULL.
+ * @param length Total length of the stream.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nfgroup_new_from_stream(struct bf_nfgroup **group, struct nlmsghdr *nlh,
+                               size_t length);
+
+/**
+ * Free a Netlink messages group.
+ *
+ * @param msg Pointer to the messages group to free. If @p msg is NULL, nothing
+ * is done.
+ */
+void bf_nfgroup_free(struct bf_nfgroup **group);
+
+/**
+ * Add a Netlink message to the Netlink messages group.
+ *
+ * @param group Netlink messages group to add the message to. Can't be NULL.
+ * @param group Message to add to the messages group. Can't be NULL. The Netlink
+ * messages group takes onwership of the message.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg);

--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -17,6 +17,20 @@ struct bf_response;
 struct bf_nfmsg;
 
 /**
+ * @file nfgroup.h
+ *
+ * Netlink allows data to be sent in multipart messages, which is a stream
+ * of multiple Netlink messages (each with its own header), flagged with
+ * @c NLM_F_MULTI and ending with a final message of type @c NLMSG_DONE
+ *
+ * @ref bf_nfgroup is an abstraction to represent multipart messages. It
+ * contains a list of @ref bf_nfmsg, each of which is a Netlink message.
+ *
+ * The messages group can be converted into a single @ref bf_response, which
+ * is a contiguous buffer containing all the messages in the group.
+ */
+
+/**
  * Cleanup function for @ref bf_nfgroup.
  */
 #define _cleanup_bf_nfgroup_ __attribute__((__cleanup__(bf_nfgroup_free)))

--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -4,7 +4,12 @@
  */
 
 #pragma once
+
+#include <stdbool.h>
 #include <stddef.h>
+
+#include "core/list.h"
+
 struct nlmsghdr;
 struct bf_nfgroup;
 struct bf_nfmsg;
@@ -43,6 +48,33 @@ int bf_nfgroup_new_from_stream(struct bf_nfgroup **group, struct nlmsghdr *nlh,
  * is done.
  */
 void bf_nfgroup_free(struct bf_nfgroup **group);
+
+/**
+ * Get the list of messages in the Netlink messages group.
+ *
+ * @param group Netlink messages group to get the list from. Can't be NULL.
+ * @return @ref bf_list containing the @ref bf_nfmsg
+ */
+const bf_list *bf_nfgroup_messages(const struct bf_nfgroup *group);
+
+/**
+ * Get the total Netlink message size.
+ *
+ * The total size of the Netlink message is the sum of the size of all the
+ * messages, including padding.
+ *
+ * @param group Netlink messages group to get the size of. Can't be NULL.
+ * @return Total size of the Netlink messages group.
+ */
+size_t bf_nfgroup_size(const struct bf_nfgroup *group);
+
+/**
+ * Test if a Netlink message group is empty.
+ *
+ * @param group Netlink message to check. Can't be NULL.
+ * @return True if the Netlink message is empty (no messages), false otherwise.
+ */
+bool bf_nfgroup_is_empty(const struct bf_nfgroup *group);
 
 /**
  * Add a Netlink message to the Netlink messages group.

--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -13,6 +13,7 @@
 
 struct nlmsghdr;
 struct bf_nfgroup;
+struct bf_response;
 struct bf_nfmsg;
 
 /**
@@ -104,3 +105,18 @@ int bf_nfgroup_add_message(struct bf_nfgroup *group, struct bf_nfmsg *msg);
  */
 int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
                                uint16_t command, uint16_t seqnr);
+
+/**
+ * Convert a Netlink messages group into a bf_response.
+ *
+ * All the Netfilter Netlink messages contained in the group will written
+ * contiguously in the payload of a single @c bf_response .
+ *
+ * @param group Netlink messages group to convert. Can't be NULL.
+ * @param resp Pointer to the new response. Can't be NULL. A new response will
+ * be allocated by this function and the caller will be responsible for freeing
+ * it.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nfgroup_to_response(const struct bf_nfgroup *group,
+                           struct bf_response **resp);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -93,6 +93,7 @@ set(bf_test_srcs
     src/generator/print.c
     src/generator/program.c
     src/xlate/nft/nfmsg.c
+    src/xlate/nft/nfgroup.c
 )
 
 add_executable(tests_unit

--- a/tests/unit/harness/helper.c
+++ b/tests/unit/harness/helper.c
@@ -13,6 +13,7 @@
 #include "generator/program.h"
 #include "harness/cmocka.h"
 #include "shared/helper.h"
+#include "xlate/nft/nfgroup.h"
 
 struct nlmsghdr;
 
@@ -137,4 +138,17 @@ struct nlmsghdr *bf_test_get_nlmsghdr(size_t nmsg, size_t *len)
     *len = msg_size;
 
     return (struct nlmsghdr *)TAKE_PTR(msg);
+}
+
+struct bf_nfgroup *bf_test_get_nfgroup(size_t nmsg, size_t *len)
+{
+    _cleanup_bf_nfgroup_ struct bf_nfgroup *group = NULL;
+    _cleanup_free_ struct nlmsghdr *nlh = NULL;
+
+    nlh = bf_test_get_nlmsghdr(nmsg, len);
+    assert_non_null(nlh);
+
+    assert_int_equal(bf_nfgroup_new_from_stream(&group, nlh, *len), 0);
+
+    return TAKE_PTR(group);
 }

--- a/tests/unit/harness/helper.h
+++ b/tests/unit/harness/helper.h
@@ -12,6 +12,7 @@
 #define _cleanup_tmp_file_ __attribute__((cleanup(bf_test_remove_tmp_file)))
 
 struct bf_codegen;
+struct bf_nfgroup;
 struct nlmsghdr;
 
 char *bf_test_get_readable_tmp_filepath(void);
@@ -19,3 +20,4 @@ void bf_test_remove_tmp_file(char **path);
 int bf_test_make_codegen(struct bf_codegen **codegen, enum bf_hook hook,
                          int nprogs);
 struct nlmsghdr *bf_test_get_nlmsghdr(size_t nmsg, size_t *len);
+struct bf_nfgroup *bf_test_get_nfgroup(size_t nmsg, size_t *len);

--- a/tests/unit/harness/helper.h
+++ b/tests/unit/harness/helper.h
@@ -5,13 +5,17 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include "core/hook.h"
 
 #define _cleanup_tmp_file_ __attribute__((cleanup(bf_test_remove_tmp_file)))
 
 struct bf_codegen;
+struct nlmsghdr;
 
 char *bf_test_get_readable_tmp_filepath(void);
 void bf_test_remove_tmp_file(char **path);
 int bf_test_make_codegen(struct bf_codegen **codegen, enum bf_hook hook,
                          int nprogs);
+struct nlmsghdr *bf_test_get_nlmsghdr(size_t nmsg, size_t *len);

--- a/tests/unit/src/xlate/nft/nfgroup.c
+++ b/tests/unit/src/xlate/nft/nfgroup.c
@@ -88,3 +88,33 @@ Test(nfgroup, helpers)
         assert_int_equal(bf_nfgroup_size(gp), len);
     }
 }
+
+Test(nfgroup, add_new_message)
+{
+    expect_assert_failure(bf_nfgroup_add_new_message(NULL, NOT_NULL, 0, 0));
+
+    {
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+
+        assert_int_equal(bf_nfgroup_new(&gp), 0);
+
+        for (int i = 0; i < 10; ++i) {
+            struct bf_nfmsg *msg = NULL;
+            assert_int_equal(bf_nfgroup_add_new_message(gp, &msg, 0, 0), 0);
+
+            assert_non_null(msg);
+            assert_int_equal(bf_list_size(bf_nfgroup_messages(gp)), i + 1);
+        }
+    }
+
+    {
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+
+        assert_int_equal(bf_nfgroup_new(&gp), 0);
+
+        for (int i = 0; i < 10; ++i) {
+            assert_int_equal(bf_nfgroup_add_new_message(gp, NULL, 0, 0), 0);
+            assert_int_equal(bf_list_size(bf_nfgroup_messages(gp)), i + 1);
+        }
+    }
+}

--- a/tests/unit/src/xlate/nft/nfgroup.c
+++ b/tests/unit/src/xlate/nft/nfgroup.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "xlate/nft/nfgroup.c"
+
+#include <linux/netfilter/nf_tables.h>
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+Test(nfgroup, new_and_free)
+{
+    expect_assert_failure(bf_nfgroup_new(NULL));
+    expect_assert_failure(bf_nfgroup_free(NULL));
+
+    {
+        struct bf_nfgroup *gp = NULL;
+
+        bf_nfgroup_free(&gp);
+        assert_int_equal(bf_nfgroup_new(&gp), 0);
+        assert_non_null(gp);
+        bf_nfgroup_free(&gp);
+    }
+
+    {
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+
+        assert_int_equal(bf_nfgroup_new(&gp), 0);
+        assert_non_null(gp);
+    }
+
+    {
+        // calloc failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+
+        assert_int_equal(bf_nfgroup_new(&gp), -ENOMEM);
+    }
+}
+
+Test(nfgroup, new_from_stream)
+{
+    expect_assert_failure(bf_nfgroup_new_from_stream(NULL, NOT_NULL, 0));
+    expect_assert_failure(bf_nfgroup_new_from_stream(NOT_NULL, NULL, 0));
+    expect_assert_failure(bf_nfgroup_add_message(NULL, NOT_NULL));
+    expect_assert_failure(bf_nfgroup_add_message(NOT_NULL, NULL));
+
+    {
+        // 1 Netlink message
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        size_t nlh_len = 0;
+        _cleanup_free_ struct nlmsghdr *nlh = bf_test_get_nlmsghdr(1, &nlh_len);
+
+        assert_int_equal(bf_nfgroup_new_from_stream(&gp, nlh, nlh_len), 0);
+        assert_non_null(gp);
+    }
+
+    {
+        // 2 Netlink messages
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        size_t nlh_len = 0;
+        _cleanup_free_ struct nlmsghdr *nlh = bf_test_get_nlmsghdr(2, &nlh_len);
+
+        assert_int_equal(bf_nfgroup_new_from_stream(&gp, nlh, nlh_len), 0);
+        assert_non_null(gp);
+    }
+}

--- a/tests/unit/src/xlate/nft/nfgroup.c
+++ b/tests/unit/src/xlate/nft/nfgroup.c
@@ -118,3 +118,36 @@ Test(nfgroup, add_new_message)
         }
     }
 }
+
+Test(nfgroup, to_response)
+{
+    expect_assert_failure(bf_nfgroup_to_response(NULL, NOT_NULL));
+    expect_assert_failure(bf_nfgroup_to_response(NOT_NULL, NULL));
+
+    {
+        // Group without any message
+
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _cleanup_bf_response_ struct bf_response *res = NULL;
+
+        assert_int_equal(bf_nfgroup_new(&gp), 0);
+        assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
+        assert_non_null(res);
+        assert_int_equal(res->type, BF_RES_SUCCESS);
+        assert_int_equal(res->data_len, 0);
+    }
+
+    {
+        // Group without multiple messages
+
+        size_t len;
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp =
+            bf_test_get_nfgroup(10, &len);
+        _cleanup_bf_response_ struct bf_response *res = NULL;
+
+        assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
+        assert_non_null(res);
+        assert_int_equal(res->type, BF_RES_SUCCESS);
+        assert_int_equal(res->data_len, len);
+    }
+}

--- a/tests/unit/src/xlate/nft/nfgroup.c
+++ b/tests/unit/src/xlate/nft/nfgroup.c
@@ -68,3 +68,23 @@ Test(nfgroup, new_from_stream)
         assert_non_null(gp);
     }
 }
+
+Test(nfgroup, helpers)
+{
+    expect_assert_failure(bf_nfgroup_messages(NULL));
+    expect_assert_failure(bf_nfgroup_size(NULL));
+    expect_assert_failure(bf_nfgroup_is_empty(NULL));
+
+    for (int i = 0; i < 10; ++i) {
+        size_t len;
+        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp =
+            bf_test_get_nfgroup(i, &len);
+
+        assert_int_equal(bf_nfgroup_is_empty(gp), i == 0);
+
+        const bf_list *msgs = bf_nfgroup_messages(gp);
+        assert_non_null(msgs);
+        assert_int_equal(bf_list_size(msgs), i);
+        assert_int_equal(bf_nfgroup_size(gp), len);
+    }
+}


### PR DESCRIPTION
Introduce `bf_nfgroup` to abstract Netlink multipart messages. This will be used to return the list of tables/chains/rules/... from `bpfilter` to `nftables`. If completes the `bf_nfmsg` abstraction.