### PR TITLE
core: prevent crash if data.bin is smaller than bf_marsh structure

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -134,9 +134,12 @@ static int _bf_load(const char *path)
     if (r < 0)
         return r;
 
+    if (len < sizeof(struct bf_marsh))
+        return bf_err_code(EIO, "marshalled data is invalid");
+
     if (bf_marsh_size(marsh) != len) {
         return bf_err_code(
-            EINVAL, "conflicting marsheled data size: got %zu, expected %zu",
+            EINVAL, "conflicting marshalled data size: got %zu, expected %zu",
             len, bf_marsh_size(marsh));
     }
 


### PR DESCRIPTION
If `data.bin` (`bpfilter`'s serialized context) is smaller than the size of a `bf_marsh` structure, the daemon will crash as it tries to access `marsh->data_len`.

To prevent this, return an error if less than `sizeof(bf_marsh)` bytes are read.