### PR TITLE
TCP flags filtering

### DIFF
--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -36,6 +36,7 @@ BF_HOOK_[A-Z_]+ { yylval.sval = strdup(yytext); return HOOK; }
     /* Matcher types */
 ip\.proto       { BEGIN(STATE_MATCHER_IPPROTO); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IPPROTO>{
+    eq { yylval.sval = strdup(yytext); return MATCHER_OP; }
     [a-z]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_IPPROTO;
@@ -45,7 +46,8 @@ ip\.proto       { BEGIN(STATE_MATCHER_IPPROTO); yylval.sval = strdup(yytext); re
 ip\.saddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IPADDR>{
-    (\!)?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
+    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    [0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(\/[0-9]+)? {
         yylval.sval = strdup(yytext);
         return MATCHER_IPADDR;
     }
@@ -54,6 +56,7 @@ ip\.daddr       { BEGIN(STATE_MATCHER_IPADDR); yylval.sval = strdup(yytext); ret
 tcp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_PORT>{
+    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     (\!)?[0-9]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_PORT;

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -66,7 +66,7 @@ udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); retur
 
 tcp\.flags      { BEGIN(STATE_MATCHER_TCP_FLAGS); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_TCP_FLAGS>{
-    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|not|any|all) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     ([A-Z]+,?)+ {
         yylval.sval = strdup(yytext);
         return MATCHER_TCP_FLAGS;

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -15,6 +15,7 @@
 %s STATE_MATCHER_IPPROTO
 %s STATE_MATCHER_IPADDR
 %s STATE_MATCHER_PORT
+%s STATE_MATCHER_TCP_FLAGS
 
 %%
 
@@ -60,6 +61,15 @@ udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); retur
     (\!)?[0-9]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_PORT;
+    }
+}
+
+tcp\.flags      { BEGIN(STATE_MATCHER_TCP_FLAGS); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_TCP_FLAGS>{
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    ([A-Z]+,?)+ {
+        yylval.sval = strdup(yytext);
+        return MATCHER_TCP_FLAGS;
     }
 }
 

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -36,7 +36,7 @@ BF_HOOK_[A-Z_]+ { yylval.sval = strdup(yytext); return HOOK; }
     /* Matcher types */
 ip\.proto       { BEGIN(STATE_MATCHER_IPPROTO); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IPPROTO>{
-    eq { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     [a-z]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_IPPROTO;

--- a/src/cli/parser.y
+++ b/src/cli/parser.y
@@ -210,7 +210,7 @@ matchers        : matcher
 matcher         : matcher_type matcher_op MATCHER_IPPROTO
                 {
                     _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
-                    uint16_t proto;
+                    uint8_t proto;
 
                     if (bf_streq($3, "icmp")) {
                         proto = IPPROTO_ICMP;

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -165,6 +165,8 @@ int bf_matcher_type_from_str(const char *str, enum bf_matcher_type *type)
 static const char *_bf_matcher_ops_strs[] = {
     [BF_MATCHER_EQ] = "eq",
     [BF_MATCHER_NE] = "not",
+    [BF_MATCHER_ANY] = "any",
+    [BF_MATCHER_ALL] = "all",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_ops_strs) == _BF_MATCHER_OP_MAX);

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -132,6 +132,7 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_IP_PROTO] = "ip.proto",
     [BF_MATCHER_TCP_SPORT] = "tcp.sport",
     [BF_MATCHER_TCP_DPORT] = "tcp.dport",
+    [BF_MATCHER_TCP_FLAGS] = "tcp.flags",
     [BF_MATCHER_UDP_SPORT] = "udp.sport",
     [BF_MATCHER_UDP_DPORT] = "udp.dport",
 };
@@ -183,6 +184,36 @@ int bf_matcher_op_from_str(const char *str, enum bf_matcher_op *op)
     for (size_t i = 0; i < _BF_MATCHER_OP_MAX; ++i) {
         if (bf_streq(_bf_matcher_ops_strs[i], str)) {
             *op = i;
+            return 0;
+        }
+    }
+
+    return -EINVAL;
+}
+
+static const char *_bf_matcher_tcp_flags_strs[] = {
+    [BF_MATCHER_TCP_FLAG_FIN] = "FIN", [BF_MATCHER_TCP_FLAG_SYN] = "SYN",
+    [BF_MATCHER_TCP_FLAG_RST] = "RST", [BF_MATCHER_TCP_FLAG_PSH] = "PSH",
+    [BF_MATCHER_TCP_FLAG_ACK] = "ACK", [BF_MATCHER_TCP_FLAG_URG] = "URG",
+    [BF_MATCHER_TCP_FLAG_ECE] = "ECE", [BF_MATCHER_TCP_FLAG_CWR] = "CWR",
+};
+
+const char *bf_matcher_tcp_flag_to_str(enum bf_matcher_tcp_flag flag)
+{
+    bf_assert(0 <= flag && flag < _BF_MATCHER_TCP_FLAG_MAX);
+
+    return _bf_matcher_tcp_flags_strs[flag];
+}
+
+int bf_matcher_tcp_flag_from_str(const char *str,
+                                 enum bf_matcher_tcp_flag *flag)
+{
+    bf_assert(str);
+    bf_assert(flag);
+
+    for (size_t i = 0; i < _BF_MATCHER_TCP_FLAG_MAX; ++i) {
+        if (bf_streq(_bf_matcher_tcp_flags_strs[i], str)) {
+            *flag = i;
             return 0;
         }
     }

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -161,16 +161,31 @@ int bf_matcher_type_from_str(const char *str, enum bf_matcher_type *type)
     return -EINVAL;
 }
 
+static const char *_bf_matcher_ops_strs[] = {
+    [BF_MATCHER_EQ] = "eq",
+    [BF_MATCHER_NE] = "not",
+};
+
+static_assert(ARRAY_SIZE(_bf_matcher_ops_strs) == _BF_MATCHER_OP_MAX);
+
 const char *bf_matcher_op_to_str(enum bf_matcher_op op)
 {
-    static const char *ops_str[] = {
-        [BF_MATCHER_EQ] = "BF_MATCHER_EQ",
-        [BF_MATCHER_NE] = "BF_MATCHER_NE",
-    };
-
     bf_assert(0 <= op && op < _BF_MATCHER_OP_MAX);
-    static_assert(ARRAY_SIZE(ops_str) == _BF_MATCHER_OP_MAX,
-                  "missing entries in the ops_str array");
 
-    return ops_str[op];
+    return _bf_matcher_ops_strs[op];
+}
+
+int bf_matcher_op_from_str(const char *str, enum bf_matcher_op *op)
+{
+    bf_assert(str);
+    bf_assert(op);
+
+    for (size_t i = 0; i < _BF_MATCHER_OP_MAX; ++i) {
+        if (bf_streq(_bf_matcher_ops_strs[i], str)) {
+            *op = i;
+            return 0;
+        }
+    }
+
+    return -EINVAL;
 }

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -51,6 +51,8 @@ enum bf_matcher_type
     BF_MATCHER_TCP_SPORT,
     /// Matches against the TCP destination port
     BF_MATCHER_TCP_DPORT,
+    /// Matchers against the TCP flags
+    BF_MATCHER_TCP_FLAGS,
     /// Matches against the UDP source port
     BF_MATCHER_UDP_SPORT,
     /// Matches against the UDP destination port
@@ -66,6 +68,22 @@ struct bf_matcher_ip_addr
 {
     uint32_t addr;
     uint32_t mask;
+};
+
+/**
+ * Define the TCP flags values as number of shifts of 1.
+ */
+enum bf_matcher_tcp_flag
+{
+    BF_MATCHER_TCP_FLAG_FIN = 0,
+    BF_MATCHER_TCP_FLAG_SYN = 1,
+    BF_MATCHER_TCP_FLAG_RST = 2,
+    BF_MATCHER_TCP_FLAG_PSH = 3,
+    BF_MATCHER_TCP_FLAG_ACK = 4,
+    BF_MATCHER_TCP_FLAG_URG = 5,
+    BF_MATCHER_TCP_FLAG_ECE = 6,
+    BF_MATCHER_TCP_FLAG_CWR = 7,
+    _BF_MATCHER_TCP_FLAG_MAX,
 };
 
 /**
@@ -185,3 +203,21 @@ const char *bf_matcher_op_to_str(enum bf_matcher_op op);
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_matcher_op_from_str(const char *str, enum bf_matcher_op *op);
+
+/**
+ * Convert a TCP flag to a string.
+ *
+ * @param flag TCP flag to convert.
+ * @return String representation of the TCP flag.
+ */
+const char *bf_matcher_tcp_flag_to_str(enum bf_matcher_tcp_flag flag);
+
+/**
+ * Convert a string to the corresponding TCP flag.
+ *
+ * @param str String containing the name of the TCP flag.
+ * @param flag TCP flag value, if the parsing succeeds.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_matcher_tcp_flag_from_str(const char *str,
+                                 enum bf_matcher_tcp_flag *flag);

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -173,6 +173,15 @@ int bf_matcher_type_from_str(const char *str, enum bf_matcher_type *type);
  * @brief Convert a matcher operator to a string.
  *
  * @param op The matcher operator to convert. Must be a valid @ref bf_matcher_op
- * @return String representation of the operator.
+ * @return String representation of the matcher operator.
  */
 const char *bf_matcher_op_to_str(enum bf_matcher_op op);
+
+/**
+ * Convert a string to the corresponding matcher operator.
+ *
+ * @param str String containing the name of a matcher operator.
+ * @param hook Matcher operator value, if the parsing succeeds.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_matcher_op_from_str(const char *str, enum bf_matcher_op *op);

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -98,6 +98,10 @@ enum bf_matcher_op
     BF_MATCHER_EQ,
     /// Test for inequality.
     BF_MATCHER_NE,
+    /// Test for partial subset match
+    BF_MATCHER_ANY,
+    /// Test for complete subset match
+    BF_MATCHER_ALL,
     _BF_MATCHER_OP_MAX,
 };
 

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -33,7 +33,7 @@ static int _bf_matcher_generate_ip_addr(struct bf_program *program,
 static int _bf_matcher_generate_ip_proto(struct bf_program *program,
                                          const struct bf_matcher *matcher)
 {
-    uint16_t proto = *(uint16_t *)&matcher->payload;
+    uint8_t proto = *(uint8_t *)&matcher->payload;
 
     EMIT(program, BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_L3,
                               offsetof(struct iphdr, protocol)));

--- a/src/generator/matcher/ip.c
+++ b/src/generator/matcher/ip.c
@@ -38,7 +38,8 @@ static int _bf_matcher_generate_ip_proto(struct bf_program *program,
     EMIT(program, BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_L3,
                               offsetof(struct iphdr, protocol)));
     EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
-               BPF_JMP_IMM(BPF_JNE, BF_REG_4, proto, 0));
+               BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
+                           BF_REG_4, proto, 0));
 
     return 0;
 }

--- a/src/generator/matcher/tcp.c
+++ b/src/generator/matcher/tcp.c
@@ -34,6 +34,16 @@ static int _bf_matcher_generate_tcp_port(struct bf_program *program,
     return 0;
 }
 
+static int _bf_matcher_generate_tcp_flags(struct bf_program *program,
+                                          const struct bf_matcher *matcher)
+{
+    EMIT(program, BPF_LDX_MEM(BPF_B, BF_REG_1, BF_REG_L4, 13));
+    EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
+               BPF_JMP_IMM(BPF_JNE, BF_REG_1, *(uint8_t *)matcher->payload, 0));
+
+    return 0;
+}
+
 int bf_matcher_generate_tcp(struct bf_program *program,
                             const struct bf_matcher *matcher)
 {
@@ -48,6 +58,9 @@ int bf_matcher_generate_tcp(struct bf_program *program,
     case BF_MATCHER_TCP_SPORT:
     case BF_MATCHER_TCP_DPORT:
         r = _bf_matcher_generate_tcp_port(program, matcher);
+        break;
+    case BF_MATCHER_TCP_FLAGS:
+        r = _bf_matcher_generate_tcp_flags(program, matcher);
         break;
     default:
         return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);

--- a/src/generator/matcher/tcp.c
+++ b/src/generator/matcher/tcp.c
@@ -40,7 +40,7 @@ int bf_matcher_generate_tcp(struct bf_program *program,
     int r;
 
     EMIT(program,
-         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_LDX_MEM(BPF_B, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
     EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
                BPF_JMP_IMM(BPF_JNE, BF_REG_1, IPPROTO_TCP, 0));
 

--- a/src/generator/matcher/udp.c
+++ b/src/generator/matcher/udp.c
@@ -41,7 +41,7 @@ int bf_matcher_generate_udp(struct bf_program *program,
     int r;
 
     EMIT(program,
-         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_LDX_MEM(BPF_B, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
     EMIT_FIXUP(program, BF_CODEGEN_FIXUP_NEXT_RULE,
                BPF_JMP_IMM(BPF_JNE, BF_REG_1, IPPROTO_UDP, 0));
 

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -346,6 +346,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
             break;
         case BF_MATCHER_TCP_SPORT:
         case BF_MATCHER_TCP_DPORT:
+        case BF_MATCHER_TCP_FLAGS:
             r = bf_matcher_generate_tcp(program, matcher);
             if (r)
                 return r;

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -137,7 +137,7 @@ struct bf_program_context
 
         /** Layer 4 protocol. Set when the L3 header is processed. Used to
          * define how many bytes to read when processing the packet. */
-        uint16_t l4_proto;
+        uint8_t l4_proto;
 
         union
         {

--- a/src/generator/stub.c
+++ b/src/generator/stub.c
@@ -251,7 +251,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
 
     // BF_ARG_4: size of the buffer.
     EMIT(program,
-         BPF_LDX_MEM(BPF_H, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_LDX_MEM(BPF_B, BF_REG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
     {
         _cleanup_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BF_ARG_4);


### PR DESCRIPTION
Introduce support for TCP flags filtering in `bpfilter`:
- Allow a specific operator to be specified in the `bfcli` rule (`ip.saddr eq 192.168.1.1`, `ip.saddr not 192.168.1.1`).
- Add support for 2 new operators: `any` and `all` (see commit for details).
- Add support for `tcp.flags` matcher: match a rule based on the packet's TCP flags.

Extra changes:
- Add support for `not` operator in `ip.proto`: `ip.proto not icmp`.
- Fix `iphdr.protocol` size: uses 1 byte instead of 2 bytes. This change resolves a verifier complain.