### PR TITLE
core: introduce `bf_matcher` structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/core/list.h ${CMAKE_SOURCE_DIR}/src/core/list.c
     ${CMAKE_SOURCE_DIR}/src/core/logger.h ${CMAKE_SOURCE_DIR}/src/core/logger.c
     ${CMAKE_SOURCE_DIR}/src/core/match.h ${CMAKE_SOURCE_DIR}/src/core/match.c
+    ${CMAKE_SOURCE_DIR}/src/core/matcher.h ${CMAKE_SOURCE_DIR}/src/core/matcher.c
     ${CMAKE_SOURCE_DIR}/src/core/rule.h ${CMAKE_SOURCE_DIR}/src/core/rule.c
     ${CMAKE_SOURCE_DIR}/src/core/marsh.h ${CMAKE_SOURCE_DIR}/src/core/marsh.c
     ${CMAKE_SOURCE_DIR}/src/core/verdict.h ${CMAKE_SOURCE_DIR}/src/core/verdict.c

--- a/doc/developers/packets_processing.rst
+++ b/doc/developers/packets_processing.rst
@@ -1,0 +1,7 @@
+Packets processing
+==================
+
+Matchers
+--------
+
+.. doxygenfile:: matcher.h

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@
    :maxdepth: 2
    :caption: Developers
 
