### PR TITLE
Refactor the generation of the bytecode to parse and detect a packet's protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ set(bpfilter_daemon_srcs
     ${CMAKE_SOURCE_DIR}/src/generator/codegen.h ${CMAKE_SOURCE_DIR}/src/generator/codegen.c
     ${CMAKE_SOURCE_DIR}/src/generator/dump.h ${CMAKE_SOURCE_DIR}/src/generator/dump.c
     ${CMAKE_SOURCE_DIR}/src/generator/jmp.h ${CMAKE_SOURCE_DIR}/src/generator/jmp.c
+    ${CMAKE_SOURCE_DIR}/src/generator/swich.h ${CMAKE_SOURCE_DIR}/src/generator/swich.c
     ${CMAKE_SOURCE_DIR}/src/generator/nf.h ${CMAKE_SOURCE_DIR}/src/generator/nf.c
     ${CMAKE_SOURCE_DIR}/src/generator/printer.h ${CMAKE_SOURCE_DIR}/src/generator/printer.c
     ${CMAKE_SOURCE_DIR}/src/generator/program.h ${CMAKE_SOURCE_DIR}/src/generator/program.c

--- a/doc/developers/generation.rst
+++ b/doc/developers/generation.rst
@@ -1,6 +1,11 @@
 Programs generation
 ===================
 
+Switch-cases
+------------
+
+.. doxygenfile:: swich.h
+
 Error handling
 --------------
 

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -5,6 +5,8 @@
 
 #include "generator/matcher/ip.h"
 
+#include <arpa/inet.h>
+
 #include "core/logger.h"
 #include "core/matcher.h"
 #include "generator/fixup.h"
@@ -45,6 +47,11 @@ int bf_matcher_generate_ip(struct bf_program *program,
                            const struct bf_matcher *matcher)
 {
     int r;
+
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l3_proto)));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_REG(BPF_JNE, htons(ETH_P_IP), BF_REG_1, 0));
 
     switch (matcher->type) {
     case BF_MATCHER_IP_SRC_ADDR:

--- a/src/generator/nf.c
+++ b/src/generator/nf.c
@@ -102,11 +102,11 @@ static int _nf_gen_inline_prologue(struct bf_program *program)
     // BPF_PROG_TYPE_NETFILTER's skb is stripped from the Ethernet header,
     // so we don't get it.
 
-    r = bf_stub_get_l3_ipv4_hdr(program);
+    r = bf_stub_parse_l3_hdr(program);
     if (r)
         return r;
 
-    r = bf_stub_get_l4_hdr(program);
+    r = bf_stub_parse_l4_hdr(program);
     if (r)
         return r;
 

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -110,6 +110,10 @@ struct bf_program_context
     /** Offset of the layer 3 header in the packet. */
     uint32_t l3_offset;
 
+    /** Layer 3 protocol. Set when the L2 header is processed. Used to define
+     * how many bytes to read when processing the packet. */
+    uint16_t l3_proto;
+
     /** Offset of the layer 4 header in the packet. */
     uint32_t l4_offset;
 

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -107,41 +107,47 @@ struct bf_program_context
     /** Total size of the packet. */
     uint64_t pkt_size;
 
-    /** Offset of the layer 3 header in the packet. */
-    uint32_t l3_offset;
-
-    /** Layer 3 protocol. Set when the L2 header is processed. Used to define
-     * how many bytes to read when processing the packet. */
-    uint16_t l3_proto;
-
-    /** Offset of the layer 4 header in the packet. */
-    uint32_t l4_offset;
-
-    /** Layer 4 protocol. Set when the L3 header is processed. Used to define
-     * how many bytes to read when processing the packet. */
-    uint8_t l4_proto;
-
     /** Layer 2 header. */
     union
     {
         struct ethhdr _ethhdr;
-        char l2raw;
+        char l2_raw;
     };
 
     /** Layer 3 header. */
-    union
+    struct
     {
-        struct iphdr _iphdr;
-        char l3raw;
+        /** Offset of the layer 3 header in the packet. */
+        uint32_t l3_offset;
+
+        /** Layer 3 protocol. Set when the L2 header is processed. Used to
+         * define how many bytes to read when processing the packet. */
+        uint16_t l3_proto;
+
+        union
+        {
+            struct iphdr _iphdr;
+            char l3_raw;
+        };
     };
 
     /** Layer 4 header. */
-    union
+    struct
     {
-        struct icmphdr _icmphdr;
-        struct udphdr _udphdr;
-        struct tcphdr _tcphdr;
-        char l4raw;
+        /** Offset of the layer 4 header in the packet. */
+        uint32_t l4_offset;
+
+        /** Layer 4 protocol. Set when the L3 header is processed. Used to
+         * define how many bytes to read when processing the packet. */
+        uint16_t l4_proto;
+
+        union
+        {
+            struct icmphdr _icmphdr;
+            struct udphdr _udphdr;
+            struct tcphdr _tcphdr;
+            char l4_raw;
+        };
     };
 } bf_aligned(8);
 

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -106,7 +106,7 @@ int bf_stub_get_l2_eth_hdr(struct bf_program *program)
 
     // BF_ARG_3: pointer to the buffer to store L2 header.
     EMIT(program, BPF_MOV64_REG(BF_ARG_3, BF_REG_CTX));
