### PR TITLE
TCP and UDP source/destination port filtering

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(generator OBJECT
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/fixup.h       ${CMAKE_CURRENT_SOURCE_DIR}/generator/fixup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/jmp.h         ${CMAKE_CURRENT_SOURCE_DIR}/generator/jmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/ip.h  ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/ip.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/tcp.h ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/tcp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/nf.h          ${CMAKE_CURRENT_SOURCE_DIR}/generator/nf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/printer.h     ${CMAKE_CURRENT_SOURCE_DIR}/generator/printer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/program.h     ${CMAKE_CURRENT_SOURCE_DIR}/generator/program.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(generator OBJECT
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/jmp.h         ${CMAKE_CURRENT_SOURCE_DIR}/generator/jmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/ip.h  ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/ip.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/tcp.h ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/tcp.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/udp.h ${CMAKE_CURRENT_SOURCE_DIR}/generator/matcher/udp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/nf.h          ${CMAKE_CURRENT_SOURCE_DIR}/generator/nf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/printer.h     ${CMAKE_CURRENT_SOURCE_DIR}/generator/printer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/generator/program.h     ${CMAKE_CURRENT_SOURCE_DIR}/generator/program.c

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -52,6 +52,7 @@ ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); ret
 }
 
 tcp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_PORT>{
     (\!)?[0-9]+ {
         yylval.sval = strdup(yytext);

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -14,6 +14,7 @@
 
 %s STATE_MATCHER_IPPROTO
 %s STATE_MATCHER_IPADDR
+%s STATE_MATCHER_PORT
 
 %%
 
@@ -47,6 +48,14 @@ ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); ret
     (\!)?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
         yylval.sval = strdup(yytext);
         return MATCHER_IPADDR;
+    }
+}
+
+tcp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_PORT>{
+    (\!)?[0-9]+ {
+        yylval.sval = strdup(yytext);
+        return MATCHER_PORT;
     }
 }
 

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -130,6 +130,8 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_IP_SRC_ADDR] = "ip.saddr",
     [BF_MATCHER_IP_DST_ADDR] = "ip.daddr",
     [BF_MATCHER_IP_PROTO] = "ip.proto",
+    [BF_MATCHER_TCP_SPORT] = "tcp.sport",
+    [BF_MATCHER_TCP_DPORT] = "tcp.dport",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_type_strs) == _BF_MATCHER_TYPE_MAX,

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -132,6 +132,8 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_IP_PROTO] = "ip.proto",
     [BF_MATCHER_TCP_SPORT] = "tcp.sport",
     [BF_MATCHER_TCP_DPORT] = "tcp.dport",
+    [BF_MATCHER_UDP_SPORT] = "udp.sport",
+    [BF_MATCHER_UDP_DPORT] = "udp.dport",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_type_strs) == _BF_MATCHER_TYPE_MAX,

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -51,6 +51,10 @@ enum bf_matcher_type
     BF_MATCHER_TCP_SPORT,
     /// Matches against the TCP destination port
     BF_MATCHER_TCP_DPORT,
+    /// Matches against the UDP source port
+    BF_MATCHER_UDP_SPORT,
+    /// Matches against the UDP destination port
+    BF_MATCHER_UDP_DPORT,
     _BF_MATCHER_TYPE_MAX,
 };
 

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -47,6 +47,10 @@ enum bf_matcher_type
     BF_MATCHER_IP_DST_ADDR,
     /// Matches against the IP protocol field
     BF_MATCHER_IP_PROTO,
+    /// Matches against the TCP source port
+    BF_MATCHER_TCP_SPORT,
+    /// Matches against the TCP destination port
+    BF_MATCHER_TCP_DPORT,
     _BF_MATCHER_TYPE_MAX,
 };
 

--- a/src/generator/matcher/tcp.c
+++ b/src/generator/matcher/tcp.c
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/matcher/tcp.h"
+
+#include <arpa/inet.h>
+
+#include "core/logger.h"
+#include "core/matcher.h"
+#include "generator/fixup.h"
+#include "generator/printer.h"
+#include "generator/program.h"
+
+// clang-format off
+// Required because of conflicting definitions from glibc
+#include <linux/in.h>
+// clang-format on
+
+static int _bf_matcher_generate_tcp_port(struct bf_program *program,
+                                         const struct bf_matcher *matcher)
+{
+    uint16_t port = *(uint16_t *)&matcher->payload;
+    size_t offset = matcher->type == BF_MATCHER_TCP_SPORT ?
+                        offsetof(struct tcphdr, source) :
+                        offsetof(struct tcphdr, dest);
+
+    EMIT(program, BPF_LDX_MEM(BPF_H, BF_REG_4, BF_REG_L4, offset));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
+                           BF_REG_4, htons(port), 0));
+
+    return 0;
+}
+
+int bf_matcher_generate_tcp(struct bf_program *program,
+                            const struct bf_matcher *matcher)
+{
+    int r;
+
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(BPF_JNE, BF_REG_1, IPPROTO_TCP, 0));
+
+    switch (matcher->type) {
+    case BF_MATCHER_TCP_SPORT:
+    case BF_MATCHER_TCP_DPORT:
+        r = _bf_matcher_generate_tcp_port(program, matcher);
+        break;
+    default:
+        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+    };
+
+    return r;
+}