+   developers/packets_processing
    developers/generation
    developers/fronts/index
    reference

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "core/matcher.h"
+
+#include "core/marsh.h"
+#include "shared/helper.h"
+
+/**
+ * @brief Matcher definition.
+ *
+ * Matchers are criterias to match the packet against. A set of matcher defines
+ * what a rule should match on.
+ */
+struct bf_matcher
+{
+    /// Matcher type.
+    enum bf_matcher_type type;
+    /// Comparison operator.
+    enum bf_matcher_op op;
+    /// Total matcher size (including payload).
+    size_t len;
+    /// Payload to match the packet against (if any).
+    uint8_t payload[0];
+};
+
+int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
+                   enum bf_matcher_op op, const uint8_t *payload,
+                   size_t payload_len)
+{
+    _cleanup_bf_matcher_ struct bf_matcher *_matcher = NULL;
+
+    bf_assert(matcher);
+    bf_assert((payload && payload_len) || (!payload && !payload_len));
+
+    _matcher = malloc(sizeof(struct bf_matcher) + payload_len);
+    if (!_matcher)
+        return -ENOMEM;
+
+    _matcher->type = type;
+    _matcher->op = op;
+    _matcher->len = sizeof(struct bf_matcher) + payload_len;
+    bf_memcpy(_matcher->payload, payload, payload_len);
+
+    *matcher = TAKE_PTR(_matcher);
+
+    return 0;
+}
+
+int bf_matcher_new_from_marsh(struct bf_matcher **matcher,
+                              const struct bf_marsh *marsh)
+{
+    struct bf_marsh *child = NULL;
+    enum bf_matcher_type type;
+    enum bf_matcher_op op;
+    size_t payload_len;
+    const void *payload;
+    int r;
+
+    bf_assert(matcher);
+    bf_assert(marsh);
+
+    if (!(child = bf_marsh_next_child(marsh, child)))
+        return -EINVAL;
+    memcpy(&type, child->data, sizeof(type));
+
+    if (!(child = bf_marsh_next_child(marsh, child)))
+        return -EINVAL;
+    memcpy(&op, child->data, sizeof(op));
+
+    if (!(child = bf_marsh_next_child(marsh, child)))
+        return -EINVAL;
+    memcpy(&payload_len, child->data, sizeof(op));
+    payload_len -= sizeof(struct bf_matcher);
+
+    if (!(child = bf_marsh_next_child(marsh, child)))
+        return -EINVAL;
+    payload = child->data;
+
+    r = bf_matcher_new(matcher, type, op, payload, payload_len);
+    if (r)
+        return bf_err_code(r,
+                           "failed to restore bf_matcher from serialised data");
+
+    return 0;
+}
+
+void bf_matcher_free(struct bf_matcher **matcher)
+{
+    bf_assert(matcher);
+
+    if (!*matcher)
+        return;
+
+    free(*matcher);
+    *matcher = NULL;
+}
+
+int bf_matcher_marsh(const struct bf_matcher *matcher, struct bf_marsh **marsh)
+{
+    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    int r;
+
+    bf_assert(matcher);
+    bf_assert(marsh);
+
+    r = bf_marsh_new(&_marsh, NULL, 0);
+    if (r < 0)
+        return r;
+
+    r |= bf_marsh_add_child_raw(&_marsh, &matcher->type, sizeof(matcher->type));
+    r |= bf_marsh_add_child_raw(&_marsh, &matcher->op, sizeof(matcher->op));
+    r |= bf_marsh_add_child_raw(&_marsh, &matcher->len, sizeof(matcher->len));
+    r |= bf_marsh_add_child_raw(&_marsh, matcher->payload,
+                                matcher->len - sizeof(struct bf_matcher));
+    if (r)
+        return bf_err_code(r, "failed to serialise bf_matcher object");
+
+    *marsh = TAKE_PTR(_marsh);
+
+    return 0;
+}
+
+void bf_matcher_dump(const struct bf_matcher *matcher, prefix_t *prefix)
+{
+    prefix_t _prefix = {};
+    prefix = prefix ?: &_prefix;
+
+    bf_assert(matcher);
+    bf_assert(prefix);
+
+    DUMP(prefix, "struct bf_matcher at %p", matcher);
+
+    bf_dump_prefix_push(prefix);
+
+    DUMP(prefix, "type: %s", bf_matcher_type_to_str(matcher->type));
+    DUMP(prefix, "op: %s", bf_matcher_op_to_str(matcher->op));
+    DUMP(prefix, "len: %ld", matcher->len);
+    DUMP(bf_dump_prefix_last(prefix), "payload:");
+    bf_dump_prefix_push(prefix);
+    bf_dump_hex(prefix, matcher->payload,
+                matcher->len - sizeof(struct bf_matcher));
+    bf_dump_prefix_pop(prefix);
+
+    bf_dump_prefix_pop(prefix);
+}
+
+const char *bf_matcher_type_to_str(enum bf_matcher_type type)
+{
+    static const char *types_str[] = {
+        [BF_MATCHER_IP_SRC_ADDR] = "BF_MATCHER_IP_SRC_ADDR",
+    };
+
+    bf_assert(0 <= type && type < _BF_MATCHER_TYPE_MAX);
+    static_assert(ARRAY_SIZE(types_str) == _BF_MATCHER_TYPE_MAX,
+                  "missing entries in the types_str array");
+
+    return types_str[type];
+}
+
+const char *bf_matcher_op_to_str(enum bf_matcher_op op)
+{
+    static const char *ops_str[] = {
+        [BF_MATCHER_EQ] = "BF_MATCHER_EQ",
+    };
+
+    bf_assert(0 <= op && op < _BF_MATCHER_OP_MAX);
+    static_assert(ARRAY_SIZE(ops_str) == _BF_MATCHER_OP_MAX,
+                  "missing entries in the ops_str array");
+
+    return ops_str[op];
+}

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "core/dump.h"
+
+struct bf_matcher;
+struct bf_marsh;
+
+/// Automatically destroy @ref bf_matcher objects going out of the scope.
+#define _cleanup_bf_matcher_ __attribute__((__cleanup__(bf_matcher_free)))
+
+/**
+ * @brief Matcher type.
+ *
+ * The matcher type define which header/field of a packet is to be used to
+ * match against the payload.
+ */
+enum bf_matcher_type
+{
+    /// Matches IP source address.
+    BF_MATCHER_IP_SRC_ADDR,
+    _BF_MATCHER_TYPE_MAX,
+};
+
+/**
+ * @brief Matcher comparison operator.
+ *
+ * The matcher comparison operator defines the type of comparison to operator
+ * for a specific matcher.
+ */
+enum bf_matcher_op
+{
+    /// Test for equality.
+    BF_MATCHER_EQ,
+    _BF_MATCHER_OP_MAX,
+};
+
+/**
+ * @brief Allocate and initalise a new matcher.
+ *
+ * @param matcher Matcher object to allocate and initialise. Can't be NULL. On
+ *  success, contain a pointer to the matcher object, unchanged on error.
+ * @param type Matcher type.
+ * @param op Comparison operator.
+ * @param payload Payload of the matcher, its content and size depends on @ref
+ * type. Can be NULL but only if @ref payload_len is 0, in which case there is
+ * no payload.
+ * @param payload_len Length of the payload.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
+                   enum bf_matcher_op op, const uint8_t *payload,
+                   size_t payload_len);
+
+/**
+ * @brief Allocate a new matcher and initialise it from serialised data.
+ *
+ * @param matcher On success, points to the newly allocated and initialised
+ *  matcher. Can't be NULL.
+ * @param marsh Serialised data to use to initialise the matcher.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_matcher_new_from_marsh(struct bf_matcher **matcher,
+                              const struct bf_marsh *marsh);
+
+/**
+ * Deinitialise and deallocate a matcher.
+ *
+ * @param matcher Matcher. Can't be NULL.
+ */
+void bf_matcher_free(struct bf_matcher **matcher);
+
+/**
+ * @brief Serialise a matcher.
+ *
+ * @param matcher Matcher object to serialise. Can't be NULL.
+ * @param marsh On success, contains the serialised matcher. Can't be NULL.
+ */
+int bf_matcher_marsh(const struct bf_matcher *matcher, struct bf_marsh **marsh);
+
+/**
+ * @brief Dump a matcher.
+ *
+ * @param matcher Matcher to dump.
+ * @param prefix Prefix for each printed line.
+ */
+void bf_matcher_dump(const struct bf_matcher *matcher, prefix_t *prefix);
+
+/**
+ * @brief Convert a matcher type to a string.
+ *
+ * @param op The matcher type to convert. Must be a valid @ref bf_matcher_type
+ * @return String representation of the matcher type.
+ */
+const char *bf_matcher_type_to_str(enum bf_matcher_type type);
+
+/**
+ * @brief Convert a matcher operator to a string.
+ *
+ * @param op The matcher operator to convert. Must be a valid @ref bf_matcher_op
+ * @return String representation of the operator.
+ */
+const char *bf_matcher_op_to_str(enum bf_matcher_op op);

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -9,6 +9,24 @@
 
 #include "core/dump.h"
 
