### PR TITLE
Refactor program management

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -8,6 +8,9 @@ This document describes the process to build ``bpfilter`` from sources. While `b
 .. note::
     Ubuntu 22.04 LTS allows for Linux 6.5 to be installed through its Hardware Enablement Stack (HWE). However, this feature only allows for the kernel and the headers **used to build the kernel modules** to be installed in v6.5. The main system kernel headers, located in ``/usr/include``, used to build userspace application, are still in the non-HWE version. This means Ubuntu 22.04 LTS is not supported by ``bpfilter``, even with the HWE stack.
 
+.. note::
+    Ubuntu 23.10 is running Linux 6.5, which is too old to support TCX hooks used by ``bpfilter``. Creating a TCX BPF program with ``bpfilter`` will return an error on Ubuntu 23.10.
+
 Required dependencies on Fedora and Ubuntu:
 
 .. code-block:: shell

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -159,6 +159,25 @@ int bf_bpf_obj_get(const char *path, int *fd)
     return 0;
 }
 
+int bf_bpf_tc_link_create(int prog_fd, int ifindex, enum bpf_attach_type hook,
+                          int *link_fd)
+{
+    union bpf_attr attr = {};
+    int r;
+
+    attr.link_create.prog_fd = prog_fd;
+    attr.link_create.target_fd = ifindex;
+    attr.link_create.attach_type = hook;
+
+    r = _bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    *link_fd = r;
+
+    return 0;
+}
+
 int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
                           int *link_fd)
 {
@@ -201,6 +220,16 @@ int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
 }
 
 int bf_bpf_xdp_link_update(int link_fd, int prog_fd)
+{
+    union bpf_attr attr = {};
+
+    attr.link_update.link_fd = link_fd;
+    attr.link_update.new_prog_fd = prog_fd;
+
+    return _bpf(BPF_LINK_UPDATE, &attr);
+}
+
+int bf_bpf_link_update(int link_fd, int prog_fd)
 {
     union bpf_attr attr = {};
 

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -200,6 +200,16 @@ int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
     return 0;
 }
 
+int bf_bpf_xdp_link_update(int link_fd, int prog_fd)
+{
+    union bpf_attr attr = {};
+
+    attr.link_update.link_fd = link_fd;
+    attr.link_update.new_prog_fd = prog_fd;
+
+    return _bpf(BPF_LINK_UPDATE, &attr);
+}
+
 int bf_bpf_link_detach(int link_fd)
 {
     union bpf_attr attr = {

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -118,6 +118,17 @@ int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
                            enum bf_xdp_attach_mode mode);
 
 /**
+ * Update the program attached to an XDP BPF link.
+ *
+ * The type, interface, or XDP mode of the link are left unchanged.
+ *
+ * @param link_fd File descriptor of the link to update.
+ * @param prog_fd File descriptor of the new program to attach to the link.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_xdp_link_update(int link_fd, int prog_fd);
+
+/**
  * @brief Detach a BPF link using its file descriptor.
  * @param link_fd File descriptor of the link to detach. You can get a file
  *  descriptor using @ref bf_bpf_obj_get.

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -92,6 +92,20 @@ int bf_bpf_obj_pin(const char *path, int fd);
 int bf_bpf_obj_get(const char *path, int *fd);
 
 /**
+ * Create a TC BPF link.
+ *
+ * @param prog_fd File descriptor of the program to attach to the link.
+ * @param ifindex Index of the interface to attach the program to.
+ * @param hook TC hook (BPF_TCX_INGRESS or BPF_TCX_EGRESS) to attach the
+ * program to.
+ * @param link_fd Link file descriptor, only valid if the return value of the
+ * function is 0.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_tc_link_create(int prog_fd, int ifindex, enum bpf_attach_type hook,
+                          int *link_fd);
+
+/**
  * @brief Create a Netfilter BPF link.
  *
  * @param prog_fd File descriptor of the program to attach to the link.
@@ -127,6 +141,18 @@ int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_bpf_xdp_link_update(int link_fd, int prog_fd);
+
+/**
+ * Update the program attached to a BPF link.
+ *
+ * Every configuration of the link remain unchanged, only the linked BPF
+ * program is modified.
+ *
+ * @param link_fd File descriptor of the link to update.
+ * @param prog_fd File descriptor of the new program to attach to the link.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_bpf_link_update(int link_fd, int prog_fd);
 
 /**
  * @brief Detach a BPF link using its file descriptor.

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -117,17 +117,21 @@ struct bf_flavor_ops
     /**
      * Load and attach a BPF program.
      *
-     * @p new_prog is the new program to be attached to the hook, and @p old_prog is the existing one.
+     * @p new_prog is the new program to be attached to the hook, and @p
+     * old_prog is the existing one.
      * @p old_prog can be NULL, if no program is already attached. The exact
-     * load and attach mechanism is up to the flavor: direct attach, BPF link, ...
+     * load and attach mechanism is up to the flavor: direct attach, BPF link,
+     * ...
      *
-     * If @p old_prog is not NULL, the replacement of @p old_prog by @p new_prog must be atomic.
+     * If @p old_prog is not NULL, the replacement of @p old_prog by @p new_prog
+     * must be atomic.
      *
      * @param new_prog New BPF program to attach to the kernel. Can't be NULL.
      * @param old_prog Previous program to replace.
      * @return 0 on success, or negative errno value on failure.
      */
-    int (*attach_prog)(struct bf_program *new_prog, struct bf_program *old_prog); 
+    int (*attach_prog)(struct bf_program *new_prog,
+                       struct bf_program *old_prog);
 
     int (*detach_prog)(struct bf_program *program);
 };

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -114,6 +114,21 @@ struct bf_flavor_ops
     int (*attach_prog_post_unload)(struct bf_program *program, int *prog_fd,
                                    union bf_flavor_attach_attr *attr);
 
+    /**
+     * Load and attach a BPF program.
+     *
+     * @p new_prog is the new program to be attached to the hook, and @p old_prog is the existing one.
+     * @p old_prog can be NULL, if no program is already attached. The exact
+     * load and attach mechanism is up to the flavor: direct attach, BPF link, ...
+     *
+     * If @p old_prog is not NULL, the replacement of @p old_prog by @p new_prog must be atomic.
+     *
+     * @param new_prog New BPF program to attach to the kernel. Can't be NULL.
+     * @param old_prog Previous program to replace.
+     * @return 0 on success, or negative errno value on failure.
+     */
+    int (*attach_prog)(struct bf_program *new_prog, struct bf_program *old_prog); 
+
     int (*detach_prog)(struct bf_program *program);
 };
 

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -7,6 +7,12 @@
 
 #include "shared/helper.h"
 
+/* Linux 6.4 and 6.5 doesn't support TCX, for BPF_TCX_{INGRESS,EGRESS} are not
+ * defined. Defining them here allow for Ubuntu 23.10 to build and use bpfilter,
+ * although bpfilter wouldn't be able to attach a TCX program. */ 
+#define BPF_TCX_INGRESS 46
+#define BPF_TCX_EGRESS 47
+
 const char *bf_hook_to_str(enum bf_hook hook)
 {
     static const char *hooks_str[] = {
@@ -71,13 +77,13 @@ enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook)
 {
     static const enum bpf_attach_type hooks[] = {
         [BF_HOOK_NFT_INGRESS] = 0,
-        [BF_HOOK_TC_INGRESS] = 0,
+        [BF_HOOK_TC_INGRESS] = BPF_TCX_INGRESS,
         [BF_HOOK_IPT_PRE_ROUTING] = 0,
         [BF_HOOK_IPT_LOCAL_IN] = BPF_NETFILTER,
         [BF_HOOK_IPT_FORWARD] = BPF_NETFILTER,
         [BF_HOOK_IPT_LOCAL_OUT] = BPF_NETFILTER,
         [BF_HOOK_IPT_POST_ROUTING] = 0,
-        [BF_HOOK_TC_EGRESS] = 0,
+        [BF_HOOK_TC_EGRESS] = BPF_TCX_EGRESS,
     };
 
     bf_assert(0 <= hook && hook < _BF_HOOK_MAX);

--- a/src/generator/codegen.h
+++ b/src/generator/codegen.h
@@ -70,14 +70,6 @@ int bf_codegen_new(struct bf_codegen **codegen);
 void bf_codegen_free(struct bf_codegen **codegen);
 
 /**
- * @brief Generate BPF programs for a codegen.
- *
- * @param codegen Codegen to generate BPF programs for. Can't be NULL.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_codegen_generate(struct bf_codegen *codegen);
-
-/**
  * @brief Update the BPF programs for a codegen.
  *
  * @param codegen Codegen to update. Can't be NULL.
@@ -96,20 +88,6 @@ int bf_codegen_update(struct bf_codegen *codegen);
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_codegen_up(struct bf_codegen *codegen);
-
-/**
- * @brief Load the BPF program stored in a codegen.
- *
- * Each program within the codegen will be loaded and attached to its interface.
- *
- * @param codegen Codegen containing the BPF program to load. Can't be NULL.
- * @param prev_codegen Codegen to replace. Can be NULL. @ref bf_codegen_load
- *  is responsible for unloading the previous codegen. @ref bf_codegen_load
- *  doesn't own @p prev_codegen, and won't free it.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_codegen_load(struct bf_codegen *codegen,
-                    struct bf_codegen *prev_codegen);
 
 /**
  * @brief Unload a codegen's BPF programs.

--- a/src/generator/codegen.h
+++ b/src/generator/codegen.h
@@ -86,6 +86,18 @@ int bf_codegen_generate(struct bf_codegen *codegen);
 int bf_codegen_update(struct bf_codegen *codegen);
 
 /**
+ * Create a @ref bf_program for each interface, generate the program, load it,
+ * and attach it to the kernel.
+ *
+ * Simplify @ref bf_program management by providing a single call to add the
+ * programs to the systems, starting from a new @ref bf_codegen.
+ *
+ * @param codegen Codegen to generate the programs for, and load to the system.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_codegen_up(struct bf_codegen *codegen);
+
+/**
  * @brief Load the BPF program stored in a codegen.
  *
  * Each program within the codegen will be loaded and attached to its interface.

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -51,7 +51,7 @@ int bf_matcher_generate_ip(struct bf_program *program,
     EMIT(program,
          BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l3_proto)));
     EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
-               BPF_JMP_REG(BPF_JNE, htons(ETH_P_IP), BF_REG_1, 0));
+               BPF_JMP_IMM(BPF_JNE, BF_REG_1, htons(ETH_P_IP), 0));
 
     switch (matcher->type) {
     case BF_MATCHER_IP_SRC_ADDR:

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -510,7 +510,7 @@ static int _bf_program_load_printer_map(struct bf_program *program)
     union bf_fixup_attr fixup_attr = {};
     int r;
 
-    bf_assert(program); 
+    bf_assert(program);
 
     // Will publish the printer if not published yet.
     r = bf_printer_publish(bf_context_get_printer());
@@ -518,7 +518,8 @@ static int _bf_program_load_printer_map(struct bf_program *program)
         return bf_err_code(r, "can't publish printer map");
 
     fixup_attr.map_fd = bf_printer_get_fd(bf_context_get_printer());
-    r = _bf_program_fixup(program, BF_CODEGEN_FIXUP_PRINTER_MAP_FD, &fixup_attr);
+    r = _bf_program_fixup(program, BF_CODEGEN_FIXUP_PRINTER_MAP_FD,
+                          &fixup_attr);
     if (r)
         return bf_err_code(r, "can't update instruction with printer map fd");
 
@@ -910,4 +911,3 @@ int bf_program_attach(struct bf_program *new_prog, struct bf_program *old_prog)
 
     return 0;
 }
-

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -210,45 +210,6 @@ int bf_program_generate(struct bf_program *program, bf_list *rules,
                         enum bf_verdict policy);
 
 /**
- * @brief Update the program's bytecode.
- *
- * This function will regenerate the BPF bytecode for @p program based on the
- * given rules. The new bytecode will be loaded into the kernel to replace the
- * current program. The program's metadata (ifindex, hook, front) will not be
- * modified.
- *
- * @note This function purposefully update the bytecode and the program in
- * one step. This is to ensure that the program is always in a consistent
- * state.
- *
- * @param program Program to regenerate. Can not be NULL.
- * @param rules List of rules to use to regenerate the program. Can not be NULL.
- * @param policy Verdict to use when no rule matches. Must be one of @ref
- * bf_verdict.
- * @return 0 on success, negative errno code on failure.
- */
-int bf_program_update(struct bf_program *program, bf_list *rules,
-                      enum bf_verdict policy);
-
-/**
- * @brief Load the program into the kernel.
- * @param program Program to load. Can not be NULL.
- * @param prev_program Previous program to unload. Can be NULL. If not NULL,
- *  @ref bf_program_load will unload @p prev_program between @ref
- *  attach_prog_pre_unload and @ref attach_prog_post_unload calls.
- * @return 0 on success, negative errno code on failure.
- */
-int bf_program_load(struct bf_program *program,
-                    struct bf_program *prev_program);
-
-int bf_program_unload(struct bf_program *program);
-
-int bf_program_get_counter(const struct bf_program *program,
-                           uint32_t counter_idx, struct bf_counter *counter);
-int bf_program_set_counters(struct bf_program *program,
-                            const struct bf_counter *counters);
-
-/**
  * Load and attach the program to the kernel.
  *
  * Perform the loading and attaching of the program to the kernel in one
@@ -259,4 +220,11 @@ int bf_program_set_counters(struct bf_program *program,
  * @param old_prog Existing program to replace.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_program_attach(struct bf_program *new_prog, struct bf_program *old_prog);
+int bf_program_load(struct bf_program *new_prog, struct bf_program *old_prog);
+
+int bf_program_unload(struct bf_program *program);
+
+int bf_program_get_counter(const struct bf_program *program,
+                           uint32_t counter_idx, struct bf_counter *counter);
+int bf_program_set_counters(struct bf_program *program,
+                            const struct bf_counter *counters);

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -247,3 +247,16 @@ int bf_program_get_counter(const struct bf_program *program,
                            uint32_t counter_idx, struct bf_counter *counter);
 int bf_program_set_counters(struct bf_program *program,
                             const struct bf_counter *counters);
+
+/**
+ * Load and attach the program to the kernel.
+ *
+ * Perform the loading and attaching of the program to the kernel in one
+ * step. If a similar program already exists, @p old_prog should be a pointer
+ * to it, and will be replaced.
+ *
+ * @param new_prog New program to load and attach to the kernel. Can't be NULL.
+ * @param old_prog Existing program to replace.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_program_attach(struct bf_program *new_prog, struct bf_program *old_prog);

--- a/src/generator/tc.h
+++ b/src/generator/tc.h
@@ -6,28 +6,5 @@
 #pragma once
 
 #include "core/flavor.h"
-#include "core/hook.h"
-
-/**
- * @brief Generate a handle for a TC codegen.
- *
- * Handles are a way to identify a BPF program within the TC namespace.
- *
- * @param codegen Codegen to generate a handle for.
- * @return 32 bits handle for the codegen.
- */
-#define bf_tc_program_handle(program)                                          \
-    ({                                                                         \
-        typeof(program) _program = (program);                                  \
-        (_program->hook << 16) | _program->front;                              \
-    })
 
 extern const struct bf_flavor_ops bf_flavor_ops_tc;
-
-/**
- * @brief Convert @ref bf_hook into a TC hook.
- *
- * @param hook Hook to convert. Must be valid TC hook.
- * @return TC hook, as a bpf_tc_attach_point enumeration value.
- */
-enum bpf_tc_attach_point bf_hook_to_tc_hook(enum bf_hook hook);

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -441,16 +441,10 @@ static int _bf_ipt_set_rules_handler(struct ipt_replace *replace, size_t len)
         if (!codegen)
             continue;
 
-        r = bf_codegen_generate(codegen);
+        r = bf_codegen_up(codegen);
         if (r) {
             bf_err_code(r, "failed to generate bytecode for hook %d, skipping",
                         codegen->hook);
-            goto end_free_codegens;
-        }
-
-        r = bf_codegen_load(codegen, bf_context_get_codegen(i, BF_FRONT_IPT));
-        if (r) {
-            bf_err_code(r, "failed to load codegen");
             goto end_free_codegens;
         }
 

--- a/src/xlate/nft/nft.c
+++ b/src/xlate/nft/nft.c
@@ -259,13 +259,9 @@ static int _bf_nft_newchain_cb(const struct bf_nfmsg *req)
         codegen->hook = BF_HOOK_NFT_INGRESS;
         codegen->policy = verdict;
 
-        r = bf_codegen_generate(codegen);
+        r = bf_codegen_up(codegen);
         if (r < 0)
             return bf_err_code(r, "failed to generate codegen");
-
-        r = bf_codegen_load(codegen, NULL);
-        if (r < 0)
-            return bf_err_code(r, "failed to load codegen");
 
         bf_context_set_codegen(BF_HOOK_NFT_INGRESS, BF_FRONT_NFT, codegen);
 

--- a/tests/unit/src/core/hook.c
+++ b/tests/unit/src/core/hook.c
@@ -62,6 +62,8 @@ Test(hook, can_get_attach_type_from_hook)
     for (int i = 0; i < _BF_HOOK_MAX; ++i) {
         attach_type = bf_hook_to_attach_type(i);
         assert_true(0 <= attach_type);
-        assert_true(attach_type < __MAX_BPF_ATTACH_TYPE);
+        // Don't check if the attach_type is a valid bpf_attach_type for the
+        // current kernel, as we might define it in compat.h to allow bpfilter
+        // to build.
     }
 }


### PR DESCRIPTION
Update the `bf_flavor_ops` to simplify program loading and attachment to the BPF hooks. TC and XDP now use BPF link and `BPF_LINK_UPDATE` to attach and update an existing program. For `BPF_NETFILTER`, the program update logic is handle in `attach_prog` to, but slightly differently as it doesn't support `BPF_LINK_UPDATE`.

The generation and program management logic in `codegen.c` and `program.c` has been simplified to provide to main paths:
- `bf_codegen_up()`: create the `bf_program` objects for a given `bf_codegen`, generate the BPF bytecode and attach the programs to the system.
- `bf_codegen_update()`: update the bytecode of existing BPF programs, and attach them to the system, replacing the out-of-date version of the same program.

This updated logic makes the daemon's workflow simpler and easier to work with. Both `ipt` and `nft` front-end have been updated.