### PR TITLE
Add `assert_success()` and `assert_error()` to check a function's return value

### DIFF
--- a/src/core/context.c
+++ b/src/core/context.c
@@ -57,7 +57,8 @@ static int _bf_context_new(struct bf_context **context)
  * @param marsh Serialised data to use to initialise the context.
  * @return 0 on success, or negative errno value on failure.
  */
-static int _bf_context_new_from_marsh(struct bf_context **context, const struct bf_marsh *marsh)
+static int _bf_context_new_from_marsh(struct bf_context **context,
+                                      const struct bf_marsh *marsh)
 {
     _cleanup_bf_context_ struct bf_context *_context = NULL;
     struct bf_marsh *child = NULL;
@@ -147,12 +148,12 @@ static void _bf_context_dump(const struct bf_context *context, prefix_t *prefix)
     DUMP(prefix, "struct bf_context at %p", context);
 
     bf_dump_prefix_push(prefix);
-    
+
     DUMP(prefix, "printer: struct bf_printer *");
     bf_dump_prefix_push(prefix);
     bf_printer_dump(context->printer, bf_dump_prefix_last(prefix));
     bf_dump_prefix_pop(prefix);
-    
+
     DUMP(bf_dump_prefix_last(prefix), "codegens: bf_codegen[%d][%d]",
          _BF_HOOK_MAX, _BF_FRONT_MAX);
     bf_dump_prefix_push(prefix);

--- a/src/core/dump.h
+++ b/src/core/dump.h
@@ -34,9 +34,10 @@
  * @param byte Byte to split.
  */
 #define BIN_SPLIT(byte)                                                        \
-    (((byte)&0x80) + 0x30), (((byte)&0x40) + 0x30), (((byte)&0x20) + 0x30),    \
-        (((byte)&0x10) + 0x30), (((byte)&0x08) + 0x30),                        \
-        (((byte)&0x04) + 0x30), (((byte)&0x02) + 0x30), (((byte)&0x01) + 0x30)
+    (((byte) & 0x80) + 0x30), (((byte) & 0x40) + 0x30),                        \
+        (((byte) & 0x20) + 0x30), (((byte) & 0x10) + 0x30),                    \
+        (((byte) & 0x08) + 0x30), (((byte) & 0x04) + 0x30),                    \
+        (((byte) & 0x02) + 0x30), (((byte) & 0x01) + 0x30)
 
 /// Format to use with BIN_SPLIT() to print a byte as 8 bits.
 #define BIN_FMT "%c%c%c%c%c%c%c%c"

--- a/tests/unit/harness/cmocka.h
+++ b/tests/unit/harness/cmocka.h
@@ -25,3 +25,4 @@
     __attribute__((section(".bf_test"))) void group##__##name(bf_unused void **state)
 
 #define assert_error(x) assert_int_not_equal(0, (x))
+#define assert_success(x) assert_int_equal(0, (x))

--- a/tests/unit/harness/cmocka.h
+++ b/tests/unit/harness/cmocka.h
@@ -23,3 +23,5 @@
 
 #define Test(group, name)                                                      \
     __attribute__((section(".bf_test"))) void group##__##name(bf_unused void **state)
+
+#define assert_error(x) assert_int_not_equal(0, (x))

--- a/tests/unit/src/core/btf.c
+++ b/tests/unit/src/core/btf.c
@@ -10,7 +10,7 @@
 
 Test(btf, init)
 {
-    assert_int_equal(0, bf_btf_setup());
+    assert_success(bf_btf_setup());
     assert_non_null(_btf);
 
     bf_btf_teardown();
@@ -28,9 +28,9 @@ Test(btf, failed_init)
 
 Test(btf, get_field_offset)
 {
-    assert_int_equal(0, bf_btf_setup());
+    assert_success(bf_btf_setup());
 
-    assert_int_equal(0, bf_btf_get_field_off("iphdr", "ihl"));
+    assert_success(bf_btf_get_field_off("iphdr", "ihl"));
     assert_int_equal(9, bf_btf_get_field_off("iphdr", "protocol"));
     assert_int_equal(8, bf_btf_get_field_off("bpf_nf_ctx", "skb"));
 

--- a/tests/unit/src/core/btf.c
+++ b/tests/unit/src/core/btf.c
@@ -22,7 +22,7 @@ Test(btf, failed_init)
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(btf__load_vmlinux_btf, NULL);
 
     assert_null(_btf);
-    assert_int_not_equal(0, bf_btf_setup());
+    assert_error(bf_btf_setup());
     assert_null(_btf);
 }
 

--- a/tests/unit/src/core/helper.c
+++ b/tests/unit/src/core/helper.c
@@ -90,8 +90,8 @@ Test(helper, write_and_read_file)
     _cleanup_free_ char *read_data = NULL;
     size_t read_len;
 
-    assert_int_equal(0, bf_write_file(filepath, content, strlen(content)));
-    assert_int_equal(0, bf_read_file(filepath, (void **)&read_data, &read_len));
+    assert_success(bf_write_file(filepath, content, strlen(content)));
+    assert_success(bf_read_file(filepath, (void **)&read_data, &read_len));
     assert_int_equal(strlen(content), read_len);
     assert_int_equal(0, memcmp(content, read_data, read_len));
 }

--- a/tests/unit/src/core/list.c
+++ b/tests/unit/src/core/list.c
@@ -53,10 +53,10 @@ static int dummy_filler_tail(bf_list *l, void *data)
 static void new_and_fill(bf_list **l, size_t count, const bf_list_ops *ops,
                          int (*filler)(bf_list *l, void *data))
 {
-    assert_int_equal(0, bf_list_new(l, ops));
+    assert_success(bf_list_new(l, ops));
 
     for (size_t i = 1; i <= count; ++i)
-        assert_int_equal(0, filler(*l, &i));
+        assert_success(filler(*l, &i));
 
     assert_int_equal(count, bf_list_size(*l));
 }
@@ -67,7 +67,7 @@ static void init_and_fill(bf_list *l, size_t count, const bf_list_ops *ops,
     bf_list_init(l, ops);
 
     for (size_t i = 1; i <= count; ++i)
-        assert_int_equal(0, filler(l, &i));
+        assert_success(filler(l, &i));
 
     assert_int_equal(count, bf_list_size(l));
 }
@@ -86,7 +86,7 @@ Test(list, new_and_free)
 
     {
         // With noop operators
-        assert_int_equal(0, bf_list_new(&l, &noop_ops));
+        assert_success(bf_list_new(&l, &noop_ops));
         assert_int_equal(0, l->len);
         assert_null(l->head);
         assert_null(l->tail);

--- a/tests/unit/src/core/marsh.c
+++ b/tests/unit/src/core/marsh.c
@@ -19,7 +19,7 @@ Test(marsh, new)
         // Create a new empty marsh.
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
         assert_int_equal(0, marsh->data_len);
         assert_int_equal(sizeof(struct bf_marsh), bf_marsh_size(marsh));
     }
@@ -29,7 +29,7 @@ Test(marsh, new)
         int a = 3;
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, &a, 0));
+        assert_success(bf_marsh_new(&marsh, &a, 0));
         assert_int_equal(0, marsh->data_len);
         assert_int_equal(sizeof(struct bf_marsh), bf_marsh_size(marsh));
     }
