### PR TITLE
core: rule: add support for `bf_matcher`

### DIFF
--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -20,6 +20,8 @@ int bf_rule_new(struct bf_rule **rule)
 {
     struct bf_rule *_rule;
 
+    bf_assert(rule);
+
     _rule = calloc(1, sizeof(*_rule));
     if (!_rule)
         return -ENOMEM;
@@ -34,6 +36,8 @@ int bf_rule_new(struct bf_rule **rule)
 
 void bf_rule_free(struct bf_rule **rule)
 {
+    bf_assert(rule);
+
     if (!*rule)
         return;
 

--- a/src/core/rule.h
+++ b/src/core/rule.h
@@ -35,6 +35,7 @@ struct bf_rule
     uint32_t dst_mask;
     uint16_t protocol;
     bf_list matches;
+    bf_list matchers;
     bool counters;
     enum bf_verdict verdict;
 };

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -88,6 +88,7 @@ set(bf_test_srcs
     src/core/list.c
     src/core/marsh.c
     src/core/matcher.c
+    src/core/rule.c
     src/core/verdict.c
     src/generator/codegen.c
     src/generator/jmp.c

--- a/tests/unit/src/core/rule.c
+++ b/tests/unit/src/core/rule.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "core/rule.c"
+
+#include "harness/cmocka.h"
+#include "harness/mock.h"
+
+static int _create_dummy_rule(struct bf_rule **rule)
+{
+    struct bf_rule *_rule;
+    int r;
+
+    bf_assert(rule);
+
+    r = bf_rule_new(rule);
+    if (r)
+        return r;
+
+    _rule = *rule;
+    _rule->index = 1;
+    _rule->ifindex = 2;
+    _rule->invflags = 3;
+    _rule->src = 4;
+    _rule->dst = 5;
+    _rule->src_mask = 6;
+    _rule->dst_mask = 7;
+    _rule->protocol = 8;
+
+    for (int i = 0; i < 10; ++i) {
+        _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+
+        r = bf_matcher_new(&matcher, 0, 0, (void *)&i, sizeof(i));
+        if (r)
+            return r;
+
+        r = bf_list_add_tail(&_rule->matchers, matcher);
+        if (r)
+            return r;
+
+        TAKE_PTR(matcher);
+    }
+
+    _rule->counters = true;
+    _rule->verdict = 1;
+
+    return 0;
+}
+
+Test(rule, new_and_free)
+{
+    // Invalid argument
+    expect_assert_failure(bf_rule_new(NULL));
+    expect_assert_failure(bf_rule_free(NULL));
+
+    // New, free, new again, then cleanup
+    {
+        _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+
+        assert_int_equal(0, bf_rule_new(&rule));
+        bf_rule_free(&rule);
+        assert_null(rule);
+        bf_rule_free(&rule);
+
+        assert_int_equal(0, bf_rule_new(&rule));
+    }
+
+    // malloc failure
+    {
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
+        struct bf_rule *rule;
+
+        assert_int_not_equal(0, bf_rule_new(&rule));
+    }
+}
+
+Test(rule, marsh_unmarsh)
+{
+    expect_assert_failure(bf_rule_marsh(NULL, NOT_NULL));
+    expect_assert_failure(bf_rule_marsh(NOT_NULL, NULL));
+    expect_assert_failure(bf_rule_unmarsh(NULL, NOT_NULL));
+    expect_assert_failure(bf_rule_unmarsh(NOT_NULL, NULL));
+
+    // All good
+    {
+        _cleanup_bf_rule_ struct bf_rule *rule0 = NULL;
+        _cleanup_bf_rule_ struct bf_rule *rule1 = NULL;
+        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+
+        assert_int_equal(0, _create_dummy_rule(&rule0));
+        assert_int_equal(0, bf_rule_marsh(rule0, &marsh));
+        assert_int_equal(0, bf_rule_unmarsh(marsh, &rule1));
+
+        assert_int_equal(rule0->index, rule1->index);
+        assert_int_equal(rule0->ifindex, rule1->ifindex);
+        assert_int_equal(rule0->invflags, rule1->invflags);
+        assert_int_equal(rule0->src, rule1->src);
+        assert_int_equal(rule0->dst, rule1->dst);
+        assert_int_equal(rule0->src_mask, rule1->src_mask);
+        assert_int_equal(rule0->dst_mask, rule1->dst_mask);
+        assert_int_equal(bf_list_size(&rule0->matchers),
+                         bf_list_size(&rule1->matchers));
+        assert_int_equal(rule0->counters, rule1->counters);
+        assert_int_equal(rule0->verdict, rule1->verdict);
+    }
+
+    // Failed serialisation
+    {
+        _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+
+        assert_int_equal(0, _create_dummy_rule(&rule));
+
+        _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
+        assert_int_not_equal(0, bf_rule_marsh(rule, &marsh));
+    }
+}


### PR DESCRIPTION
Add a new field in `bf_rule`: `matchers`, which is a list of `bf_matcher` object. `bf_matcher` are expected to replace specific individual packet matching criteria in `bf_rule`.