### PR TITLE
build: drop support for Fedora 38 and Ubuntu 23.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["fedora:38", "fedora:39", "ubuntu:23.10", "ubuntu:24.04"]
+        image: ["fedora:39", "ubuntu:24.04"]
         arch: ["X64", "ARM64"]
     container: ${{ matrix.image }}
     runs-on: [self-hosted, "${{ matrix.arch }}"]
@@ -79,7 +79,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Install dependencies (Fedora)
-        if: ${{ (matrix.image == 'fedora:38') || (matrix.image == 'fedora:39') }}
+        if: matrix.image == 'fedora:39'
         run: |
           sudo dnf --disablerepo=* --enablerepo=fedora,updates --setopt=install_weak_deps=False -y install \
             bison \
@@ -102,7 +102,7 @@ jobs:
             python3-sphinx \
             pkgconf
       - name: Install dependencies (Ubuntu)
-        if: ${{ (matrix.image == 'ubuntu:23.10') || (matrix.image == 'ubuntu:24.04') }}
+        if: matrix.image == 'ubuntu:24.04'
         run: |
           apt-get update
           DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install \

--- a/README.md
+++ b/README.md
@@ -7,15 +7,20 @@ BPF-based packet filtering framework
 
 ## Quick start
 
-To quickly get `bpfilter` up and running on Fedora (38+):
+To quickly get `bpfilter` up and running on Fedora 40:
 
 ```shell
 # Install dependencies
-sudo dnf install \
+sudo dnf install -y \
+    bison \
+    bpftool \
+    clang \
     clang-tools-extra \
     cmake \
+    flex \
     libcmocka-devel \
     doxygen \
+    git \
     lcov \
     libasan \
     libbpf-devel \
@@ -23,6 +28,7 @@ sudo dnf install \
     libubsan \
     python3-breathe \
     python3-furo \
+    python3-linuxdoc \
     python3-sphinx \
     pkgconf
 

--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -1,25 +1,18 @@
 Build from sources
 ==================
 
-This document describes the process to build ``bpfilter`` from sources. While `bpfilter` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon.
-
-``bpfilter`` development is mostly done using Fedora (40, but 38+ supported), but Ubuntu (23.10+) is also officially supported. Other distributions may work as long as Linux 6.4+ is available, but they are not officially supported at the moment.
-
-.. note::
-    Ubuntu 22.04 LTS allows for Linux 6.5 to be installed through its Hardware Enablement Stack (HWE). However, this feature only allows for the kernel and the headers **used to build the kernel modules** to be installed in v6.5. The main system kernel headers, located in ``/usr/include``, used to build userspace application, are still in the non-HWE version. This means Ubuntu 22.04 LTS is not supported by ``bpfilter``, even with the HWE stack.
-
-.. note::
-    Ubuntu 23.10 is running Linux 6.5, which is too old to support TCX hooks used by ``bpfilter``. Creating a TCX BPF program with ``bpfilter`` will return an error on Ubuntu 23.10.
+This document describes the process to build ``bpfilter`` from sources. While `bpfilter` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon. ``bpfilter`` officially supports Fedora 39 and 40, and Ubuntu 24.04 LTS.
 
 Required dependencies on Fedora and Ubuntu:
 
 .. code-block:: shell
 
-    # Fedora 40
-    bpftool clang clang-tools-extra cmake libcmocka-devel doxygen lcov libasan libbpf-devel libnl3-devel libubsan python3-breathe python3-furo python3-sphinx pkgconf
+    # Fedora
+    sudo dnf install -y bison bpftool clang clang-tools-extra cmake doxygen flex git lcov libasan libbpf-devel libcmocka-devel libnl3-devel libubsan python3-breathe python3-furo python3-linuxdoc python3-sphinx pkgconf
 
-    # Ubuntu 24.04
-    clang clang-format clang-tidy cmake doxygen furo lcov libbpf-dev libcmocka-dev libnl-3-dev linux-tools-common pkgconf python3-breathe python3-sphinx
+    # Ubuntu
+    sudo apt-get install -y bison clang clang-format clang-tidy cmake doxygen flex git furo lcov libpf-dev libcmocka-dev libnl-3-dev linux-tools-common python3-breathe python3-pip python3-sphinx pkgconf
+    pip3 install linuxdoc
 
 You can then use CMake to generate the build system:
 

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -7,12 +7,6 @@
 
 #include "shared/helper.h"
 
-/* Linux 6.4 and 6.5 doesn't support TCX, for BPF_TCX_{INGRESS,EGRESS} are not
- * defined. Defining them here allow for Ubuntu 23.10 to build and use bpfilter,
- * although bpfilter wouldn't be able to attach a TCX program. */
-#define BPF_TCX_INGRESS 46
-#define BPF_TCX_EGRESS 47
-
 static const char *_bf_hook_strs[] = {
     [BF_HOOK_NFT_INGRESS] = "BF_HOOK_NFT_INGRESS",
     [BF_HOOK_TC_INGRESS] = "BF_HOOK_TC_INGRESS",


### PR DESCRIPTION
Ubuntu 23.10 (https://endoflife.date/ubuntu) and Fedora 38 (https://endoflife.date/fedora) are EOL. I missed this information the last time I updated the documentation, but it's not worth maintaining bpfilter for those distributions.

I don't expect anyone to use bpfilter on those systems, so it's better to drop them now than later. Eventually, bpfilter can be build and run on those, but they're not officially supported.