@@ -39,7 +39,7 @@ Test(marsh, new)
         int a = 3;
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, &a, sizeof(a)));
+        assert_success(bf_marsh_new(&marsh, &a, sizeof(a)));
         assert_int_equal(sizeof(a), marsh->data_len);
         assert_int_equal(sizeof(struct bf_marsh) + sizeof(a),
                          bf_marsh_size(marsh));
@@ -66,15 +66,15 @@ Test(marsh, add_child_obj)
     _cleanup_bf_marsh_ struct bf_marsh *child0 = NULL;
     _cleanup_bf_marsh_ struct bf_marsh *child1 = NULL;
 
-    assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-    assert_int_equal(0, bf_marsh_new(&child0, NULL, 0));
-    assert_int_equal(0, bf_marsh_new(&child1, NULL, 0));
+    assert_success(bf_marsh_new(&marsh, NULL, 0));
+    assert_success(bf_marsh_new(&child0, NULL, 0));
+    assert_success(bf_marsh_new(&child1, NULL, 0));
 
-    assert_int_equal(0, bf_marsh_add_child_obj(&marsh, child0));
+    assert_success(bf_marsh_add_child_obj(&marsh, child0));
     assert_int_equal(bf_marsh_size(child0), marsh->data_len);
     assert_int_equal(0, memcmp(child0, marsh->data, marsh->data_len));
 
