### PR TITLE
 generator: matcher: use `bf_matcher` to create the BPF bytecode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/generator/fixup.h ${CMAKE_SOURCE_DIR}/src/generator/fixup.c
     ${CMAKE_SOURCE_DIR}/src/generator/tc.h ${CMAKE_SOURCE_DIR}/src/generator/tc.c
     ${CMAKE_SOURCE_DIR}/src/generator/xdp.h ${CMAKE_SOURCE_DIR}/src/generator/xdp.c
+    ${CMAKE_SOURCE_DIR}/src/generator/matcher/ip.h ${CMAKE_SOURCE_DIR}/src/generator/matcher/ip.c
 
     ${CMAKE_SOURCE_DIR}/src/xlate/front.h ${CMAKE_SOURCE_DIR}/src/xlate/front.c
     ${CMAKE_SOURCE_DIR}/src/xlate/ipt/helpers.h

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -8,24 +8,6 @@
 #include "core/marsh.h"
 #include "shared/helper.h"
 
-/**
- * @brief Matcher definition.
- *
- * Matchers are criterias to match the packet against. A set of matcher defines
- * what a rule should match on.
- */
-struct bf_matcher
-{
-    /// Matcher type.
-    enum bf_matcher_type type;
-    /// Comparison operator.
-    enum bf_matcher_op op;
-    /// Total matcher size (including payload).
-    size_t len;
-    /// Payload to match the packet against (if any).
-    uint8_t payload[0];
-};
-
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
                    enum bf_matcher_op op, const void *payload,
                    size_t payload_len)

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -76,6 +76,24 @@ enum bf_matcher_op
 };
 
 /**
+ * @brief Matcher definition.
+ *
+ * Matchers are criterias to match the packet against. A set of matcher defines
+ * what a rule should match on.
+ */
+struct bf_matcher
+{
+    /// Matcher type.
+    enum bf_matcher_type type;
+    /// Comparison operator.
+    enum bf_matcher_op op;
+    /// Total matcher size (including payload).
+    size_t len;
+    /// Payload to match the packet against (if any).
+    uint8_t payload[0];
+};
+
+/**
  * @brief Allocate and initalise a new matcher.
  *
  * @param matcher Matcher object to allocate and initialise. Can't be NULL. On

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/matcher/ip.h"
+
+#include "core/logger.h"
+#include "core/matcher.h"
+#include "generator/fixup.h"
+#include "generator/program.h"
+
+static int _bf_matcher_generate_ip_addr(struct bf_program *program,
+                                        const struct bf_matcher *matcher)
+{
+    struct bf_matcher_ip_addr *addr = (void *)&matcher->payload;
+    size_t offset = matcher->type == BF_MATCHER_IP_SRC_ADDR ?
+                        offsetof(struct iphdr, saddr) :
+                        offsetof(struct iphdr, daddr);
+
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_L3, offset));
+    if (addr->mask != 0xffffffff)
+        EMIT(program, BPF_ALU32_IMM(BPF_AND, BF_REG_2, addr->mask));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
+                           BF_REG_2, addr->addr, 0));
+
+    return 0;
+}
+
+static int _bf_matcher_generate_ip_proto(struct bf_program *program,
+                                         const struct bf_matcher *matcher)
+{
+    uint16_t proto = *(uint16_t *)&matcher->payload;
+
+    EMIT(program, BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_L3,
+                              offsetof(struct iphdr, protocol)));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(BPF_JNE, BF_REG_4, proto, 0));
+
+    return 0;
+}
+
+int bf_matcher_generate_ip(struct bf_program *program,
+                           const struct bf_matcher *matcher)
+{
+    int r;
+
+    switch (matcher->type) {
+    case BF_MATCHER_IP_SRC_ADDR:
+    case BF_MATCHER_IP_DST_ADDR:
+        r = _bf_matcher_generate_ip_addr(program, matcher);
+        break;
+    case BF_MATCHER_IP_PROTO:
+        r = _bf_matcher_generate_ip_proto(program, matcher);
+        break;
+    default:
+        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+    };
+
+    if (r)
+        return r;
+
+    return 0;
+}

--- a/src/generator/matcher/ip.h
+++ b/src/generator/matcher/ip.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+struct bf_matcher;
+struct bf_program;
+
+/**
+ * @brief Generate the bytecode for the BF_MATCHER_IP_* matcher types.
+ *
+ * @param program Program to generate the bytecode into. Can't be NULL.
+ * @param matcher Matcher to generate the bytecode for. Can't be NULL.
+ * @return 0 on success, negative errno value on failure.
+ */
+int bf_matcher_generate_ip(struct bf_program *program,
+                           const struct bf_matcher *matcher);


### PR DESCRIPTION
Generate a rule's bytecode using `bf_rule.matchers` (`bf_matcher` objects) instead of the matching criteria defined in the rule.

The "old" matching criteria remain in the `bf_rule` structure and are still set during front-end translation, but they will be deleted in a subsequent commit.