-    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l2raw)));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l2_raw)));
 
     // BF_ARG_4: size of the L2 header buffer.
     EMIT(program, BPF_MOV64_IMM(BF_ARG_4, sizeof(struct ethhdr)));
@@ -156,7 +156,7 @@ int bf_stub_get_l3_ipv4_hdr(struct bf_program *program)
 
     // BF_ARG_3: pointer to the buffer.
     EMIT(program, BPF_MOV64_REG(BF_ARG_3, BF_REG_CTX));
-    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l3raw)));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l3_raw)));
 
     // BF_ARG_4: size of the buffer
     EMIT(program, BPF_MOV64_IMM(BF_ARG_4, sizeof(struct iphdr)));
@@ -225,12 +225,11 @@ int bf_stub_get_l4_hdr(struct bf_program *program)
 
     // BF_ARG_3: pointer to the buffer.
     EMIT(program, BPF_MOV64_REG(BF_ARG_3, BF_REG_CTX));
-    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l4raw)));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_ARG_3, BF_PROG_CTX_OFF(l4_raw)));
 
     // Load L4 protocol from the context.
     EMIT(program,
-         BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
-
+         BPF_LDX_MEM(BPF_H, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
     {
         // If L4 protocol is TCP.
         EMIT(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_4, IPPROTO_TCP, 4));

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -94,7 +94,7 @@ int bf_stub_make_ctx_skb_dynptr(struct bf_program *program, enum bf_reg skb_reg)
     return _stub_make_ctx_dynptr(program, skb_reg, "bpf_dynptr_from_skb");
 }
 
-int bf_stub_get_l2_eth_hdr(struct bf_program *program)
+int bf_stub_parse_l2_ethhdr(struct bf_program *program)
 {
     bf_assert(program);
 
@@ -143,7 +143,7 @@ int bf_stub_get_l2_eth_hdr(struct bf_program *program)
     return 0;
 }
 
-int bf_stub_get_l3_ipv4_hdr(struct bf_program *program)
+int bf_stub_parse_l3_hdr(struct bf_program *program)
 {
     _cleanup_bf_swich_ struct bf_swich swich;
     int r;
@@ -231,7 +231,7 @@ int bf_stub_get_l3_ipv4_hdr(struct bf_program *program)
     return 0;
 }
 
-int bf_stub_get_l4_hdr(struct bf_program *program)
+int bf_stub_parse_l4_hdr(struct bf_program *program)
 {
     int r;
 

--- a/src/generator/stub.h
+++ b/src/generator/stub.h
@@ -80,7 +80,7 @@ int bf_stub_make_ctx_skb_dynptr(struct bf_program *program,
  * @param program Program to emit instructions into.
  * @return 0 on success, or negative errno value on error.
  */
-int bf_stub_get_l2_eth_hdr(struct bf_program *program);
+int bf_stub_parse_l2_ethhdr(struct bf_program *program);
 
 /**
  * @brief Emit instructions to get a dynptr slice for the packet's L3 IPv4
@@ -106,7 +106,7 @@ int bf_stub_get_l2_eth_hdr(struct bf_program *program);
  * @param program Program to emit instructions into.
  * @return 0 on success, or negative errno value on error.
  */
-int bf_stub_get_l3_ipv4_hdr(struct bf_program *program);
+int bf_stub_parse_l3_hdr(struct bf_program *program);
 
 /**
  * @brief Emit instructions to get a dynptr slice for the packet's L4 header.
@@ -125,4 +125,4 @@ int bf_stub_get_l3_ipv4_hdr(struct bf_program *program);
  * @param program Program to emit instructions into.
  * @return 0 on success, or negative errno value on error.
  */
-int bf_stub_get_l4_hdr(struct bf_program *program);
+int bf_stub_parse_l4_hdr(struct bf_program *program);

--- a/src/generator/swich.c
+++ b/src/generator/swich.c
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/swich.h"
+
+#include "generator/jmp.h"
+#include "generator/program.h"
+#include "shared/helper.h"
+
+/// Cleanup attribute for a @ref bf_swich_option variable.
+#define _cleanup_bf_swich_option_                                              \
+    __attribute__((cleanup(_bf_swich_option_free)))
+
+/**
+ * @struct bf_swich_option
+ *
+ * Represent a @c case of the switch: contains the instructions to execute if
+ * the switch's register is equal to a specific value.
+ */
+struct bf_swich_option
+{
+    /// Immediate value to match against the switch's register.
+    uint32_t imm;
+    /// Jump context used to jump from the comparison to the bytecode to
+    /// execute, then to the end of the switch.
+    struct bf_jmpctx jmp;
+    /// Number of instructions for this option.
+    size_t insns_len;
+    /// Instructions to execute, as a flexible array member.
+    struct bpf_insn insns[];
+};
+
+static void _bf_swich_option_free(struct bf_swich_option **option);
+
+/**
+ * Allocate and initialize a new switch option (case).
+ *
+ * @param option Switch option to allocate and initialize. Can't be NULL.
+ * @param imm Immediate value to match against the switch's register.
+ * @param insns Instructions to execute if the option matches.
+ * @param insns_len Number of instructions in @p insns .
+ * @return 0 on success, or negative errno value on failure.
+ */
+static int _bf_swich_option_new(struct bf_swich_option **option, uint32_t imm,
+                                const struct bpf_insn *insns, size_t insns_len)
+{
+    _cleanup_bf_swich_option_ struct bf_swich_option *_option = NULL;
+
+    bf_assert(option);
+    bf_assert(insns);
+
+    _option = malloc(sizeof(*_option) + sizeof(struct bpf_insn) * insns_len);
+    if (!_option)
+        return -ENOMEM;
+
+    _option->imm = imm;
+    _option->insns_len = insns_len;
+    memcpy(_option->insns, insns, sizeof(struct bpf_insn) * insns_len);
+
+    *option = TAKE_PTR(_option);
+
+    return 0;
+}
+
+/**
+ * Free a switch option.
+ *
+ * Free @p option is it points to valid memory. If @p option points to a NULL
+ * pointer, nothing is done.
+ *
+ * @param option Option to free. Can't be NULL.
+ */
+static void _bf_swich_option_free(struct bf_swich_option **option)
+{
+    bf_assert(option);
+
+    if (!*option)
+        return;
+
+    free(*option);
+    *option = NULL;
+}
+
+int bf_swich_init(struct bf_swich *swich, struct bf_program *program,
+                  enum bf_reg reg)
+{
+    bf_assert(swich);
+    bf_assert(program);
+
+    swich->program = program;
+    swich->reg = reg;
+
+    bf_list_init(
+        &swich->options,
+        (bf_list_ops[]) {{.free = (bf_list_ops_free)_bf_swich_option_free}});
+
+    swich->default_opt = NULL;
+
+    return 0;
+}
+
+void bf_swich_cleanup(struct bf_swich *swich)
+{
+    bf_assert(swich);
+
+    bf_list_clean(&swich->options);
+    _bf_swich_option_free(&swich->default_opt);
+    free(swich->default_opt);
+}
+
+int bf_swich_add_option(struct bf_swich *swich, uint32_t imm,
+                        const struct bpf_insn *insns, size_t insns_len)
+{
+    _cleanup_bf_swich_option_ struct bf_swich_option *option = NULL;
+    int r;
+
+    bf_assert(swich);
+    bf_assert(insns);
+
+    r = _bf_swich_option_new(&option, imm, insns, insns_len);
+    if (r)
+        return r;
+
+    r = bf_list_add_tail(&swich->options, option);
+    if (r)
+        return r;
+
+    TAKE_PTR(option);
+
+    return 0;
+}
+
+int bf_swich_set_default(struct bf_swich *swich, const struct bpf_insn *insns,
+                         size_t insns_len)
+{
+    _cleanup_bf_swich_option_ struct bf_swich_option *option = NULL;
+    int r;
+
+    bf_assert(swich);
+    bf_assert(insns);
+
+    if (swich->default_opt) {
+        bf_warn("default bf_swich option already exists, replacing it");
+        _bf_swich_option_free(&swich->default_opt);
+    }
+
+    r = _bf_swich_option_new(&option, 0, insns, insns_len);
+    if (r)
+        return r;
+
+    swich->default_opt = TAKE_PTR(option);
+
+    return 0;
+}
+
+int bf_swich_generate(struct bf_swich *swich)
+{
+    struct bf_program *program = swich->program;
+
+    // Match an option against the value and jump to the related bytecode
+    bf_list_foreach (&swich->options, option_node) {
+        struct bf_swich_option *option = bf_list_node_get_data(option_node);
+
+        option->jmp = bf_jmpctx_get(
+            program, BPF_JMP_IMM(BPF_JEQ, swich->reg, option->imm, 0));
+    }
+
+    // Insert the default option if any
+    if (swich->default_opt)
+        swich->default_opt->jmp = bf_jmpctx_get(program, BPF_JMP_A(0));
+
+    // Insert each option's bytecode
+    bf_list_foreach (&swich->options, option_node) {
+        struct bf_swich_option *option = bf_list_node_get_data(option_node);
+
+        bf_jmpctx_cleanup(&option->jmp);
+        for (size_t i = 0; i < option->insns_len; ++i)
+            EMIT(program, option->insns[i]);
+        option->jmp = bf_jmpctx_get(program, BPF_JMP_A(0));
+    }
+
+    // Insert the default instructions
+    if (swich->default_opt) {
+        bf_jmpctx_cleanup(&swich->default_opt->jmp);
+        for (size_t i = 0; i < swich->default_opt->insns_len; ++i)
+            EMIT(program, swich->default_opt->insns[i]);
+    }
+
+    bf_list_foreach (&swich->options, option_node) {
+        struct bf_swich_option *option = bf_list_node_get_data(option_node);
+
+        bf_jmpctx_cleanup(&option->jmp);
+    }
+
+    return 0;
+}

--- a/src/generator/swich.h
+++ b/src/generator/swich.h
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "core/list.h"
+#include "generator/reg.h"
+
+/**
+ * @file swich.h
+ *
+ * @ref bf_swich is used to generate a switch-case logic in BPF bytecode, the
+ * logic is the following:
+ * - Create a new @ref bf_swich object and initialize it. Use @ref bf_switch_get
+ * to simplify this step. A @ref bf_switch object contains a pointer to the
+ * generated program, and the register to perform the switch comparison against.
+ * - Call @ref EMIT_SWICH_OPTION to define the various cases for the switch, and
+ * the associated BPF bytecode to run.
+ * - Call @ref EMIT_DEFAULT_OPTION to define the default case of the switch,
+ * this is optional.
+ * - Call @ref bf_swich_generate to generate the BPF bytecode for the switch.
+ *
+ * Once @ref bf_swich_generate has been called, this is what the switch
+ * structure will look like in BPF bytecode:
+ * @code{.c}
+ *  if case 1 matches REG, jump to case 1 code
+ *  if case 2 matches REG, jump to case 2 code
+ *  else jump to default code
+ *  case 1 code
+ *      jump after the switch
+ *  case 2 code
+ *      jump after the switch
+ *  default code
+ * @endcode
+ *
+ * @note
+ * I am fully aware it's supposed to be spelled @c switch and not @c swich , but
+ * both @c switch and @c case are reserved keywords in C, so I had to come
+ * up with a solution to avoid clashes, and @c swich could be pronounced
+ * similarly to @c switch , at least to my non-native speak ear.
+ */
+
+struct bf_program;
+
+/// Cleanup attribute for a @ref bf_swich variable.
+#define _cleanup_bf_swich_ __attribute__((cleanup(bf_swich_cleanup)))
+
+/**
+ * @brief Create, initialize, and return a new @ref bf_swich object.
+ *
+ * @param program @ref bf_program object to create the switch in.
+ * @param reg Register to use to compare the cases values to.
+ * @return A new @ref bf_swich object.
+ */
+#define bf_swich_get(program, reg)                                             \
+    ({                                                                         \
+        struct bf_swich __swich = {};                                          \
+        int __r = bf_swich_init(&__swich, (program), (reg));                   \
+        if (__r)                                                               \
+            return __r;                                                        \
+        __swich;                                                               \
+    })
+
+/**
+ * @brief Add a case to the @ref bf_swich
+ *
+ * @param swich Pointer to a valid @ref bf_swich .
+ * @param imm Immediate value to compare against the switch's register.
+ * @param ... BPF instructions to execute if the case matches.
+ */
+#define EMIT_SWICH_OPTION(swich, imm, ...)                                     \
+    do {                                                                       \
+        const struct bpf_insn __insns[] = {__VA_ARGS__};                       \
+        int __r =                                                              \
+            bf_swich_add_option((swich), (imm), __insns, ARRAY_SIZE(__insns)); \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+    } while (0)
+
+/**
+ * @brief Set the default instruction if no cases of the switch matches the
+ * register.
+ *
+ * Defining a default option to a @ref bf_swich is optional. If this macro is
+ * called twice, the existing default options will be replaced by the new ones.
+ *
+ * @param swich Pointer to a valid @ref bf_swich .
+ * @param ... BPF instructions to execute if no case matches.
+ */
+#define EMIT_SWICH_DEFAULT(swich, ...)                                         \
+    do {                                                                       \
+        const struct bpf_insn __insns[] = {__VA_ARGS__};                       \
+        int __r = bf_swich_set_default((swich), __insns, ARRAY_SIZE(__insns)); \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+    } while (0)
+
+/**
+ * @struct bf_swich
+ *
+ * Context used to define a switch-case structure in BPF bytecode.
+ */
+struct bf_swich
+{
+    /// Program to generate the switch-case in.
+    struct bf_program *program;
+    /// Register to compare to the various cases of the switch.
+    enum bf_reg reg;
+    /// List of options (cases) for the switch.
+    bf_list options;
+    /// Default option, if no case matches the switch's register.
+    struct bf_swich_option *default_opt;
+};
+
+/**
+ * Initialise a @ref bf_swich object.
+ *
+ * @param swich @ref bf_swich object to initialize, can't be NULL.
+ * @param program @ref bf_program object to generate the switch-case for. Can't
+ * be NULL.
+ * @param reg Register to compare to the cases of the switch.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_swich_init(struct bf_swich *swich, struct bf_program *program,
+                  enum bf_reg reg);
+
+/**
+ * Cleanup a @ref bf_switch object.
+ *
+ * Once this function returns, the @p swich object can be reused by calling
+ * @ref bf_swich_init .
+ *
+ * @param swich The @ref bf_switch object to clean up.
+ */
+void bf_swich_cleanup(struct bf_swich *swich);
+
+/**
+ * Add an option (case) to the switch object.
+ *
+ * @param swich @ref bf_swich object to add the option to. Can't be NULL.
+ * @param imm Immediate value to compare the switch's register to. If the
+ * values are equal, the option's instructions are executed.
+ * @param insns Array of BPF instructions to execute if the case matches.
+ * @param insns_len Number of instructions in @p insns .
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_swich_add_option(struct bf_swich *swich, uint32_t imm,
+                        const struct bpf_insn *insns, size_t insns_len);
+
+/**
+ * Set the switch's default actions if no case matches.
+ *
+ * @param swich @ref bf_swich object to set the default action for. Can't be
+ * NULL.
+ * @param insns Array of BPF instructions to execute.
+ * @param insns_len Number of instructions in @p insns .
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_swich_set_default(struct bf_swich *swich, const struct bpf_insn *insns,
+                         size_t insns_len);
+
+/**
+ * Generate the bytecode for the switch.
+ *
+ * The BPF program doesn't contain any of the instructions of the @ref bf_swich
+ * until this function is called.
+ *
+ * @param swich @ref bf_swich object to generate the bytecode for. Can't be
+ * NULL.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_swich_generate(struct bf_swich *swich);

--- a/src/generator/tc.c
+++ b/src/generator/tc.c
@@ -70,15 +70,15 @@ static int _tc_gen_inline_prologue(struct bf_program *program)
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 
-    r = bf_stub_get_l2_eth_hdr(program);
+    r = bf_stub_parse_l2_ethhdr(program);
     if (r)
         return r;
 
-    r = bf_stub_get_l3_ipv4_hdr(program);
+    r = bf_stub_parse_l3_hdr(program);
     if (r)
         return r;
 
-    r = bf_stub_get_l4_hdr(program);
+    r = bf_stub_parse_l4_hdr(program);
     if (r)
         return r;
 

--- a/src/generator/xdp.c
+++ b/src/generator/xdp.c
@@ -77,15 +77,15 @@ static int _xdp_gen_inline_prologue(struct bf_program *program)
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 
-    r = bf_stub_get_l2_eth_hdr(program);
+    r = bf_stub_parse_l2_ethhdr(program);
     if (r)
         return r;
 
-    r = bf_stub_get_l3_ipv4_hdr(program);
+    r = bf_stub_parse_l3_hdr(program);
     if (r)
         return r;
 
-    r = bf_stub_get_l4_hdr(program);
+    r = bf_stub_parse_l4_hdr(program);
     if (r)
         return r;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -95,6 +95,7 @@ set(bf_test_srcs
     src/generator/nf.c
     src/generator/printer.c
     src/generator/program.c
+    src/generator/swich.c
     src/xlate/nft/nft.c
     src/xlate/nft/nfmsg.c
     src/xlate/nft/nfgroup.c


### PR DESCRIPTION
This PR refactors the generation of the bytecode used to parse a packet's content, in order to prepare for the program's matchers to be used. It consists in:
- Introduce `bf_swich` to emulate a switch-like functionality in BPF bytecode (with doc and unit tests).
- Refactor packet pre-processing: uses `bf_swich` to simplify protocol detection, reorder instructions for more clarity.
- Reorder and cleanup pre-processed packet data located in the runtime context