### PR TITLE
xlate: nft: `bf_nfgroup` automatically set `NLM_F_MULTI` flag on multipart messages

### DIFF
--- a/src/xlate/nft/nfgroup.h
+++ b/src/xlate/nft/nfgroup.h
@@ -126,6 +126,14 @@ int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
  * All the Netfilter Netlink messages contained in the group will written
  * contiguously in the payload of a single @c bf_response .
  *
+ * If only one message is present in the group, the response will contain only
+ * the message payload. If more than one message is present, the response will
+ * contain a multipart message, with the @c NLM_F_MULTI flag set on all the
+ * messages and a final @c NLMSG_DONE message.
+ *
+ * If the group is empty, the reponse will contain a single @c NLMSG_DONE
+ * message.
+ *
  * @param group Netlink messages group to convert. Can't be NULL.
  * @param resp Pointer to the new response. Can't be NULL. A new response will
  * be allocated by this function and the caller will be responsible for freeing

--- a/src/xlate/nft/nfmsg.h
+++ b/src/xlate/nft/nfmsg.h
@@ -85,6 +85,14 @@ extern const bf_nfpolicy *bf_nf_verdict_policy;
 int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr);
 
 /**
+ * Create a new Netfilter Netlink @c NLMSG_DONE message.
+ *
+ * @param msg The new message to allocate and initialise. Can't be NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_nfmsg_new_done(struct bf_nfmsg **msg);
+
+/**
  * Create a new Netfilter Netlink message from an existing Netlink message.
  *
  * The provided @p nlmsghdr must be a valid Netlink message targeted to the

--- a/tests/unit/src/xlate/nft/nfgroup.c
+++ b/tests/unit/src/xlate/nft/nfgroup.c
@@ -121,6 +121,7 @@ Test(nfgroup, add_new_message)
 
 Test(nfgroup, to_response)
 {
+    size_t done_msg_len = sizeof(struct nlmsghdr) + sizeof(struct nfgenmsg);
     expect_assert_failure(bf_nfgroup_to_response(NULL, NOT_NULL));
     expect_assert_failure(bf_nfgroup_to_response(NOT_NULL, NULL));
 
@@ -134,7 +135,7 @@ Test(nfgroup, to_response)
         assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
         assert_non_null(res);
         assert_int_equal(res->type, BF_RES_SUCCESS);
-        assert_int_equal(res->data_len, 0);
+        assert_int_equal(res->data_len, done_msg_len);
     }
 
     {
@@ -148,6 +149,11 @@ Test(nfgroup, to_response)
         assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
         assert_non_null(res);
         assert_int_equal(res->type, BF_RES_SUCCESS);
-        assert_int_equal(res->data_len, len);
+        assert_int_equal(res->data_len, len + done_msg_len);
+
+        struct nlmsghdr *last =
+            (struct nlmsghdr *)(res->data + res->data_len - done_msg_len);
+
+        assert_int_equal(last->nlmsg_type, NLMSG_DONE);
     }
 }

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -75,6 +75,50 @@ Test(nfmsg, new_and_free)
     }
 }
 
+Test(nfmsg, new_done)
+{
+    expect_assert_failure(bf_nfmsg_new_done(NULL));
+
+    {
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_equal(0, bf_nfmsg_new_done(&msg));
+        assert_non_null(msg);
+    }
+
+    {
+        // calloc failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+    }
+
+    {
+        // nlmsg_put failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_alloc, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+    }
+
+    {
+        // nlmsg_put failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_put, NULL);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+    }
+
+    {
+        // nlmsg_append failure
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_append, -1);
+        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+
+        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+    }
+}
+
 Test(nfmsg, new_from_nlmsghdr)
 {
     expect_assert_failure(bf_nfmsg_new_from_nlmsghdr(NULL, NOT_NULL));


### PR DESCRIPTION
When a group of Netfilter Netlink messages is converted to a response, the response will contain a multipart message if the group contains more than one message. The NLM_F_MULTI flag will be set on all the messages and a final NLMSG_DONE message will be appended to the response.