### PR TITLE
Cleanup `*_dump()` function (and other minor fixes)

### DIFF
--- a/src/core/context.c
+++ b/src/core/context.c
@@ -150,25 +150,31 @@ static void _bf_context_dump(const struct bf_context *context, prefix_t *prefix)
     DUMP(prefix, "struct bf_context at %p", context);
 
     bf_dump_prefix_push(prefix);
-
-    DUMP(bf_dump_prefix_last(prefix), "codegens:");
+    
+    DUMP(bf_dump_prefix_last(prefix), "codegens: bf_codegen[%d][%d]",
+         _BF_HOOK_MAX, _BF_FRONT_MAX);
     bf_dump_prefix_push(prefix);
 
     for (int i = 0; i < _BF_HOOK_MAX; ++i) {
         if (i == _BF_HOOK_MAX - 1)
             bf_dump_prefix_last(prefix);
 
-        DUMP(prefix, "%s", bf_hook_to_str(i));
+        DUMP(prefix, "[%s]", bf_hook_to_str(i));
         bf_dump_prefix_push(prefix);
 
         for (int j = 0; j < _BF_FRONT_MAX; ++j) {
             if (j == _BF_FRONT_MAX - 1)
                 bf_dump_prefix_last(prefix);
 
-            if (context->codegens[i][j])
-                bf_codegen_dump(context->codegens[i][j], prefix);
-            else
-                DUMP(prefix, "%s: <null>", bf_front_to_str(j));
+            if (context->codegens[i][j]) {
+                DUMP(prefix, "[%s]: struct bf_codegen *", bf_front_to_str(j));
+                bf_dump_prefix_push(prefix);
+                bf_codegen_dump(context->codegens[i][j],
+                                bf_dump_prefix_last(prefix));
+                bf_dump_prefix_pop(prefix);
+            } else {
+                DUMP(prefix, "[%s]: <null>", bf_front_to_str(j));
+            }
         }
 
         bf_dump_prefix_pop(prefix);

--- a/src/core/context.c
+++ b/src/core/context.c
@@ -151,6 +151,11 @@ static void _bf_context_dump(const struct bf_context *context, prefix_t *prefix)
 
     bf_dump_prefix_push(prefix);
     
+    DUMP(prefix, "printer: struct bf_printer *");
+    bf_dump_prefix_push(prefix);
+    bf_printer_dump(context->printer, bf_dump_prefix_last(prefix));
+    bf_dump_prefix_pop(prefix);
+    
     DUMP(bf_dump_prefix_last(prefix), "codegens: bf_codegen[%d][%d]",
          _BF_HOOK_MAX, _BF_FRONT_MAX);
     bf_dump_prefix_push(prefix);

--- a/src/core/context.c
+++ b/src/core/context.c
@@ -144,9 +144,6 @@ static void _bf_context_free(struct bf_context **context)
  */
 static void _bf_context_dump(const struct bf_context *context, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-
     DUMP(prefix, "struct bf_context at %p", context);
 
     bf_dump_prefix_push(prefix);

--- a/src/core/dump.h
+++ b/src/core/dump.h
@@ -44,6 +44,9 @@
 /// Maximum length of the prefix buffer.
 #define DUMP_PREFIX_LEN 65
 
+/// Empty prefix for dump functions
+#define EMPTY_PREFIX ((prefix_t[]) {{}})
+
 typedef char(prefix_t)[DUMP_PREFIX_LEN];
 
 /**

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -125,9 +125,6 @@ int bf_matcher_marsh(const struct bf_matcher *matcher, struct bf_marsh **marsh)
 
 void bf_matcher_dump(const struct bf_matcher *matcher, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-
     bf_assert(matcher);
     bf_assert(prefix);
 

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -197,6 +197,8 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
 
 void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
 {
+    bf_assert(rule);
+    bf_assert(prefix);
 
     DUMP(prefix, "struct bf_rule at %p", rule);
 

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -225,6 +225,7 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
 
         bf_matcher_dump(matcher, prefix);
     }
+    bf_dump_prefix_pop(prefix);
 
     DUMP(prefix, "counters: %s", rule->counters ? "yes" : "no");
     DUMP(bf_dump_prefix_last(prefix), "verdict: %s",

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -197,8 +197,6 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
 
 void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
 
     DUMP(prefix, "struct bf_rule at %p", rule);
 

--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -297,7 +297,7 @@ void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix)
     DUMP(prefix, "policy: %s", bf_verdict_to_str(codegen->policy));
 
     // Rules
-    DUMP(prefix, "rules: %lu", bf_list_size(&codegen->rules));
+    DUMP(prefix, "rules: bf_list<bf_rule>[%lu]", bf_list_size(&codegen->rules));
     bf_dump_prefix_push(prefix);
     bf_list_foreach (&codegen->rules, rule_node) {
         struct bf_rule *rule = bf_list_node_get_data(rule_node);
@@ -310,7 +310,7 @@ void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix)
     bf_dump_prefix_pop(prefix);
 
     // Programs
-    DUMP(bf_dump_prefix_last(prefix), "programs: %lu",
+    DUMP(bf_dump_prefix_last(prefix), "programs: bf_list<bf_program>[%lu]",
          bf_list_size(&codegen->programs));
     bf_dump_prefix_push(prefix);
     bf_list_foreach (&codegen->programs, program_node) {

--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -111,13 +111,13 @@ int bf_codegen_load(struct bf_codegen *codegen, struct bf_codegen *prev_codegen)
 
         r = bf_program_load(program, prev_program);
         if (r) {
-            bf_program_dump(program, NULL);
+            bf_program_dump(program, EMPTY_PREFIX);
             bf_program_dump_bytecode(program, false);
             return bf_err_code(r, "failed to load program");
         }
     }
 
-    bf_codegen_dump(codegen, NULL);
+    bf_codegen_dump(codegen, EMPTY_PREFIX);
 
     return 0;
 }
@@ -286,8 +286,6 @@ int bf_codegen_unmarsh(const struct bf_marsh *marsh,
 
 void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
 
     DUMP(prefix, "struct bf_codegen at %p", codegen);
 

--- a/src/generator/codegen.c
+++ b/src/generator/codegen.c
@@ -286,6 +286,8 @@ int bf_codegen_unmarsh(const struct bf_marsh *marsh,
 
 void bf_codegen_dump(const struct bf_codegen *codegen, prefix_t *prefix)
 {
+    bf_assert(codegen);
+    bf_assert(prefix);
 
     DUMP(prefix, "struct bf_codegen at %p", codegen);
 

--- a/src/generator/fixup.c
+++ b/src/generator/fixup.c
@@ -63,9 +63,11 @@ void bf_fixup_free(struct bf_fixup **fixup)
     *fixup = NULL;
 }
 
-void bf_fixup_dump(const struct bf_fixup *fixup,
-                   char (*prefix)[DUMP_PREFIX_LEN])
+void bf_fixup_dump(const struct bf_fixup *fixup, prefix_t *prefix)
 {
+    bf_assert(fixup);
+    bf_assert(prefix);
+
     DUMP(prefix, "struct bf_fixup at %p", fixup);
 
     bf_dump_prefix_push(prefix);

--- a/src/generator/fixup.h
+++ b/src/generator/fixup.h
@@ -65,5 +65,4 @@ const char *bf_fixup_function_to_str(enum bf_fixup_function function);
 
 int bf_fixup_new(struct bf_fixup **fixup);
 void bf_fixup_free(struct bf_fixup **fixup);
-void bf_fixup_dump(const struct bf_fixup *fixup,
-                   char (*prefix)[DUMP_PREFIX_LEN]);
+void bf_fixup_dump(const struct bf_fixup *fixup, prefix_t *prefix);

--- a/src/generator/printer.c
+++ b/src/generator/printer.c
@@ -172,9 +172,6 @@ static int _bf_printer_msg_marsh(const struct bf_printer_msg *msg,
 static void _bf_printer_msg_dump(const struct bf_printer_msg *msg,
                                  prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-
     bf_assert(msg);
 
     DUMP(prefix, "struct bf_printer_msg at %p", msg);
@@ -300,9 +297,6 @@ int bf_printer_marsh(const struct bf_printer *printer, struct bf_marsh **marsh)
 
 void bf_printer_dump(const struct bf_printer *printer, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-
     bf_assert(printer);
 
     DUMP(prefix, "struct bf_printer at %p", printer);

--- a/src/generator/printer.c
+++ b/src/generator/printer.c
@@ -173,6 +173,7 @@ static void _bf_printer_msg_dump(const struct bf_printer_msg *msg,
                                  prefix_t *prefix)
 {
     bf_assert(msg);
+    bf_assert(prefix);
 
     DUMP(prefix, "struct bf_printer_msg at %p", msg);
 
@@ -298,6 +299,7 @@ int bf_printer_marsh(const struct bf_printer *printer, struct bf_marsh **marsh)
 void bf_printer_dump(const struct bf_printer *printer, prefix_t *prefix)
 {
     bf_assert(printer);
+    bf_assert(prefix);
 
     DUMP(prefix, "struct bf_printer at %p", printer);
 

--- a/src/generator/printer.c
+++ b/src/generator/printer.c
@@ -226,9 +226,11 @@ int bf_printer_new_from_marsh(struct bf_printer **printer,
         TAKE_PTR(msg);
     }
 
-    r = bf_bpf_obj_get(_bf_printer_pin_path, &_printer->fd);
-    if (r < 0)
-        return bf_err_code(r, "failed to get printer map fd");
+    if (!bf_list_is_empty(&_printer->msgs)) {
+        r = bf_bpf_obj_get(_bf_printer_pin_path, &_printer->fd);
+        if (r < 0)
+            return bf_err_code(r, "failed to get printer map fd");
+    }
 
     *printer = TAKE_PTR(_printer);
 

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -127,6 +127,14 @@ void bf_printer_free(struct bf_printer **printer);
 int bf_printer_marsh(const struct bf_printer *printer, struct bf_marsh **marsh);
 
 /**
+ * @brief Dump the content of the printer structure.
+ *
+ * @param printer Printer object to dump. Can't be NULL.
+ * @param prefix Prefix to use for the dump. Can be NULL.
+ */
+void bf_printer_dump(const struct bf_printer *printer, prefix_t *prefix);
+
+/**
  * @brief Get the printer map's file descriptor.
  *
  * @param printer Printer context. Can't be NULL.
@@ -168,4 +176,3 @@ const struct bf_printer_msg *bf_printer_add_msg(struct bf_printer *printer,
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_printer_publish(struct bf_printer *printer);
-

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -179,8 +179,6 @@ int bf_program_unmarsh(const struct bf_marsh *marsh,
 
 void bf_program_dump(const struct bf_program *program, prefix_t *prefix)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
     char ifname_buf[IF_NAMESIZE] = {};
 
     DUMP(prefix, "struct bf_program at %p", program);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -181,6 +181,9 @@ void bf_program_dump(const struct bf_program *program, prefix_t *prefix)
 {
     char ifname_buf[IF_NAMESIZE] = {};
 
+    bf_assert(program);
+    bf_assert(prefix);
+
     DUMP(prefix, "struct bf_program at %p", program);
 
     bf_dump_prefix_push(prefix);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -199,7 +199,27 @@ void bf_program_dump(const struct bf_program *program, prefix_t *prefix)
          bf_opts_transient() ? "<transient>" : program->map_pin_path);
     DUMP(prefix, "img: %p", program->img);
     DUMP(prefix, "img_size: %lu", program->img_size);
-    DUMP(bf_dump_prefix_last(prefix), "img_cap: %lu", program->img_cap);
+    DUMP(prefix, "img_cap: %lu", program->img_cap);
+
+    DUMP(prefix, "fixups: bf_list<struct bf_fixup>[%lu]",
+         bf_list_size(&program->fixups));
+    bf_dump_prefix_push(prefix);
+    bf_list_foreach (&program->fixups, fixup_node) {
+        struct bf_fixup *fixup = bf_list_node_get_data(fixup_node);
+
+        if (bf_list_is_tail(&program->fixups, fixup_node))
+            bf_dump_prefix_last(prefix);
+
+        bf_fixup_dump(fixup, prefix);
+    }
+    bf_dump_prefix_pop(prefix);
+
+    DUMP(bf_dump_prefix_last(prefix), "runtime: <anonymous>");
+    bf_dump_prefix_push(prefix);
+    DUMP(prefix, "prog_fd: %d", program->runtime.prog_fd);
+    DUMP(prefix, "map_fd: %d", program->runtime.map_fd);
+    DUMP(bf_dump_prefix_last(prefix), "ops: %p", program->runtime.ops);
+    bf_dump_prefix_pop(prefix);
 
     bf_dump_prefix_pop(prefix);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -280,7 +280,7 @@ static int _bf_init(int argc, char *argv[])
             return bf_err_code(r, "failed to setup context");
     }
 
-    bf_context_dump(NULL);
+    bf_context_dump(EMPTY_PREFIX);
 
     for (enum bf_front front = 0; front < _BF_FRONT_MAX; ++front) {
         if (!bf_opts_is_front_enabled(front))

--- a/src/main.c
+++ b/src/main.c
@@ -171,8 +171,6 @@ static int _bf_load(const char *path)
 
     bf_dbg("loaded marshalled context from %s", path);
 
-    bf_context_dump(NULL);
-
     return 1;
 }
 
@@ -281,6 +279,8 @@ static int _bf_init(int argc, char *argv[])
         if (r < 0)
             return bf_err_code(r, "failed to setup context");
     }
+
+    bf_context_dump(NULL);
 
     for (enum bf_front front = 0; front < _BF_FRONT_MAX; ++front) {
         if (!bf_opts_is_front_enabled(front))

--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -303,7 +303,7 @@ static int _bf_nft_getchain_cb(const struct bf_nfmsg *req,
     if (r < 0)
         return bf_err_code(r, "failed to create bf_nfmsg");
 
-    bf_codegen_dump(codegen, NULL);
+    bf_codegen_dump(codegen, EMPTY_PREFIX);
 
     switch (codegen->policy) {
     case BF_VERDICT_ACCEPT:


### PR DESCRIPTION
- Dump `bf_printer` on `bf_context_dump()`
- Do not restore the `bf_printer` map FD if it doesn't exist
- In `bf_program`, dump the fixups and the runtime-only fields, so the full object is dumped
- Add details to the container of dumped objects (e.g. `bf_list<$TYPE>[$SIZE]`)
- Add missing `bf_prefix_pop()` in `bf_rule_dump()`
- Always dump `bf_context`, whether it's been created from scratch or restored (even in transient mode)
- Assert pointer arguments of `*_dump()` functions
- Define `EMPTY_PREFIX` to act as an empty prefix for `*_dump()` function, remove the need for `NULL` check and creation of an empty prefix.