### PR TITLE
doc: clarify Ubuntu 22.04 LTW HWE situation

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -3,7 +3,10 @@ Build from sources
 
 This document describes the process to build ``bpfilter`` from sources. While `bpfilter` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon.
 
-``bpfilter`` development is mostly done using Fedora (38 and 39), but Ubuntu (23.10+) is also officially supported. Other distributions may work as long as Linux 6.4+ is available, but they are not officially supported at the moment.
+``bpfilter`` development is mostly done using Fedora (40, but 38+ supported), but Ubuntu (23.10+) is also officially supported. Other distributions may work as long as Linux 6.4+ is available, but they are not officially supported at the moment.
+
+.. note::
+    Ubuntu 22.04 LTS allows for Linux 6.5 to be installed through its Hardware Enablement Stack (HWE). However, this feature only allows for the kernel and the headers **used to build the kernel modules** to be installed in v6.5. The main system kernel headers, located in ``/usr/include``, used to build userspace application, are still in the non-HWE version. This means Ubuntu 22.04 LTS is not supported by ``bpfilter``, even with the HWE stack.
 
 Required dependencies on Fedora and Ubuntu:
 


### PR DESCRIPTION
Ubuntu 22.04 can't be used to build bpfilter, even though its HWE stack allows for Linux 6.5 to be installed: kernel headers used to build kernel modules are updated to 6.5, but the system headers, used by userspace application, remain in v5.15.