### PR TITLE
build: add Ubuntu 24.04 and Fedora 40 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         arch: ["X64", "ARM64"]
         mode: ["release", "debug"]
-    container: "fedora:39"
+    container: "fedora:40"
     runs-on: [self-hosted, "${{ matrix.arch }}"]
     steps:
       - name: Check out repository code
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["fedora:38", "ubuntu:23.10"]
+        image: ["fedora:38", "fedora:39", "ubuntu:23.10", "ubuntu:24.04"]
         arch: ["X64", "ARM64"]
     container: ${{ matrix.image }}
     runs-on: [self-hosted, "${{ matrix.arch }}"]
@@ -76,7 +76,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install dependencies (Fedora)
-        if: matrix.image == 'fedora:38'
+        if: ${{ (matrix.image == 'fedora:38') || (matrix.image == 'fedora:39') }}
         run: |
           sudo dnf --disablerepo=* --enablerepo=fedora,updates --setopt=install_weak_deps=False -y install \
             bpftool \
@@ -96,7 +96,7 @@ jobs:
             python3-sphinx \
             pkgconf
       - name: Install dependencies (Ubuntu)
-        if: matrix.image == 'ubuntu:23.10'
+        if: ${{ (matrix.image == 'ubuntu:23.10') || (matrix.image == 'ubuntu:24.04') }}
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install \

--- a/.github/workflows/fork.yaml
+++ b/.github/workflows/fork.yaml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # This forces GitHub to print "fedora:39, x64" in the job name.
-        system: ["fedora:39"]
+        # This forces GitHub to print "fedora:40, x64" in the job name.
+        system: ["fedora:40"]
         arch: ["X64"]
         mode: ["release", "debug"]
     container: "${{ matrix.system }}"

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   deploy:
     if: github.repository == 'facebook/bpfilter'
-    container: "fedora:39"
+    container: "fedora:40"
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages


### PR DESCRIPTION
Run CI on Ubuntu 24.04 and Fedora 40, in addition to existing distros. Use Fedora 40 as default runner.