+/**
+ * @file matcher.h
+ *
+ * Matchers are criteria used to match a network packet against a specific
+ * rule. For example, a matcher could be used to match the destination IP
+ * field of an IPv4 packet to a specific IP address.
+ *
+ * Matchers are composed of:
+ * - A type, defining which data in the network packet to match the payload
+ *   against. In the example about, the type would be related to IPv4
+ *   destination address field.
+ * - An operator, to know how to compare the data in the packet defined by
+ *   the @ref type to the payload contained in the matcher. For example, we
+ *   want the matcher to match when the IPv4 destination address is equal to
+ *   the IP address in the payload.
+ * - A payload, which is compared to the similar value in the network packet.
+ */
+
 struct bf_matcher;
 struct bf_marsh;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -87,6 +87,7 @@ set(bf_test_srcs
     src/core/hook.c
     src/core/list.c
     src/core/marsh.c
+    src/core/matcher.c
     src/core/verdict.c
     src/generator/codegen.c
     src/generator/jmp.c


### PR DESCRIPTION
Currently, rules contains a fixed set of criteria to match the network,packets against: source/destination IP addresses, source/destination ports, ... Adding new criteria to match the packets against would only grow the complexity higher and bloat the `bf_rule` structure, keeping in might that chances are low that all the criteria a used in the same rule, leading to a lot of unused fields.

Instead, a solution is to define packet matching criteria differently, that's what this change is about: bf_matcher are used to define how to match bytes from the network packet according to a reference value, they're composed of:
- A type defining which protocol/field of the network packet the matcher is to be compared to.
- An operator, defining how to compare the network packet data to the reference value.
- A payload, which is the reference value to compare the packet data against.

This change only define the bf_matcher structure, further change will introduce it into bf_rule and generate the relevant BPF bytecode.