-    assert_int_equal(0, bf_marsh_add_child_obj(&marsh, child1));
+    assert_success(bf_marsh_add_child_obj(&marsh, child1));
     assert_int_equal(bf_marsh_size(child0) + bf_marsh_size(child1),
                      marsh->data_len);
     assert_int_equal(0, memcmp(child1, marsh->data + bf_marsh_size(child0),
@@ -90,9 +90,9 @@ Test(marsh, add_child_raw)
     const char *child1_str = "hello";
     const char *child2_str = "world";
 
-    assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
+    assert_success(bf_marsh_new(&marsh, NULL, 0));
 
-    assert_int_equal(0, bf_marsh_add_child_raw(&marsh, NULL, 0));
+    assert_success(bf_marsh_add_child_raw(&marsh, NULL, 0));
     assert_int_equal(sizeof(struct bf_marsh), marsh->data_len);
 
     assert_int_equal(
@@ -125,7 +125,7 @@ Test(marsh, next_child)
         // Empty marsh.
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
         assert_null(bf_marsh_next_child(marsh, NULL));
     }
 
@@ -135,9 +135,9 @@ Test(marsh, next_child)
         struct bf_marsh *child;
         const char *str = "hello, world";
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, str, 2));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, &str[2], 3));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_add_child_raw(&marsh, str, 2));
+        assert_success(bf_marsh_add_child_raw(&marsh, &str[2], 3));
 
         assert_non_null(child = bf_marsh_next_child(marsh, NULL));
         assert_non_null(child = bf_marsh_next_child(marsh, child));
@@ -151,9 +151,9 @@ Test(marsh, next_child)
         struct bf_marsh *child1;
         const char *str = "hello, world";
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, str, 2));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, &str[2], 3));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_add_child_raw(&marsh, str, 2));
+        assert_success(bf_marsh_add_child_raw(&marsh, &str[2], 3));
 
         assert_non_null(child0 = bf_marsh_next_child(marsh, NULL));
         assert_non_null(child1 = bf_marsh_next_child(marsh, child0));
@@ -181,7 +181,7 @@ Test(marsh, child_assert_failure)
         // have a valid marsh.
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
         expect_assert_failure(bf_marsh_add_child_obj(&marsh, NULL));
     }
 
@@ -190,7 +190,7 @@ Test(marsh, child_assert_failure)
         // have a valid marsh.
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
         expect_assert_failure(bf_marsh_add_child_raw(&marsh, NULL, 1));
     }
 }
@@ -201,8 +201,8 @@ Test(marsh, child_is_valid)
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child0;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, "hello", 6));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_add_child_raw(&marsh, "hello", 6));
         assert_non_null(child0 = bf_marsh_next_child(marsh, NULL));
 
         assert_int_equal(0, bf_marsh_child_is_valid(marsh, NULL));
@@ -226,8 +226,8 @@ Test(marsh, child_is_valid)
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child0;
 
-        assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-        assert_int_equal(0, bf_marsh_add_child_raw(&marsh, NULL, 0));
+        assert_success(bf_marsh_new(&marsh, NULL, 0));
+        assert_success(bf_marsh_add_child_raw(&marsh, NULL, 0));
         assert_non_null(child0 = bf_marsh_next_child(marsh, NULL));
         assert_int_equal(child0, marsh->data);
         assert_int_equal(bf_marsh_end(child0), bf_marsh_end(marsh));
@@ -239,8 +239,8 @@ Test(marsh, add_child_obj_failure)
     _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
     _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
 
-    assert_int_equal(0, bf_marsh_new(&marsh, NULL, 0));
-    assert_int_equal(0, bf_marsh_new(&child, NULL, 0));
+    assert_success(bf_marsh_new(&marsh, NULL, 0));
+    assert_success(bf_marsh_new(&child, NULL, 0));
 
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
     assert_true(bf_marsh_add_child_obj(&marsh, child) < 0);

