### PR TITLE
fix warning: ‘child’ may be used uninitialized

### DIFF
--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -89,7 +89,7 @@ static int _bf_nft_unmarsh(struct bf_marsh *marsh)
     bf_assert(marsh);
 
     _cleanup_bf_list_ bf_list *list = NULL;
-    struct bf_marsh *child;
+    struct bf_marsh *child = NULL;
     int r;
 
     r = bf_list_new(


### PR DESCRIPTION
The warning:
```
In file included from /home/ikruglov/src/bpfilter/src/xlate/nft/nft.c:14:
In function ‘bf_marsh_next_child’,
    inlined from ‘_bf_nft_unmarsh’ at /home/ikruglov/src/bpfilter/src/xlate/nft/nft.c:100:21:
/home/ikruglov/src/bpfilter/src/core/marsh.h:114:37: warning: ‘child’ may be used uninitialized [-Wmaybe-uninitialized]
  114 |         child ? (struct bf_marsh *)(child->data + child->data_len) :
      |                                     ^~~~~
/home/ikruglov/src/bpfilter/src/xlate/nft/nft.c: In function ‘_bf_nft_unmarsh’:
/home/ikruglov/src/bpfilter/src/xlate/nft/nft.c:92:22: note: ‘child’ was declared here
   92 |     struct bf_marsh *child;
      |                      ^~~~~
```