### PR TITLE
Add debug mode

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -10,6 +10,7 @@ The bpfilter daemon must be run as root in order to write to `/run` and manipula
 - ``--no-iptables``: disable ``iptables`` support. If ``iptables`` is enabled, ``bpfilter`` will create pass-through programs to represent the ``INPUT``, ``OUTPUT``, and ``FORWARD`` hook used by ``iptables``, with ``ACCEPT`` as the default policy. If ``iptables`` support is disabled, no BPF program will be generated for ``iptables`` and ``bpfilter`` will answer to every request coming from ``iptables`` with a failure response.
 - ``-b``, ``--buffer-len=BUF_LEN_POW``: size of the ``BPF_PROG_LOAD`` buffer as a power of 2. Only available if ``--verbose`` is used. ``BPF_PROG_LOAD`` system call can be provided a buffer for the BPF verifier to provide details in case the program can't be loaded. The required size for the buffer being hardly predictable, this option allows for the user to control it. The final buffer will have a size of ``1 << BUF_LEN_POWER``.
 - ``-v``, ``--verbose``: print more detailed log messages.
+- ``--debug``: generate the BPF programs in debug mode: if a call to a kfunc or a BPF helper fails, a log message will be printed to ``/sys/kernel/debug/tracing/trace_pipe``.
 - ``--usage``: print a short usage message.
 - ``-?``, ``--help``: print the help message
 

--- a/src/generator/printer.c
+++ b/src/generator/printer.c
@@ -226,6 +226,10 @@ int bf_printer_new_from_marsh(struct bf_printer **printer,
         TAKE_PTR(msg);
     }
 
+    r = bf_bpf_obj_get(_bf_printer_pin_path, &_printer->fd);
+    if (r < 0)
+        return bf_err_code(r, "failed to get printer map fd");
+
     *printer = TAKE_PTR(_printer);
 
     return 0;

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -7,6 +7,8 @@
 
 #include <stddef.h>
 
+#include "core/context.h"
+
 /**
  * @file printer.h
  *

--- a/src/opts.c
+++ b/src/opts.c
@@ -30,11 +30,17 @@ static struct bf_options
 
     /** If true, print debug log messages (bf_debug). */
     bool verbose;
+
+    /** If true, the BPF programs including log messages to be printed when
+     * a BPF helper or kfunc fails.
+     */
+    bool debug;
 } _opts = {
     .transient = false,
     .bpf_log_buf_len_pow = 16,
     .fronts = 0xffff,
     .verbose = false,
+    .debug = false,
 };
 
 static struct argp_option options[] = {
@@ -47,6 +53,7 @@ static struct argp_option options[] = {
     {"no-iptables", 0x01, 0, 0, "Disable iptables support", 0},
     {"no-nftables", 0x02, 0, 0, "Disable nftables support", 0},
     {"verbose", 'v', 0, 0, "Print debug logs", 0},
+    {"debug", 0x03, 0, 0, "Generate BPF programs with debug logs", 0},
     {0},
 };
 
@@ -78,6 +85,10 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
         break;
     case 'v':
         args->verbose = true;
+        break;
+    case 0x03:
+        bf_info("generating BPF programs with debug logs");
+        args->debug = true;
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -111,4 +122,9 @@ bool bf_opts_is_front_enabled(enum bf_front front)
 bool bf_opts_verbose(void)
 {
     return _opts.verbose;
+}
+
+bool bf_opts_debug(void)
+{
+    return _opts.debug;
 }

--- a/src/opts.h
+++ b/src/opts.h
@@ -14,3 +14,4 @@ bool bf_opts_transient(void);
 unsigned int bf_opts_bpf_log_buf_len_pow(void);
 bool bf_opts_is_front_enabled(enum bf_front front);
 bool bf_opts_verbose(void);
+bool bf_opts_debug(void);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -178,6 +178,7 @@ bf_test_mock(tests_unit
         nlmsg_convert
         nlmsg_put
         nlmsg_append
+        bf_bpf_obj_get
 )
 
 add_custom_target(test

--- a/tests/unit/harness/mock.c
+++ b/tests/unit/harness/mock.c
@@ -131,3 +131,11 @@ bf_mock_define(int, nlmsg_append,
     errno = -EINVAL;
     return mock_type(int);
 }
+
+bf_mock_define(int, bf_bpf_obj_get, (const char *path, int *fd))
+{
+    if (!bf_mock_bf_bpf_obj_get_is_enabled())
+        return bf_mock_real(bf_bpf_obj_get)(path, fd);
+
+    return mock_type(int);
+}

--- a/tests/unit/harness/mock.h
+++ b/tests/unit/harness/mock.h
@@ -52,3 +52,4 @@ bf_mock_declare(struct nlmsghdr *, nlmsg_put,
                  int payload, int flags));
 bf_mock_declare(int, nlmsg_append,
                 (struct nl_msg * n, void *data, size_t len, int pad));
+bf_mock_declare(int, bf_bpf_obj_get, (const char *path, int *fd));

--- a/tests/unit/src/generator/printer.c
+++ b/tests/unit/src/generator/printer.c
@@ -119,6 +119,7 @@ Test(printer, printer_marsh_unmarsh)
     expect_assert_failure(bf_printer_add_msg(NOT_NULL, NULL));
     expect_assert_failure(bf_printer_add_msg(NULL, NULL));
 
+    _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, 10);
     _cleanup_bf_printer_ struct bf_printer *printer0 = NULL;
     _cleanup_bf_printer_ struct bf_printer *printer1 = NULL;
     const struct bf_printer_msg *msg0;
@@ -146,4 +147,21 @@ Test(printer, printer_marsh_unmarsh)
 
     assert_int_equal(_bf_printer_total_size(printer0),
                      _bf_printer_total_size(printer1));
+}
+
+Test(printer, printer_marsh_unmarsh_failed_map_fd_open)
+{
+    _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, -1);
+    _cleanup_bf_printer_ struct bf_printer *printer0 = NULL;
+    _cleanup_bf_printer_ struct bf_printer *printer1 = NULL;
+    const struct bf_printer_msg *msg0;
+    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+
+    assert_int_equal(bf_printer_new(&printer0), 0);
+    msg0 = bf_printer_add_msg(printer0, "hello");
+    assert_ptr_not_equal(msg0, NULL);
+
+    // Serialise and deserialise the printer
+    assert_int_equal(bf_printer_marsh(printer0, &marsh), 0);
+    assert_int_not_equal(bf_printer_new_from_marsh(&printer1, marsh), 0);
 }


### PR DESCRIPTION
Add `--debug` to generate the BPF programs in debug mode: failed calls to kfunc or BPF helpers will trigger a call to `bpf_printk()` with a debug message. 

Debug mode is disabled by default to avoid overhead.