--- a/tests/unit/src/core/matcher.c
+++ b/tests/unit/src/core/matcher.c
@@ -34,7 +34,7 @@ Test(matcher, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
         struct bf_matcher *matcher;
 
-        assert_int_not_equal(0, bf_matcher_new(&matcher, 0, 0, NULL, 0));
+        assert_error(bf_matcher_new(&matcher, 0, 0, NULL, 0));
     }
 
     // malloc failure with payload
@@ -77,7 +77,7 @@ Test(matcher, marsh_unmarsh)
             0, bf_matcher_new(&matcher0, 1, 2, payload, sizeof(payload)));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
-        assert_int_not_equal(0, bf_matcher_marsh(matcher0, &marsh));
+        assert_error(bf_matcher_marsh(matcher0, &marsh));
     }
 
     // Failed deserialisation
@@ -92,7 +92,7 @@ Test(matcher, marsh_unmarsh)
         assert_int_equal(0, bf_matcher_marsh(matcher0, &marsh));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
-        assert_int_not_equal(0, bf_matcher_new_from_marsh(&matcher1, marsh));
+        assert_error(bf_matcher_new_from_marsh(&matcher1, marsh));
     }
 }
 

--- a/tests/unit/src/core/matcher.c
+++ b/tests/unit/src/core/matcher.c
@@ -21,7 +21,7 @@ Test(matcher, new_and_free)
     {
         _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
 
-        assert_int_equal(0, bf_matcher_new(&matcher, 0, 0, NULL, 0));
+        assert_success(bf_matcher_new(&matcher, 0, 0, NULL, 0));
         bf_matcher_free(&matcher);
         assert_null(matcher);
 
@@ -64,8 +64,8 @@ Test(matcher, marsh_unmarsh)
 
         assert_int_equal(
             0, bf_matcher_new(&matcher0, 1, 2, payload, sizeof(payload)));
-        assert_int_equal(0, bf_matcher_marsh(matcher0, &marsh));
-        assert_int_equal(0, bf_matcher_new_from_marsh(&matcher1, marsh));
+        assert_success(bf_matcher_marsh(matcher0, &marsh));
+        assert_success(bf_matcher_new_from_marsh(&matcher1, marsh));
     }
 
     // Failed serialisation
@@ -89,7 +89,7 @@ Test(matcher, marsh_unmarsh)
 
         assert_int_equal(
             0, bf_matcher_new(&matcher0, 1, 2, payload, sizeof(payload)));
-        assert_int_equal(0, bf_matcher_marsh(matcher0, &marsh));
+        assert_success(bf_matcher_marsh(matcher0, &marsh));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
         assert_error(bf_matcher_new_from_marsh(&matcher1, marsh));

--- a/tests/unit/src/core/rule.c
+++ b/tests/unit/src/core/rule.c
@@ -66,7 +66,7 @@ Test(rule, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         struct bf_rule *rule;
 
-        assert_int_not_equal(0, bf_rule_new(&rule));
+        assert_error(bf_rule_new(&rule));
     }
 }
 
@@ -103,6 +103,6 @@ Test(rule, marsh_unmarsh)
         assert_int_equal(0, _create_dummy_rule(&rule));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
-        assert_int_not_equal(0, bf_rule_marsh(rule, &marsh));
+        assert_error(bf_rule_marsh(rule, &marsh));
     }
 }

--- a/tests/unit/src/core/rule.c
+++ b/tests/unit/src/core/rule.c
@@ -53,12 +53,12 @@ Test(rule, new_and_free)
     {
         _cleanup_bf_rule_ struct bf_rule *rule = NULL;
 
-        assert_int_equal(0, bf_rule_new(&rule));
+        assert_success(bf_rule_new(&rule));
         bf_rule_free(&rule);
         assert_null(rule);
         bf_rule_free(&rule);
 
-        assert_int_equal(0, bf_rule_new(&rule));
+        assert_success(bf_rule_new(&rule));
     }
 
     // malloc failure