--- a/src/generator/matcher/tcp.h
+++ b/src/generator/matcher/tcp.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+struct bf_matcher;
+struct bf_program;
+
+int bf_matcher_generate_tcp(struct bf_program *program,
+                            const struct bf_matcher *matcher);

--- a/src/generator/matcher/udp.c
+++ b/src/generator/matcher/udp.c
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "generator/matcher/udp.h"
+
+#include <arpa/inet.h>
+
+#include <linux/udp.h>
+
+#include "core/logger.h"
+#include "core/matcher.h"
+#include "generator/fixup.h"
+#include "generator/program.h"
+
+// clang-format off
+// Required because of conflicting definitions from glibc
+#include <linux/in.h>
+// clang-format on
+
+static int _bf_matcher_generate_udp_port(struct bf_program *program,
+                                         const struct bf_matcher *matcher)
+{
+    uint16_t port = *(uint16_t *)&matcher->payload;
+    size_t offset = matcher->type == BF_MATCHER_UDP_SPORT ?
+                        offsetof(struct udphdr, source) :
+                        offsetof(struct udphdr, dest);
+
+    EMIT(program, BPF_LDX_MEM(BPF_H, BF_REG_4, BF_REG_L4, offset));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
+                           BF_REG_4, htons(port), 0));
+
+    return 0;
+}
+
+int bf_matcher_generate_udp(struct bf_program *program,
+                            const struct bf_matcher *matcher)
+{
+    int r;
+
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(BPF_JNE, BF_REG_1, IPPROTO_UDP, 0));
+
+    switch (matcher->type) {
+    case BF_MATCHER_UDP_SPORT:
+    case BF_MATCHER_UDP_DPORT:
+        r = _bf_matcher_generate_udp_port(program, matcher);
+        break;
+    default:
+        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+    };
+
+    return r;
+}

--- a/src/generator/matcher/udp.h
+++ b/src/generator/matcher/udp.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+struct bf_matcher;
+struct bf_program;
+
+int bf_matcher_generate_udp(struct bf_program *program,
+                            const struct bf_matcher *matcher);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -29,6 +29,7 @@
 #include "core/verdict.h"
 #include "generator/jmp.h"
 #include "generator/matcher/ip.h"
+#include "generator/matcher/tcp.h"
 #include "generator/printer.h"
 #include "generator/stub.h"
 #include "shared/helper.h"
@@ -339,6 +340,12 @@ static int _bf_program_generate_rule(struct bf_program *program,
         case BF_MATCHER_IP_DST_ADDR:
         case BF_MATCHER_IP_PROTO:
             r = bf_matcher_generate_ip(program, matcher);
+            if (r)
+                return r;
+            break;
+        case BF_MATCHER_TCP_SPORT:
+        case BF_MATCHER_TCP_DPORT:
+            r = bf_matcher_generate_tcp(program, matcher);
             if (r)
                 return r;
             break;

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -30,6 +30,7 @@
 #include "generator/jmp.h"
 #include "generator/matcher/ip.h"
 #include "generator/matcher/tcp.h"
+#include "generator/matcher/udp.h"
 #include "generator/printer.h"
 #include "generator/stub.h"
 #include "shared/helper.h"
@@ -346,6 +347,12 @@ static int _bf_program_generate_rule(struct bf_program *program,
         case BF_MATCHER_TCP_SPORT:
         case BF_MATCHER_TCP_DPORT:
             r = bf_matcher_generate_tcp(program, matcher);
+            if (r)
+                return r;
+            break;
+        case BF_MATCHER_UDP_SPORT:
+        case BF_MATCHER_UDP_DPORT:
+            r = bf_matcher_generate_udp(program, matcher);
             if (r)
                 return r;
             break;

--- a/src/shared/helper.h
+++ b/src/shared/helper.h
@@ -80,6 +80,19 @@ extern const char *strerrordesc_np(int errnum);
 #define bf_strerror(v) strerrordesc_np(abs(v))
 
 /**
+ * Swap two values.
+ *
+ * @param a First value to swap.
+ * @param b Second value to swap.
+ */
+#define bf_swap(a, b)                                                          \
+    do {                                                                       \
+        typeof(a) __a = (a);                                                   \
+        (a) = (b);                                                             \
+        (b) = __a;                                                             \
+    } while (0)
+
+/**
  * @brief Free a pointer and set it to NULL.
  * @param ptr Pointer to free.
  */

--- a/src/xlate/cli.c
+++ b/src/xlate/cli.c
@@ -62,10 +62,7 @@ int _bf_cli_set_rules(const struct bf_request *request,
     }
 
     codegen->policy = chain->policy;
-    codegen->rules = chain->rules;
-    chain->rules.len = 0;
-    chain->rules.head = NULL;
-    chain->rules.tail = NULL;
+    bf_swap(codegen->rules, chain->rules);
 
     if (bf_context_get_codegen(chain->hook, BF_FRONT_CLI)) {
         r = bf_codegen_update(codegen);


### PR DESCRIPTION
Add matcher support to filter packets based on source and/or destination port in TCP and UDP. `bfcli` has been updated to allow those new matchers to be used, for example:
- Block SSH: `tcp.dport 22`
- Block outgoing DNS requests: `udp.dport 53`

Fix a memory leak in the `xlate/cli` when the rules are updated.