### PR TITLE
 matcher: ip: support `ip.(s|d)addr` in `bfcli`

### DIFF
--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -13,6 +13,7 @@
 %option nounput
 
 %s STATE_MATCHER_IPPROTO
+%s STATE_MATCHER_IPADDR
 
 %%
 
@@ -37,6 +38,15 @@ ip\.proto       { BEGIN(STATE_MATCHER_IPPROTO); yylval.sval = strdup(yytext); re
     [a-z]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_IPPROTO;
+    }
+}
+
+ip\.saddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_IPADDR>{
+    [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
+        yylval.sval = strdup(yytext);
+        return MATCHER_IPADDR;
     }
 }
 

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -44,7 +44,7 @@ ip\.proto       { BEGIN(STATE_MATCHER_IPPROTO); yylval.sval = strdup(yytext); re
 ip\.saddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IPADDR>{
-    [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
+    (\!)?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
         yylval.sval = strdup(yytext);
         return MATCHER_IPADDR;
     }

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -24,7 +24,7 @@ static int _bf_matcher_generate_ip_addr(struct bf_program *program,
     if (addr->mask != 0xffffffff)
         EMIT(program, BPF_ALU32_IMM(BPF_AND, BF_REG_2, addr->mask));
     EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
-               BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
+               BPF_JMP32_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
                            BF_REG_2, addr->addr, 0));
 
     return 0;


### PR DESCRIPTION
Allow `ip.saddr` and `ip.daddr` to be used in `bfcli` to filter based on source or destination IP, such as:

    ip.(s|d)addr (!)$IP(/$MASK)

`!` is optional before the IP address to inverse the match: `ip.saddr 192.168.1.1` will match every packet with source address `192.168.1.1`, while `ip.saddr !192.168.1.1` will match packet without the source address `192.168.1.1` (packet from every other address that is).

Fix IPv4 address filtering bytecode generation by inserting `JMP32` instead of `JMP` for address comparison.