@@ -84,8 +84,8 @@ Test(rule, marsh_unmarsh)
         _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_int_equal(0, _create_dummy_rule(&rule0));
-        assert_int_equal(0, bf_rule_marsh(rule0, &marsh));
-        assert_int_equal(0, bf_rule_unmarsh(marsh, &rule1));
+        assert_success(bf_rule_marsh(rule0, &marsh));
+        assert_success(bf_rule_unmarsh(marsh, &rule1));
 
         assert_int_equal(rule0->index, rule1->index);
         assert_int_equal(rule0->ifindex, rule1->ifindex);

--- a/tests/unit/src/generator/printer.c
+++ b/tests/unit/src/generator/printer.c
@@ -39,7 +39,7 @@ Test(printer, msg_lifetime)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         struct bf_printer_msg *msg = NULL;
 
-        assert_int_not_equal(_bf_printer_msg_new(&msg), 0);
+        assert_error(_bf_printer_msg_new(&msg));
         assert_ptr_equal(msg, NULL);
     }
 }
@@ -101,7 +101,7 @@ Test(printer, printer_lifetime)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(malloc, NULL);
         struct bf_printer *printer = NULL;
 
-        assert_int_not_equal(bf_printer_new(&printer), 0);
+        assert_error(bf_printer_new(&printer));
         assert_ptr_equal(printer, NULL);
     }
 }
@@ -163,5 +163,5 @@ Test(printer, printer_marsh_unmarsh_failed_map_fd_open)
 
     // Serialise and deserialise the printer
     assert_int_equal(bf_printer_marsh(printer0, &marsh), 0);
-    assert_int_not_equal(bf_printer_new_from_marsh(&printer1, marsh), 0);
+    assert_error(bf_printer_new_from_marsh(&printer1, marsh));
 }

--- a/tests/unit/src/generator/swich.c
+++ b/tests/unit/src/generator/swich.c
@@ -50,7 +50,7 @@ Test(swich, init_and_cleanup)
     expect_assert_failure(bf_swich_init(NOT_NULL, NULL, 0));
     expect_assert_failure(bf_swich_cleanup(NULL));
 
-    assert_int_equal(0, bf_swich_init(&swich, NOT_NULL, 0));
+    assert_success(bf_swich_init(&swich, NOT_NULL, 0));
     bf_swich_cleanup(&swich);
     assert_true(bf_list_is_empty(&swich.options));
 }
@@ -68,13 +68,13 @@ Test(swich, generate_swich)
         _cleanup_bf_program_ struct bf_program *program = NULL;
         _cleanup_bf_swich_ struct bf_swich swich;
 
-        assert_int_equal(0, bf_program_new(&program, 1, 0, 0));
-        assert_int_equal(0, bf_swich_init(&swich, program, 0));
+        assert_success(bf_program_new(&program, 1, 0, 0));
+        assert_success(bf_swich_init(&swich, program, 0));
 
         for (int i = 0; i < 3; ++i)
-            assert_int_equal(0, bf_swich_add_option(&swich, i, insns, i + 1));
+            assert_success(bf_swich_add_option(&swich, i, insns, i + 1));
 
-        assert_int_equal(0, bf_swich_generate(&swich));
+        assert_success(bf_swich_generate(&swich));
         assert_int_equal(12, program->img_size);
         bf_swich_cleanup(&swich);
     }
@@ -84,16 +84,16 @@ Test(swich, generate_swich)
         _cleanup_bf_program_ struct bf_program *program = NULL;
         _cleanup_bf_swich_ struct bf_swich swich;
 
-        assert_int_equal(0, bf_program_new(&program, 1, 0, 0));
-        assert_int_equal(0, bf_swich_init(&swich, program, 0));
+        assert_success(bf_program_new(&program, 1, 0, 0));
+        assert_success(bf_swich_init(&swich, program, 0));
 
         for (int i = 0; i < 3; ++i)
-            assert_int_equal(0, bf_swich_add_option(&swich, i, insns, i + 1));
+            assert_success(bf_swich_add_option(&swich, i, insns, i + 1));
 
