### PR TITLE
tests: add `--group` command line option to filter test groups

### DIFF
--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -167,4 +167,5 @@ const struct bf_printer_msg *bf_printer_add_msg(struct bf_printer *printer,
  * @param printer Printer context. Can't be NULL.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_printer_publish(struct bf_printer *prinbter);
+int bf_printer_publish(struct bf_printer *printer);
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -105,8 +105,10 @@ add_executable(tests_unit
     harness/main.c
     harness/cmocka.h
     harness/elf.c harness/elf.h
+    harness/filter.c harness/filter.h
     harness/helper.c harness/helper.h
     harness/mock.c harness/mock.h
+    harness/opts.c harness/opts.h
     harness/test.c harness/test.h
 
     ${bf_test_srcs}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -182,7 +182,7 @@ bf_test_mock(tests_unit
 )
 
 add_custom_target(test
-    COMMAND $<TARGET_FILE:tests_unit> --verbose --xml=test-report.xml
+    COMMAND $<TARGET_FILE:tests_unit>
     DEPENDS tests_unit
     COMMENT "Running unit tests"
 )

--- a/tests/unit/harness/filter.c
+++ b/tests/unit/harness/filter.c
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "harness/filter.h"
+
+#include <regex.h>
+#include <stdio.h>
+
+#include "shared/helper.h"
+
+static void _bf_test_filter_regex_free(regex_t **regex)
+{
+    bf_assert(regex);
+
+    if (!*regex)
+        return;
+
+    regfree(*regex);
+    free(*regex);
+    *regex = NULL;
+}
+
+int bf_test_filter_new(struct bf_test_filter **filter)
+{
+    bf_assert(filter);
+
+    *filter = malloc(sizeof(struct bf_test_filter));
+    if (!*filter)
+        return -ENOMEM;
+
+    bf_list_init(&(*filter)->patterns,
+                 (bf_list_ops[]) {
+                     {.free = (bf_list_ops_free)_bf_test_filter_regex_free}});
+
+    return 0;
+}
+
+void bf_test_filter_free(struct bf_test_filter **filter)
+{
+    bf_assert(filter);
+
+    if (!*filter)
+        return;
+
+    bf_list_clean(&(*filter)->patterns);
+    free(*filter);
+    *filter = NULL;
+}
+
+int bf_test_filter_add_pattern(struct bf_test_filter *filter,
+                               const char *pattern)
+{
+    regex_t *regex;
+    char errbuf[128];
+    int r;
+
+    regex = malloc(sizeof(*regex));
+    if (!regex)
+        return -ENOMEM;
+
+    r = regcomp(regex, pattern, 0);
+    if (r) {
+        regerror(r, regex, errbuf, sizeof(errbuf));
+        fprintf(stderr, "failed to compile regex '%s': %s\n", pattern, errbuf);
+        free(regex);
+        return -EINVAL;
+    }
+
+    r = bf_list_add_tail(&filter->patterns, regex);
+    if (r) {
+        regfree(regex);
+        free(regex);
+        return r;
+    }
+
+    return 0;
+}
+
+bool bf_test_filter_matches(struct bf_test_filter *filter, const char *str)
+{
+    char errbuf[128];
+    int r;
+
+    bf_assert(filter);
+
+    // If the patterns list is empty: everything is allowed
+    if (bf_list_is_empty(&filter->patterns))
+        return true;
+
+    bf_list_foreach (&filter->patterns, pattern_node) {
+        regex_t *regex = bf_list_node_get_data(pattern_node);
+
+        r = regexec(regex, str, 0, NULL, 0);
+        if (r != REG_NOMATCH) {
+            // If we match, return true.
+            // If an error is returned (which is not REG_NOMATCH), log it and
+            // assume the pattern matched.
+            if (r) {
+                regerror(r, regex, errbuf, sizeof(errbuf));
+                fprintf(
+                    stderr,
+                    "failed to match '%s' against a regex, assuming pattern is allowed: %s\n",
+                    str, errbuf);
+            }
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/tests/unit/harness/filter.h
+++ b/tests/unit/harness/filter.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+
+#include "core/list.h"
+
+#define _cleanup_bf_test_filter_ __attribute__((cleanup(bf_test_filter_free)))
+
+struct bf_test_filter
+{
+    bf_list patterns;
+};
+
+int bf_test_filter_new(struct bf_test_filter **filter);
+void bf_test_filter_free(struct bf_test_filter **filter);
+int bf_test_filter_add_pattern(struct bf_test_filter *filter,
+                               const char *pattern);
+bool bf_test_filter_matches(struct bf_test_filter *filter, const char *str);

--- a/tests/unit/harness/main.c
+++ b/tests/unit/harness/main.c
@@ -50,16 +50,14 @@ int main(void)
     bf_list_foreach (&suite->groups, group_node) {
         bf_test_group *group = bf_list_node_get_data(group_node);
 
+        fprintf(stderr, "[STARTING TEST SUITE: %s]\n", group->name);
+
         r = _cmocka_run_group_tests(group->name, group->cmtests,
                                     bf_list_size(&group->tests), NULL, NULL);
-        if (r) {
+        if (r)
             failed = 1;
-            fprintf(stderr,
-                    "WARNING: unit tests group '%s' faileds: "
-                    "%s\n",
-                    group->name, strerror(-r));
-            continue;
-        }
+
+        fprintf(stderr, "[FINISHED TEST SUITE: %s]\n\n", group->name);
     }
 
     if (failed)

--- a/tests/unit/harness/opts.c
+++ b/tests/unit/harness/opts.c
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "harness/opts.h"
+
+#include <argp.h>
+
+#include "harness/filter.h"
+#include "shared/helper.h"
+
+static struct argp_option _bf_test_options[] = {
+    {"group", 'g', "REGEX", 0,
+     "Regex to filter the test groups to run. If unused, all the test groups are executed.",
+     0},
+    {0},
+};
+
+static error_t _bf_test_argp_cb(int key, char *arg, struct argp_state *state)
+{
+    struct bf_test_opts *opts = state->input;
+    int r;
+
+    switch (key) {
+    case 'g':
+        r = bf_test_filter_add_pattern(opts->group_filter, arg);
+        if (r)
+            return r;
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+int bf_test_opts_new(struct bf_test_opts **opts, int argc, char *argv[])
+{
+    _cleanup_bf_test_opts_ struct bf_test_opts *_opts = NULL;
+    struct argp argp = {
+        _bf_test_options, _bf_test_argp_cb, NULL, NULL, 0, NULL, NULL};
+    int r;
+
+    bf_assert(opts);
+    bf_assert(argv);
+
+    _opts = calloc(1, sizeof(*_opts));
+    if (!_opts)
+        return -ENOMEM;
+
+    r = bf_test_filter_new(&_opts->group_filter);
+    if (r)
+        return r;
+
+    r = argp_parse(&argp, argc, argv, 0, 0, _opts);
+    if (r)
+        return r;
+
+    *opts = TAKE_PTR(_opts);
+
+    return 0;
+}
+
+void bf_test_opts_free(struct bf_test_opts **opts)
+{
+    bf_assert(opts);
+
+    if (!*opts)
+        return;
+
+    bf_test_filter_free(&(*opts)->group_filter);
+
+    free(*opts);
+    *opts = NULL;
+}

--- a/tests/unit/harness/opts.h
+++ b/tests/unit/harness/opts.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#define _cleanup_bf_test_opts_ __attribute__((cleanup(bf_test_opts_free)))
+
+struct bf_test_filter;
+
+struct bf_test_opts
+{
+    struct bf_test_filter *group_filter;
+};
+
+int bf_test_opts_new(struct bf_test_opts **opts, int argc, char *argv[]);
+void bf_test_opts_free(struct bf_test_opts **opts);


### PR DESCRIPTION
Introduce `--group` (`-g`) command line option support to filter test groups to be run when executing the unit tests. A test group is usually a complete source file of tests.

This change allows for more targeted test execution: it provides a clearer output and faster tests run, leading to simpler development feedback loop.