### PR TITLE
Add boilerplate for `nft` front-end for `nftables` support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/helpers.h
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.h ${CMAKE_SOURCE_DIR}/src/xlate/ipt/dump.c
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/ipt.c
+    ${CMAKE_SOURCE_DIR}/src/xlate/nft/nft.c
     ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfgroup.h ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfgroup.c
     ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.h ${CMAKE_SOURCE_DIR}/src/xlate/nft/nfmsg.c
 )
@@ -104,6 +105,7 @@ set(bpfilter_library_srcs
     ${CMAKE_SOURCE_DIR}/lib/include/bpfilter/bpfilter.h
     ${CMAKE_SOURCE_DIR}/lib/src/generic.c
     ${CMAKE_SOURCE_DIR}/lib/src/ipt.c
+    ${CMAKE_SOURCE_DIR}/lib/src/nft.c
 )
 
 set(bpfilter_cflags

--- a/lib/include/bpfilter/bpfilter.h
+++ b/lib/include/bpfilter/bpfilter.h
@@ -7,11 +7,13 @@
 
 #include <bpfilter/shared/request.h>
 #include <bpfilter/shared/response.h>
+#include <stddef.h>
 
 struct ipt_getinfo;
 struct ipt_get_entries;
 struct ipt_replace;
 struct xt_counters_info;
+struct nlmsghdr;
 
 /**
  * @brief Send a request to the daemon and receive the response.
@@ -60,3 +62,34 @@ int bf_ipt_get_info(struct ipt_getinfo *info);
  * @return 0 on success, negative errno value on error.
  */
 int bf_ipt_get_entries(struct ipt_get_entries *entries);
+
+/**
+ * @brief Send nftable's Netlink request to the bpfilter daemon but do not
+ * expect a response.
+ *
+ * @param data Netlink data to send to the daemon. Can't be NULL.
+ * @param len Length of the request. Can't be 0.
+ * @return 0 on success, or negative errno value on error. Returns an error if
+ * @p data is NULL or @p len is 0.
+ */
+int bf_nft_send(const void *data, size_t len);
+
+/**
+ * @brief Send nftable's Netlink request to the bpfilter daemon and write the
+ * response back.
+ *
+ * @p res and @p res_len won't be modified unless the call is successful.
+ *
+ * @param req Netlink request to send to the daemon. The caller retain ownership
+ * of the request. Can't be NULL.
+ * @param req_len Length of the request. Can't be 0.
+ * @param res Buffer to store the response. Can't be NULL. Must be allocated by
+ * the caller.
+ * @param res_len Size of the response buffer. If the call is successful, @p
+ * res_len will be updated to the length of the response. If the data received
+ * from the daemon is larger than the buffer, the function will return
+ * -EMSGSIZE and @p res_len will be updated to the size of the response.
+ * @return 0 on success, or negative errno value on error.
+ */
+int bf_nft_sendrecv(const struct nlmsghdr *req, size_t req_len,
+                    struct nlmsghdr *res, size_t *res_len);

--- a/lib/src/nft.c
+++ b/lib/src/nft.c
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/netlink.h>
+
+#include <errno.h>
+#include <stdio.h>
+
+#include "bpfilter/bpfilter.h"
+#include "shared/front.h"
+#include "shared/request.h"
+#include "shared/response.h"
+
+int bf_nft_send(const void *data, size_t len)
+{
+    _cleanup_bf_request_ struct bf_request *request = NULL;
+    _cleanup_bf_response_ struct bf_response *response = NULL;
+    int r;
+
+    if (!data || !len)
+        return -EINVAL;
+
+    r = bf_request_new(&request, data, len);
+    if (r < 0)
+        return r;
+
+    request->front = BF_FRONT_NFT;
+
+    r = bf_send(request, &response);
+    if (r < 0)
+        return r;
+
+    return response->type == BF_RES_FAILURE ? response->error : 0;
+}
+
+int bf_nft_sendrecv(const struct nlmsghdr *req, size_t req_len,
+                    struct nlmsghdr *res, size_t *res_len)
+{
+    _cleanup_bf_request_ struct bf_request *request = NULL;
+    _cleanup_bf_response_ struct bf_response *response = NULL;
+    int r;
+
+    if (!req || !req_len || !res || !res_len)
+        return -EINVAL;
+
+    if (req_len != req->nlmsg_len)
+        return -EINVAL;
+
+    r = bf_request_new(&request, req, req_len);
+    if (r < 0)
+        return r;
+
+    request->front = BF_FRONT_NFT;
+
+    r = bf_send(request, &response);
+    if (r < 0)
+        return r;
+
+    if (response->type == BF_RES_FAILURE)
+        return response->error;
+
+    // The response should be a netlink message
+    if (response->data_len < NLMSG_HDRLEN)
+        return -EMSGSIZE;
+
+    if (((struct nlmsghdr *)response->data)->nlmsg_len != response->data_len)
+        return -EMSGSIZE;
+
+    if (response->data_len > *res_len) {
+        *res_len = response->data_len;
+        return -EMSGSIZE;
+    }
+
+    memcpy(res, response->data, response->data_len);
+    *res_len = response->data_len;
+
+    return 0;
+}

--- a/shared/include/bpfilter/shared/front.h
+++ b/shared/include/bpfilter/shared/front.h
@@ -8,6 +8,7 @@
 enum bf_front
 {
     BF_FRONT_IPT,
+    BF_FRONT_NFT,
     _BF_FRONT_MAX,
 };
 

--- a/shared/src/front.c
+++ b/shared/src/front.c
@@ -13,6 +13,7 @@ const char *bf_front_to_str(enum bf_front front)
 
     static const char * const names[] = {
         [BF_FRONT_IPT] = "BF_FRONT_IPT",
+        [BF_FRONT_NFT] = "BF_FRONT_NFT",
     };
 
     return names[front];

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -10,6 +10,7 @@
 const char *bf_hook_to_str(enum bf_hook hook)
 {
     static const char *hooks_str[] = {
+        [BF_HOOK_NFT_INGRESS] = "BF_HOOK_NFT_INGRESS",
         [BF_HOOK_TC_INGRESS] = "BF_HOOK_TC_INGRESS",
         [BF_HOOK_IPT_PRE_ROUTING] = "BF_HOOK_IPT_PRE_ROUTING",
         [BF_HOOK_IPT_LOCAL_IN] = "BF_HOOK_IPT_LOCAL_IN",
@@ -29,6 +30,7 @@ const char *bf_hook_to_str(enum bf_hook hook)
 unsigned int bf_hook_to_bpf_prog_type(enum bf_hook hook)
 {
     static const unsigned int prog_type[] = {
+        [BF_HOOK_NFT_INGRESS] = BPF_PROG_TYPE_XDP,
         [BF_HOOK_TC_INGRESS] = BPF_PROG_TYPE_SCHED_CLS,
         [BF_HOOK_IPT_PRE_ROUTING] = BPF_PROG_TYPE_NETFILTER,
         [BF_HOOK_IPT_LOCAL_IN] = BPF_PROG_TYPE_NETFILTER,
@@ -48,6 +50,7 @@ unsigned int bf_hook_to_bpf_prog_type(enum bf_hook hook)
 enum bf_flavor bf_hook_to_flavor(enum bf_hook hook)
 {
     static const enum bf_flavor flavors[] = {
+        [BF_HOOK_NFT_INGRESS] = BF_FLAVOR_XDP,
         [BF_HOOK_TC_INGRESS] = BF_FLAVOR_TC,
         [BF_HOOK_IPT_PRE_ROUTING] = BF_FLAVOR_NF,
         [BF_HOOK_IPT_LOCAL_IN] = BF_FLAVOR_NF,
@@ -67,6 +70,7 @@ enum bf_flavor bf_hook_to_flavor(enum bf_hook hook)
 enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook)
 {
     static const enum bpf_attach_type hooks[] = {
+        [BF_HOOK_NFT_INGRESS] = 0,
         [BF_HOOK_TC_INGRESS] = 0,
         [BF_HOOK_IPT_PRE_ROUTING] = 0,
         [BF_HOOK_IPT_LOCAL_IN] = BPF_NETFILTER,

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -18,6 +18,7 @@
 
 enum bf_hook
 {
+    BF_HOOK_NFT_INGRESS,
     BF_HOOK_TC_INGRESS,
     BF_HOOK_IPT_PRE_ROUTING,
     BF_HOOK_IPT_LOCAL_IN,

--- a/src/opts.c
+++ b/src/opts.c
@@ -45,6 +45,7 @@ static struct argp_option options[] = {
      "Size of the BPF log buffer as a power of 2 (only used when --verbose is used). Default: 16.",
      0},
     {"no-iptables", 0x01, 0, 0, "Disable iptables support", 0},
+    {"no-nftables", 0x02, 0, 0, "Disable nftables support", 0},
     {"verbose", 'v', 0, 0, "Print debug logs", 0},
     {0},
 };
@@ -70,6 +71,10 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
     case 0x01:
         bf_info("disabling iptables support");
         args->fronts &= ~(1 << BF_FRONT_IPT);
+        break;
+    case 0x02:
+        bf_info("disabling nftables support");
+        args->fronts &= ~(1 << BF_FRONT_NFT);
         break;
     case 'v':
         args->verbose = true;

--- a/src/xlate/front.c
+++ b/src/xlate/front.c
@@ -8,6 +8,7 @@
 #include "shared/helper.h"
 
 extern const struct bf_front_ops ipt_front;
+extern const struct bf_front_ops nft_front;
 
 const struct bf_front_ops *bf_front_ops_get(enum bf_front front)
 {
@@ -15,6 +16,7 @@ const struct bf_front_ops *bf_front_ops_get(enum bf_front front)
 
     static const struct bf_front_ops *fronts[] = {
         [BF_FRONT_IPT] = &ipt_front,
+        [BF_FRONT_NFT] = &nft_front,
     };
 
     // We need to have an entry for each value in `bf_front` enumeration.

--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "shared/request.h"
+#include "shared/response.h"
+#include "xlate/front.h"
+
+struct bf_marsh;
+
+static int _bf_nft_setup(void);
+static int _bf_nft_teardown(void);
+static int _bf_nft_request_handler(struct bf_request *request,
+                                   struct bf_response **response);
+static int _bf_nft_marsh(struct bf_marsh **marsh);
+static int _bf_nft_unmarsh(struct bf_marsh *marsh);
+
+const struct bf_front_ops nft_front = {
+    .setup = _bf_nft_setup,
+    .teardown = _bf_nft_teardown,
+    .request_handler = _bf_nft_request_handler,
+    .marsh = _bf_nft_marsh,
+    .unmarsh = _bf_nft_unmarsh,
+};
+
+static int _bf_nft_setup(void)
+{
+    return 0;
+}
+
+static int _bf_nft_teardown(void)
+{
+    return 0;
+}
+
+static int _bf_nft_marsh(struct bf_marsh **marsh)
+{
+    UNUSED(marsh);
+
+    return 0;
+}
+
+static int _bf_nft_unmarsh(struct bf_marsh *marsh)
+{
+    UNUSED(marsh);
+
+    return 0;
+}
+
+static int _bf_nft_request_handler(struct bf_request *request,
+                                   struct bf_response **response)
+{
+    bf_assert(request);
+    bf_assert(response);
+
+    return bf_response_new_failure(response, -ENOTSUP);
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -92,8 +92,10 @@ set(bf_test_srcs
     src/generator/nf.c
     src/generator/print.c
     src/generator/program.c
+    src/xlate/nft/nft.c
     src/xlate/nft/nfmsg.c
     src/xlate/nft/nfgroup.c
+    shared/src/front.c
 )
 
 add_executable(tests_unit
@@ -140,6 +142,7 @@ set_source_files_properties(${bf_coverage_srcs}
 
 target_include_directories(tests_unit
     PRIVATE
+        ${CMAKE_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/shared/include

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -79,6 +79,7 @@ endfunction()
 enable_testing()
 
 set(bf_test_srcs
+    src/opts.c
     src/core/btf.c
     src/core/context.c
     src/core/flavor.c

--- a/tests/unit/shared/src/front.c
+++ b/tests/unit/shared/src/front.c
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "shared/src/front.c"
+
+#include "harness/cmocka.h"
+#include "harness/mock.h"
+
+Test(shared_front, front_to_str_assert_failure)
+{
+    expect_assert_failure(bf_front_to_str(-1));
+    expect_assert_failure(bf_front_to_str(_BF_FRONT_MAX));
+}
+
+Test(hook, can_get_str_from_front)
+{
+    for (int i = 0; i < _BF_FRONT_MAX; ++i)
+        assert_non_null(bf_front_to_str(i));
+}

--- a/tests/unit/src/opts.c
+++ b/tests/unit/src/opts.c
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "src/opts.c"
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+Test(opts, no_nftables)
+{
+    char *opt0[] = {"tests_unit", "--no-nftables"};
+
+    _opts.fronts = 0xffff;
+    assert_int_equal(0, bf_opts_init(ARRAY_SIZE(opt0), opt0));
+    assert(0 == (_opts.fronts & (1 << BF_FRONT_NFT)));
+}

--- a/tests/unit/src/xlate/nft/nft.c
+++ b/tests/unit/src/xlate/nft/nft.c
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "xlate/nft/nft.c"
+
+#include "harness/cmocka.h"
+#include "harness/helper.h"
+#include "harness/mock.h"
+
+Test(nft, check_front_ops)
+{
+    assert_ptr_equal(&nft_front, bf_front_ops_get(BF_FRONT_NFT));
+}


### PR DESCRIPTION
This change is part of a bigger work in progress to support `nftables` with `bpfilter`.

This change introduce the new `nft` front-end, which only supports `nftables`'s `INGRESS` hook. While `libbpfilter` has 2 new functions (`bf_nft_send()` and `bf_nft_sendrecv()`), all the requests will be answered with `-ENOTSUP` from `bpfilter`.

All `--no-nftables` command line option to disable `nftables` support.