-        assert_int_equal(0, bf_swich_set_default(&swich, insns, 3));
-        assert_int_equal(0, bf_swich_set_default(&swich, insns, 3));
+        assert_success(bf_swich_set_default(&swich, insns, 3));
+        assert_success(bf_swich_set_default(&swich, insns, 3));
 
-        assert_int_equal(0, bf_swich_generate(&swich));
+        assert_success(bf_swich_generate(&swich));
         assert_int_equal(16, program->img_size);
         bf_swich_cleanup(&swich);
     }

--- a/tests/unit/src/opts.c
+++ b/tests/unit/src/opts.c
@@ -14,6 +14,6 @@ Test(opts, no_nftables)
     char *opt0[] = {"tests_unit", "--no-nftables"};
 
     _opts.fronts = 0xffff;
-    assert_int_equal(0, bf_opts_init(ARRAY_SIZE(opt0), opt0));
+    assert_success(bf_opts_init(ARRAY_SIZE(opt0), opt0));
     assert(0 == (_opts.fronts & (1 << BF_FRONT_NFT)));
 }

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -22,7 +22,7 @@ Test(nfmsg, new_and_free)
     {
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
         assert_non_null(msg);
         assert_int_equal(NFT_MSG_GETRULE, bf_nfmsg_command(msg));
         assert_int_equal(17, bf_nfmsg_seqnr(msg));
@@ -32,7 +32,7 @@ Test(nfmsg, new_and_free)
     {
         struct bf_nfmsg *msg = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
         assert_non_null(msg);
         assert_int_equal(NFT_MSG_GETRULE, bf_nfmsg_command(msg));
         assert_int_equal(17, bf_nfmsg_seqnr(msg));
@@ -82,7 +82,7 @@ Test(nfmsg, new_done)
     {
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new_done(&msg));
+        assert_success(bf_nfmsg_new_done(&msg));
         assert_non_null(msg);
     }
 
@@ -129,7 +129,7 @@ Test(nfmsg, new_from_nlmsghdr)
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
         assert_int_equal(0,
                          bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
         assert_int_equal(bf_nfmsg_command(msg0), bf_nfmsg_command(msg1));
@@ -142,7 +142,7 @@ Test(nfmsg, new_from_nlmsghdr)
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
         bf_nfmsg_hdr(msg0)->nlmsg_type = 0;
         assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
@@ -151,7 +151,7 @@ Test(nfmsg, new_from_nlmsghdr)
         // calloc failed
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
@@ -163,7 +163,7 @@ Test(nfmsg, new_from_nlmsghdr)
         // nlmsg_convert failed
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
 
-        assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
+        assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
 
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_convert, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
@@ -189,33 +189,33 @@ Test(nfmsg, write_attributes)
     expect_assert_failure(bf_nfmsg_nest_init(NULL, NOT_NULL, 0));
     expect_assert_failure(bf_nfmsg_nest_init(NOT_NULL, NULL, 0));
 
-    assert_int_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
-    assert_int_equal(0, bf_nfmsg_push_u8(msg, 0, 0));
-    assert_int_equal(0, bf_nfmsg_push_u16(msg, 1, 1));
-    assert_int_equal(0, bf_nfmsg_push_u32(msg, 2, 2));
-    assert_int_equal(0, bf_nfmsg_push_u64(msg, 3, 3));
-    assert_int_equal(0, bf_nfmsg_push_str(msg, 4, "4"));
+    assert_success(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+    assert_success(bf_nfmsg_push_u8(msg, 0, 0));
+    assert_success(bf_nfmsg_push_u16(msg, 1, 1));
+    assert_success(bf_nfmsg_push_u32(msg, 2, 2));
+    assert_success(bf_nfmsg_push_u64(msg, 3, 3));
+    assert_success(bf_nfmsg_push_str(msg, 4, "4"));
     {
         _cleanup_bf_nfnest_ struct bf_nfnest nest;
 
-        assert_int_equal(0, bf_nfmsg_nest_init(&nest, msg, 5));
-        assert_int_equal(0, bf_nfmsg_push_u8(msg, 0, 0));
-        assert_int_equal(0, bf_nfmsg_push_u16(msg, 1, 1));
-        assert_int_equal(0, bf_nfmsg_push_u32(msg, 2, 2));
-        assert_int_equal(0, bf_nfmsg_push_u64(msg, 3, 3));
-        assert_int_equal(0, bf_nfmsg_push_str(msg, 4, "4"));
+        assert_success(bf_nfmsg_nest_init(&nest, msg, 5));
+        assert_success(bf_nfmsg_push_u8(msg, 0, 0));
+        assert_success(bf_nfmsg_push_u16(msg, 1, 1));
+        assert_success(bf_nfmsg_push_u32(msg, 2, 2));
+        assert_success(bf_nfmsg_push_u64(msg, 3, 3));
+        assert_success(bf_nfmsg_push_str(msg, 4, "4"));
     }
 
     assert_int_equal(
         0, bf_nfmsg_parse(msg, attrs, ARRAY_SIZE(attrs), test_policy));
-    assert_int_equal(0, bf_nfattr_get_u8(attrs[0]));
+    assert_success(bf_nfattr_get_u8(attrs[0]));
     assert_int_equal(1, bf_nfattr_get_u16(attrs[1]));
     assert_int_equal(2, bf_nfattr_get_u32(attrs[2]));
     assert_int_equal(3, bf_nfattr_get_u64(attrs[3]));
     assert_string_equal("4", bf_nfattr_get_str(attrs[4]));
 
-    assert_int_equal(0, bf_nfattr_parse(attrs[5], nested_attrs,
-                                        ARRAY_SIZE(nested_attrs), test_policy));
+    assert_success(bf_nfattr_parse(attrs[5], nested_attrs,
+                                   ARRAY_SIZE(nested_attrs), test_policy));
     assert_int_equal(0, bf_nfattr_get_u8(nested_attrs[0]));
     assert_int_equal(1, bf_nfattr_get_u16(nested_attrs[1]));
     assert_int_equal(2, bf_nfattr_get_u32(nested_attrs[2]));

--- a/tests/unit/src/xlate/nft/nfmsg.c
+++ b/tests/unit/src/xlate/nft/nfmsg.c
@@ -47,7 +47,7 @@ Test(nfmsg, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
 
     {
@@ -55,7 +55,7 @@ Test(nfmsg, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_alloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
 
     {
@@ -63,7 +63,7 @@ Test(nfmsg, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_put, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
 
     {
@@ -71,7 +71,7 @@ Test(nfmsg, new_and_free)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_append, -1);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
+        assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
 }
 
@@ -91,7 +91,7 @@ Test(nfmsg, new_done)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+        assert_error(bf_nfmsg_new_done(&msg));
     }
 
     {
@@ -99,7 +99,7 @@ Test(nfmsg, new_done)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_alloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+        assert_error(bf_nfmsg_new_done(&msg));
     }
 
     {
@@ -107,7 +107,7 @@ Test(nfmsg, new_done)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_put, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+        assert_error(bf_nfmsg_new_done(&msg));
     }
 
     {
@@ -115,7 +115,7 @@ Test(nfmsg, new_done)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_append, -1);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
-        assert_int_not_equal(0, bf_nfmsg_new_done(&msg));
+        assert_error(bf_nfmsg_new_done(&msg));
     }
 }
 
@@ -144,8 +144,7 @@ Test(nfmsg, new_from_nlmsghdr)
 
         assert_int_equal(0, bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
         bf_nfmsg_hdr(msg0)->nlmsg_type = 0;
-        assert_int_not_equal(
-            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+        assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 
     {
@@ -157,8 +156,7 @@ Test(nfmsg, new_from_nlmsghdr)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(calloc, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
-        assert_int_not_equal(
-            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+        assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 
     {
@@ -170,8 +168,7 @@ Test(nfmsg, new_from_nlmsghdr)
         _cleanup_bf_mock_ bf_mock _ = bf_mock_get(nlmsg_convert, NULL);
         _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
-        assert_int_not_equal(
-            0, bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
+        assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 }
 


### PR DESCRIPTION
Shorten `assert_int_not_equal(0, xxx())` with `assert_error(xxx())` and `assert_int_equal(0, xxx())` with `assert_success(xxx())`.