### PR TITLE
Fill `bf_rule`'s matchers from `ipt` and `nft` front-ends

### DIFF
--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -148,6 +148,8 @@ const char *bf_matcher_type_to_str(enum bf_matcher_type type)
 {
     static const char *types_str[] = {
         [BF_MATCHER_IP_SRC_ADDR] = "BF_MATCHER_IP_SRC_ADDR",
+        [BF_MATCHER_IP_DST_ADDR] = "BF_MATCHER_IP_DST_ADDR",
+        [BF_MATCHER_IP_PROTO] = "BF_MATCHER_IP_PROTO",
     };
 
     bf_assert(0 <= type && type < _BF_MATCHER_TYPE_MAX);
@@ -161,6 +163,7 @@ const char *bf_matcher_op_to_str(enum bf_matcher_op op)
 {
     static const char *ops_str[] = {
         [BF_MATCHER_EQ] = "BF_MATCHER_EQ",
+        [BF_MATCHER_NE] = "BF_MATCHER_NE",
     };
 
     bf_assert(0 <= op && op < _BF_MATCHER_OP_MAX);

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -27,7 +27,7 @@ struct bf_matcher
 };
 
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
-                   enum bf_matcher_op op, const uint8_t *payload,
+                   enum bf_matcher_op op, const void *payload,
                    size_t payload_len)
 {
     _cleanup_bf_matcher_ struct bf_matcher *_matcher = NULL;

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -43,6 +43,10 @@ enum bf_matcher_type
 {
     /// Matches IP source address.
     BF_MATCHER_IP_SRC_ADDR,
+    /// Matches IP destination address.
+    BF_MATCHER_IP_DST_ADDR,
+    /// Matches against the IP protocol field
+    BF_MATCHER_IP_PROTO,
     _BF_MATCHER_TYPE_MAX,
 };
 
@@ -56,6 +60,8 @@ enum bf_matcher_op
 {
     /// Test for equality.
     BF_MATCHER_EQ,
+    /// Test for inequality.
+    BF_MATCHER_NE,
     _BF_MATCHER_OP_MAX,
 };
 

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -51,6 +51,16 @@ enum bf_matcher_type
 };
 
 /**
+ * @brief Defines the structure of the payload for bf_matcher's
+ * BF_MATCHER_IP_SRC_ADDR and BF_MATCHER_IP_DST_ADDR types.
+ */
+struct bf_matcher_ip_addr
+{
+    uint32_t addr;
+    uint32_t mask;
+};
+
+/**
  * @brief Matcher comparison operator.
  *
  * The matcher comparison operator defines the type of comparison to operator

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -89,7 +89,7 @@ enum bf_matcher_op
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
-                   enum bf_matcher_op op, const uint8_t *payload,
+                   enum bf_matcher_op op, const void *payload,
                    size_t payload_len);
 
 /**

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -13,7 +13,6 @@
 #include "core/logger.h"
 #include "core/marsh.h"
 #include "core/match.h"
-#include "core/matcher.h"
 #include "core/verdict.h"
 #include "shared/helper.h"
 
@@ -232,4 +231,26 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
          bf_verdict_to_str(rule->verdict));
 
     bf_dump_prefix_pop(prefix);
+}
+
+int bf_rule_add_matcher(struct bf_rule *rule, enum bf_matcher_type type,
+                        enum bf_matcher_op op, const void *payload,
+                        size_t payload_len)
+{
+    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+    int r;
+
+    bf_assert(rule);
+
+    r = bf_matcher_new(&matcher, type, op, payload, payload_len);
+    if (r)
+        return r;
+
+    r = bf_list_add_tail(&rule->matchers, matcher);
+    if (r)
+        return r;
+
+    TAKE_PTR(matcher);
+
+    return 0;
 }

--- a/src/core/rule.h
+++ b/src/core/rule.h
@@ -10,6 +10,7 @@
 
 #include "core/dump.h"
 #include "core/list.h"
+#include "core/matcher.h"
 #include "core/verdict.h"
 
 struct bf_marsh;
@@ -86,3 +87,19 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule);
  * @param prefix Prefix for each printed line.
  */
 void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix);
+
+/**
+ * @brief Create a new matcher and add it to the rule.
+ *
+ * @param rule Rule to add the matcher to. Can't be NULL.
+ * @param type Matcher type.
+ * @param op Comparison operator.
+ * @param payload Payload of the matcher, its content and size depends on @ref
+ * type. Can be NULL but only if @ref payload_len is 0, in which case there is
+ * no payload.
+ * @param payload_len Length of the payload.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_rule_add_matcher(struct bf_rule *rule, enum bf_matcher_type type,
+                        enum bf_matcher_op op, const void *payload,
+                        size_t payload_len);

--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -12,6 +12,7 @@
 #include "core/hook.h"
 #include "core/logger.h"
 #include "core/marsh.h"
+#include "core/matcher.h"
 #include "core/rule.h"
 #include "core/verdict.h"
 #include "generator/codegen.h"
@@ -512,13 +513,32 @@ static int _bf_nft_newrule_cb(const struct bf_nfmsg *req)
     rule->counters = counter;
     switch (off) {
     case 9:
+        r = bf_rule_add_matcher(rule, BF_MATCHER_IP_PROTO, BF_MATCHER_EQ,
+                                (uint16_t[]) {htonl(cmp_value)},
+                                sizeof(uint16_t));
+        if (r)
+            return r;
         rule->protocol = htonl(cmp_value);
         break;
     case 12:
+        r = bf_rule_add_matcher(rule, BF_MATCHER_IP_SRC_ADDR, BF_MATCHER_EQ,
+                                (struct bf_matcher_ip_addr[]) {
+                                    {.addr = htonl(cmp_value),
+                                     .mask = 0xffffffff >> (32 - len * 8)}},
+                                sizeof(struct bf_matcher_ip_addr));
+        if (r)
+            return r;
         rule->src = htonl(cmp_value);
         rule->src_mask = 0xffffffff >> (32 - len * 8);
         break;
     case 16:
+        r = bf_rule_add_matcher(rule, BF_MATCHER_IP_DST_ADDR, BF_MATCHER_EQ,
+                                (struct bf_matcher_ip_addr[]) {
+                                    {.addr = htonl(cmp_value),
+                                     .mask = 0xffffffff >> (32 - len * 8)}},
+                                sizeof(struct bf_matcher_ip_addr));
+        if (r)
+            return r;
         rule->dst = htonl(cmp_value);
         rule->dst_mask = 0xffffffff >> (32 - len * 8);
         break;


### PR DESCRIPTION
Add missing matchers types and operators, and convert the filtering rules coming from `iptables` and `nftables` into `bf_matcher`. Existing matching criteria are still used (e.g. `bf_rule.src`) as the `bf_matcher` are not yet used to create the BPF bytecode.