### PR TITLE
Fix strings map pinning and detail support Ubuntu version.

### DIFF
--- a/doc/sources.rst
+++ b/doc/sources.rst
@@ -3,7 +3,7 @@ Build from sources
 
 This document describes the process to build ``bpfilter`` from sources. While `bpfilter` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon.
 
-``bpfilter`` development is mostly done using Fedora (38 and 39), but Ubuntu is also officially supported.
+``bpfilter`` development is mostly done using Fedora (38 and 39), but Ubuntu (23.10+) is also officially supported. Other distributions may work as long as Linux 6.4+ is available, but they are not officially supported at the moment.
 
 Required dependencies on Fedora and Ubuntu:
 

--- a/src/generator/print.c
+++ b/src/generator/print.c
@@ -31,7 +31,7 @@ static struct
     make_print_str(BF_PRINT_NO_IPV4, "L3 header is not IPv4"),
 };
 
-static int _bf_fd = 1;
+static int _bf_fd;
 static const char *_bf_print_strs_path = "/sys/fs/bpf/bf_print_strs";
 
 size_t _bf_compute_offsets(void)
@@ -79,7 +79,7 @@ int bf_print_setup(void)
         return bf_err_code(r, "failed to freeze strings map");
 
     if (!bf_opts_transient()) {
-        r = bf_bpf_obj_pin(_bf_print_strs_path, _bf_fd);
+        r = bf_bpf_obj_pin(_bf_print_strs_path, fd);
         if (r < 0)
             return bf_err_code(r, "failed to pin strings map");
     }


### PR DESCRIPTION
Related to #11, update the documentation to clarify that Ubuntu 23.10+ is required.