### PR TITLE
 xlate: nft: fix counter support when translating nft bytecode 

### DIFF
--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -458,8 +458,11 @@ static int _bf_nft_newrule_cb(const struct bf_nfmsg *req)
             return bf_err_code(-EINVAL, "expecting cmp, got invalid attribute");
     }
 
-    if (!bf_streq(bf_nfattr_data(expr_attrs[NFTA_EXPR_NAME]), "immediate"))
-        return bf_err_code(r, "expected cmp attribute, got something else");
+    if (!bf_streq(bf_nfattr_data(expr_attrs[NFTA_EXPR_NAME]), "immediate")) {
+        return bf_err_code(
+            r, "expected immediate attribute, but have '%s' instead",
+            bf_nfattr_get_str(expr_attrs[NFTA_EXPR_NAME]));
+    }
 
     r = bf_nfattr_parse(expr_attrs[NFTA_EXPR_DATA], immediate_attrs,
                         __NFTA_IMMEDIATE_MAX, bf_nf_immediate_policy);

--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -456,6 +456,13 @@ static int _bf_nft_newrule_cb(const struct bf_nfmsg *req)
         attr = bf_nfattr_next(attr, &rem);
         if (!bf_nfattr_is_ok(attr, rem))
             return bf_err_code(-EINVAL, "expecting cmp, got invalid attribute");
+
+        r = bf_nfattr_parse(attr, expr_attrs, __NFTA_EXPR_MAX,
+                            bf_nf_expr_policy);
+        if (r < 0) {
+            return bf_err_code(
+                r, "failed to parse NFTA_RULE_EXPRESSIONS attributes");
+        }
     }
 
     if (!bf_streq(bf_nfattr_data(expr_attrs[NFTA_EXPR_NAME]), "immediate")) {


### PR DESCRIPTION
When a counter instruction is discovered within the nft bytecode, it is proceed and the current attribute pointer is updated to the next attribute. However, the next attribute's content is not parsed.

This patch fixes this issue by parsing the next attribute's content when a counter instruction is discovered.