### PR TITLE
Fix `iptables` protocol filtering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,16 @@ else ()
     endif ()
 endif ()
 
+# Ensure artefacts are moved to a common directory
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/output/include/bpfilter)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output/bin)
+configure_file(
+    ${CMAKE_SOURCE_DIR}/src/lib/bpfilter.h
+    ${CMAKE_BINARY_DIR}/output/include/bpfilter/bpfilter.h
+)
+
 set(bf_cflags
     -std=gnu17 -Wall -Wextra
     $<$<CONFIG:debug>:-O0 -g3 -ggdb -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 #[[
     shared
 #]]
-add_library(shared OBJECT
+set(shared_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/front.h          ${CMAKE_CURRENT_SOURCE_DIR}/shared/front.c
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/generic.h        ${CMAKE_CURRENT_SOURCE_DIR}/shared/generic.c
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/helper.h
@@ -13,9 +13,15 @@ add_library(shared OBJECT
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/response.h       ${CMAKE_CURRENT_SOURCE_DIR}/shared/response.c
 )
 
+add_library(shared OBJECT ${shared_srcs})
 target_include_directories(shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(shared PUBLIC ${bf_cflags})
 target_link_options(shared PUBLIC ${bf_ldflags})
+
+add_library(shared_pic OBJECT ${shared_srcs})
+target_include_directories(shared_pic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(shared_pic PUBLIC -fPIC ${bf_cflags})
+target_link_options(shared_pic PUBLIC ${bf_ldflags})
 
 #[[
     core
@@ -105,17 +111,22 @@ target_link_libraries(xlate
 #[[
     lib
 #]]
-add_library(lib OBJECT
+set(lib_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/bpfilter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/lib/generic.h           ${CMAKE_CURRENT_SOURCE_DIR}/lib/generic.c
                                                         ${CMAKE_CURRENT_SOURCE_DIR}/lib/ipt.c
                                                         ${CMAKE_CURRENT_SOURCE_DIR}/lib/nft.c
 )
 
-target_include_directories(shared PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_options(lib PRIVATE -fPIC ${bf_cflags})
+add_library(lib OBJECT ${lib_srcs})
+target_include_directories(lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(lib PRIVATE ${bf_cflags})
 target_link_options(lib PUBLIC ${bf_ldflags})
-target_link_libraries(lib PRIVATE shared)
+
+add_library(lib_pic OBJECT ${lib_srcs})
+target_include_directories(lib_pic PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_options(lib_pic PRIVATE -fPIC ${bf_cflags})
+target_link_options(lib_pic PUBLIC ${bf_ldflags})
 
 #[[
     daemon
@@ -191,12 +202,15 @@ install(
 #[[
     libraries
 #]]
-add_library(libbpfilter_static STATIC $<TARGET_OBJECTS:lib>)
+add_library(libbpfilter_static STATIC)
 set_target_properties(libbpfilter_static PROPERTIES OUTPUT_NAME bpfilter)
+target_compile_options(libbpfilter_static PRIVATE -fPIC)
+target_link_libraries(libbpfilter_static PRIVATE shared_pic lib_pic)
 
-add_library(libbpfilter_shared SHARED $<TARGET_OBJECTS:lib>)
+add_library(libbpfilter_shared SHARED)
 set_target_properties(libbpfilter_shared PROPERTIES OUTPUT_NAME bpfilter)
 target_compile_options(libbpfilter_shared PRIVATE -fPIC)
+target_link_libraries(libbpfilter_shared PRIVATE shared_pic lib_pic)
 
 add_custom_target(library
     ALL

--- a/src/core/context.h
+++ b/src/core/context.h
@@ -35,7 +35,6 @@
 
 struct bf_codegen;
 struct bf_marsh;
-struct bf_printer;
 
 /**
  * @struct bf_context
@@ -45,8 +44,6 @@ struct bf_printer;
  */
 struct bf_context
 {
-    /// Printer context, required to print custom strings from the BPF programs.
-    struct bf_printer *printer;
     /// Codegens used by bpfilter. One codegen per (hook, front) set.
     struct bf_codegen *codegens[_BF_HOOK_MAX][_BF_FRONT_MAX];
 };
@@ -153,11 +150,3 @@ int bf_context_set_codegen(enum bf_hook hook, enum bf_front front,
  */
 void bf_context_replace_codegen(enum bf_hook hook, enum bf_front front,
                                 struct bf_codegen *codegen);
-
-/**
- * @brief Returns a pointer to the printer context.
- *
- * @return Pointer to the printer context, can't be NULL as the printer context
- *  is always created.
- */
-struct bf_printer *bf_context_get_printer(void);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -208,6 +208,9 @@ static int _bf_save(const char *path)
     for (int i = 0; i < _BF_FRONT_MAX; ++i) {
         _cleanup_free_ struct bf_marsh *child = NULL;
 
+        if (!bf_opts_is_front_enabled(i))
+            continue;
+
         r = bf_marsh_new(&child, NULL, 0);
         if (r < 0)
             return r;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -358,8 +358,13 @@ static int _process_request(struct bf_request *request,
     bf_assert(request);
     bf_assert(response);
 
-    if (!bf_opts_is_front_enabled(request->front))
+    if (!bf_opts_is_front_enabled(request->front)) {
+        bf_warn("received a request from %s, but front is disabled, ignoring",
+                bf_front_to_str(request->front));
         return bf_response_new_failure(response, -ENOTSUP);
+    }
+
+    bf_info("received a request from %s", bf_front_to_str(request->front)); 
 
     ops = bf_front_ops_get(request->front);
     r = ops->request_handler(request, response);
@@ -430,8 +435,6 @@ static int _run(void)
         r = bf_recv_request(client_fd, &request);
         if (r < 0)
             return bf_err_code(r, "failed to receive request");
-
-        bf_dbg("received request from client on FD %d", client_fd);
 
         r = _process_request(request, &response);
         if (r) {

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -67,7 +67,7 @@ struct bf_printer_msg;
     ({                                                                         \
         int __r;                                                               \
         const struct bf_printer_msg *__msg =                                   \
-            bf_printer_add_msg(bf_context_get_printer(), msg);                 \
+            bf_printer_add_msg(program->printer, msg);                         \
         struct bpf_insn __ld_insn[2] = {                                       \
             BPF_LD_MAP_FD(BF_ARG_1, 0),                                        \
         };                                                                     \

--- a/src/generator/printer.h
+++ b/src/generator/printer.h
@@ -135,14 +135,6 @@ int bf_printer_marsh(const struct bf_printer *printer, struct bf_marsh **marsh);
 void bf_printer_dump(const struct bf_printer *printer, prefix_t *prefix);
 
 /**
- * @brief Get the printer map's file descriptor.
- *
- * @param printer Printer context. Can't be NULL.
- * @return File descriptor of the printer's BPF map.
- */
-int bf_printer_get_fd(const struct bf_printer *printer);
-
-/**
  * @brief Return the offset of a specific printer message.
  *
  * @param msg Printer message. Can't be NULL.
@@ -170,9 +162,15 @@ const struct bf_printer_msg *bf_printer_add_msg(struct bf_printer *printer,
                                                 const char *str);
 
 /**
- * @brief Publish the printer's messages in the BPF map.
+ * Assemble the messages defined inside the printer into a single nul-separated
+ * string.
  *
- * @param printer Printer context. Can't be NULL.
+ * @param printer Printer containing the messages to assemble. Can't be NULL.
+ * @param str On success, contains the pointer to the result string. Can't be
+ * NULL.
+ * @param str_len On success, contains the length of the result string,
+ * including the nul termination character. Can't be NULL.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_printer_publish(struct bf_printer *printer);
+int bf_printer_assemble(const struct bf_printer *printer, void **str,
+                        size_t *str_len);

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -53,14 +53,14 @@ int bf_program_new(struct bf_program **program, int ifindex, enum bf_hook hook,
     _program->front = front;
     _program->runtime.ops = bf_flavor_ops_get(bf_hook_to_flavor(hook));
 
-    snprintf(_program->prog_name, BPF_OBJ_NAME_LEN, "bpfltr_%02d%02d%04d", hook,
+    snprintf(_program->prog_name, BPF_OBJ_NAME_LEN, "bf_prog_%02x%02x%02x", hook,
              front, ifindex);
-    snprintf(_program->cmap_name, BPF_OBJ_NAME_LEN, "bpfltr_%02d%02d%04d", hook,
+    snprintf(_program->cmap_name, BPF_OBJ_NAME_LEN, "bf_cmap_%02x%02x%02x", hook,
              front, ifindex);
     snprintf(_program->prog_pin_path, PIN_PATH_LEN,
-             "/sys/fs/bpf/bpfltr_p_%02d%02d%04d", hook, front, ifindex);
+             "/sys/fs/bpf/bf_prog_%02x%02x%02x", hook, front, ifindex);
     snprintf(_program->cmap_pin_path, PIN_PATH_LEN,
-             "/sys/fs/bpf/bpfltr_m_%02d%02d%04d", hook, front, ifindex);
+             "/sys/fs/bpf/bf_cmap_%02x%02x%02x", hook, front, ifindex);
 
     r = bf_printer_new(&_program->printer);
     if (r)

--- a/src/generator/program.c
+++ b/src/generator/program.c
@@ -930,30 +930,3 @@ int bf_codegen_set_counters(struct bf_program *program,
 
     return -ENOTSUP;
 }
-
-int bf_program_attach(struct bf_program *new_prog, struct bf_program *old_prog)
-{
-    int r;
-
-    bf_assert(new_prog);
-
-    r = _bf_program_load_counters_map(new_prog);
-    if (r)
-        return r;
-
-    r = _bf_program_load_printer_map(new_prog);
-    if (r)
-        return r;
-
-    r = new_prog->runtime.ops->attach_prog(new_prog, old_prog);
-    if (r)
-        return r;
-
-    if (!bf_opts_transient()) {
-        if (old_prog)
-            _bf_program_unpin(old_prog);
-        r = _bf_program_pin(new_prog);
-    }
-
-    return r;
-}

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -161,9 +161,13 @@ struct bf_program
     char prog_name[BPF_OBJ_NAME_LEN];
     /// Counters map name.
     char cmap_name[BPF_OBJ_NAME_LEN];
+    /// Printer map name.
+    char pmap_name[BPF_OBJ_NAME_LEN];
     char prog_pin_path[PIN_PATH_LEN];
     /// Counters map pinning path.
     char cmap_pin_path[PIN_PATH_LEN];
+    /// Pinter map pinning path.
+    char pmap_pin_path[PIN_PATH_LEN];
 
     /// Log messages printer.
     struct bf_printer *printer;
@@ -188,6 +192,8 @@ struct bf_program
         int prog_fd;
         /** File descriptor of the counters map. */
         int cmap_fd;
+        /** File descriptor of the printer map. */
+        int pmap_fd;
         /** Hook-specific ops to use to generate the program. */
         const struct bf_flavor_ops *ops;
     } runtime;

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -22,6 +22,7 @@
 #include "core/list.h"
 #include "core/verdict.h"
 #include "generator/fixup.h"
+#include "generator/printer.h"
 #include "generator/reg.h"
 #include "shared/front.h"
 
@@ -163,6 +164,9 @@ struct bf_program
     char prog_pin_path[PIN_PATH_LEN];
     /// Counters map pinning path.
     char cmap_pin_path[PIN_PATH_LEN];
+
+    /// Log messages printer.
+    struct bf_printer *printer;
 
     /** Number of counters in the counters map. Not all of them are used by
      * the program, but this value is common for all the programs of a given

--- a/src/generator/program.h
+++ b/src/generator/program.h
@@ -158,9 +158,11 @@ struct bf_program
     enum bf_hook hook;
     enum bf_front front;
     char prog_name[BPF_OBJ_NAME_LEN];
-    char map_name[BPF_OBJ_NAME_LEN];
+    /// Counters map name.
+    char cmap_name[BPF_OBJ_NAME_LEN];
     char prog_pin_path[PIN_PATH_LEN];
-    char map_pin_path[PIN_PATH_LEN];
+    /// Counters map pinning path.
+    char cmap_pin_path[PIN_PATH_LEN];
 
     /** Number of counters in the counters map. Not all of them are used by
      * the program, but this value is common for all the programs of a given
@@ -181,7 +183,7 @@ struct bf_program
         /** File descriptor of the program. */
         int prog_fd;
         /** File descriptor of the counters map. */
-        int map_fd;
+        int cmap_fd;
         /** Hook-specific ops to use to generate the program. */
         const struct bf_flavor_ops *ops;
     } runtime;

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -474,6 +474,7 @@ static int _bf_ipt_set_rules_handler(struct ipt_replace *replace, size_t len)
     memcpy(_cache->hook_entry, replace->hook_entry, sizeof(_cache->hook_entry));
     memcpy(_cache->underflow, replace->underflow, sizeof(_cache->underflow));
     _cache->size = replace->size;
+    _cache->num_entries = replace->num_entries;
 
     free(_cache->entries);
     _cache->entries = TAKE_PTR(entries);

--- a/src/xlate/ipt/ipt.c
+++ b/src/xlate/ipt/ipt.c
@@ -293,8 +293,12 @@ static int _bf_ipt_to_rule(const struct ipt_entry *ipt_rule,
     }
 
     if (ipt_rule->ip.proto) {
+        uint8_t ip_proto = (uint8_t)ipt_rule->ip.proto;
+
+        if (ip_proto != ipt_rule->ip.proto)
+            return bf_err_code(-EINVAL, "invalid ip.proto %d", ipt_rule->ip.proto);
         r = bf_rule_add_matcher(_rule, BF_MATCHER_IP_PROTO, BF_MATCHER_EQ,
-                                &ipt_rule->ip.proto, sizeof(uint16_t));
+                                &ip_proto, sizeof(uint8_t));
     }
 
     if (offset < ipt_rule->target_offset) {

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -24,8 +24,8 @@ ExternalProject_Add(nftables
             ${CMAKE_COMMAND} -E env
                 LDFLAGS=$<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
                 CFLAGS=$<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
-                BPFILTER_LIBS=-L${CMAKE_BINARY_DIR}/lib\ -lbpfilter\ -Wl,-rpath=${CMAKE_BINARY_DIR}/lib
-                BPFILTER_CFLAGS=-I${CMAKE_SOURCE_DIR}/lib/include\ -I${CMAKE_SOURCE_DIR}/shared/include
+                BPFILTER_LIBS=-L${CMAKE_BINARY_DIR}/output/lib\ -lbpfilter\ -Wl,-rpath=${CMAKE_BINARY_DIR}/output/lib
+                BPFILTER_CFLAGS=-I${CMAKE_BINARY_DIR}/output/include
                 ./configure
                     --with-bpfilter
                     --disable-man-doc
@@ -51,8 +51,8 @@ ExternalProject_Add(iptables
     CONFIGURE_COMMAND ./autogen.sh
         COMMAND
             ${CMAKE_COMMAND} -E env
-                bpfilter_LIBS=-Wl,-rpath=${CMAKE_BINARY_DIR}/lib\ -L${CMAKE_BINARY_DIR}/lib\ -lbpfilter\ $<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
-                bpfilter_CFLAGS=-I${CMAKE_SOURCE_DIR}/lib/include\ -I${CMAKE_SOURCE_DIR}/shared/include\ $<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
+                bpfilter_LIBS=-Wl,-rpath=${CMAKE_BINARY_DIR}/output/lib\ -L${CMAKE_BINARY_DIR}/output/lib\ -lbpfilter\ $<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
+                bpfilter_CFLAGS=-I${CMAKE_BINARY_DIR}/output/include\ $<$<CONFIG:Debug>:-fsanitize=address\ -fsanitize=undefined>
                 ./configure
                     --enable-bpfilter
                     --disable-ipv6

--- a/tests/unit/src/generator/printer.c
+++ b/tests/unit/src/generator/printer.c
@@ -119,7 +119,6 @@ Test(printer, printer_marsh_unmarsh)
     expect_assert_failure(bf_printer_add_msg(NOT_NULL, NULL));
     expect_assert_failure(bf_printer_add_msg(NULL, NULL));
 
-    _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, 10);
     _cleanup_bf_printer_ struct bf_printer *printer0 = NULL;
     _cleanup_bf_printer_ struct bf_printer *printer1 = NULL;
     const struct bf_printer_msg *msg0;
@@ -147,21 +146,4 @@ Test(printer, printer_marsh_unmarsh)
 
     assert_int_equal(_bf_printer_total_size(printer0),
                      _bf_printer_total_size(printer1));
-}
-
-Test(printer, printer_marsh_unmarsh_failed_map_fd_open)
-{
-    _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, -1);
-    _cleanup_bf_printer_ struct bf_printer *printer0 = NULL;
-    _cleanup_bf_printer_ struct bf_printer *printer1 = NULL;
-    const struct bf_printer_msg *msg0;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-
-    assert_int_equal(bf_printer_new(&printer0), 0);
-    msg0 = bf_printer_add_msg(printer0, "hello");
-    assert_ptr_not_equal(msg0, NULL);
-
-    // Serialise and deserialise the printer
-    assert_int_equal(bf_printer_marsh(printer0, &marsh), 0);
-    assert_error(bf_printer_new_from_marsh(&printer1, marsh));
 }


### PR DESCRIPTION
Someone reached out regarding `iptables`' front-end for `bpfilter` because the following command doesn't seem to block packets as expected (tested with `dig +short google.ch @1.1.1.1`):

```shell
iptables -I INPUT --bpf -p udp -j DROP
```

The `iptables` front-end has been let down a bit over the past weeks, this PR aims to fix this specific issue and make the support for `iptables` more stable (amongst a few other issues found during this process). Here's a list of changes:
- Ensure `libbpfilter.so` and `libbpfilter.a` are build with `-fPIC`, while `lib` and `shared` modules used in the daemon are not.
- Fix `nftables` and `iptables` build following the reorganization of the sources tree.
- In `xlate/ipt`, `ip.proto` matcher should have an 8-bits payload, not 16-bits.
- Manually set `l3_proto` and `l3_offset` runtime context fields for `nf` flavor. Those are usually set by `bf_stub_parse_l2_ethhdr()`, but this function isn't called for `nf`, because `BPF_NETFILTER` programs don't have access to the Ethernet header.
- Improve logging of incoming request, and log a message if a request is received for a disabled front-end.
- Move `bf_printer` out of `bf_context` into `bf_program`, meaning each program will have its own printer map, this will solve some issues about updating the printer map, especially when shared between multiple programs.
- Remove unused `bf_program_attach()` function.
- Use new `bf_codegen` API in the `ipt` front-end, makes it simpler to create a new codegen or update an existing one.
- Fix a buffer overflow in `iptables` by properly returning the number of entries in the response from `bpfilter`.