### PR TITLE
Fix documentation generation by installing `libnl3-devel`

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,6 +37,7 @@ jobs:
             lcov \
             libasan \
             libbpf-devel \
+            libnl3-devel \
             libubsan \
             python3-breathe \
             python3-furo \


### PR DESCRIPTION
Documentation generation [failed due to a missing dependency](https://github.com/facebook/bpfilter/actions/runs/8008621318/job/21875440115). This commit aims to install that missing dependency for the failing workflow.