### PR TITLE
Add missing copyright headers, fix `clang-format` errors, enable mask support for `ip6.(s|d)ddr`

### DIFF
--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -93,7 +93,7 @@ int main(int argc, char *argv[])
     bf_list_foreach (&chains, chain_node) {
         struct bf_chain *chain = bf_list_node_get_data(chain_node);
         uint32_t index = 0;
-    
+
         bf_list_foreach (&chain->rules, rule_node) {
             struct bf_rule *rule = bf_list_node_get_data(rule_node);
             rule->index = index++;

--- a/src/cli/lexer.l
+++ b/src/cli/lexer.l
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
 %{
     #include <stdio.h>
     #include <stdbool.h>

--- a/src/cli/parser.y
+++ b/src/cli/parser.y
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
 %{
     #include <stdio.h>
     #include <stdlib.h>

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -367,7 +367,7 @@ static int _process_request(struct bf_request *request,
         return bf_response_new_failure(response, -ENOTSUP);
     }
 
-    bf_info("received a request from %s", bf_front_to_str(request->front)); 
+    bf_info("received a request from %s", bf_front_to_str(request->front));
 
     ops = bf_front_ops_get(request->front);
     r = ops->request_handler(request, response);

--- a/src/generator/matcher/ip6.c
+++ b/src/generator/matcher/ip6.c
@@ -25,7 +25,7 @@ static int _bf_matcher_generate_ip6_addr(struct bf_program *program,
     EMIT(program, BPF_LDX_MEM(BPF_DW, BF_REG_1, BF_REG_L3, offset));
     EMIT(program, BPF_LDX_MEM(BPF_DW, BF_REG_2, BF_REG_L3, offset + 8));
 
-    if (0 && addr->mask[0] != ~0ULL || addr->mask[1] != ~0ULL) {
+    if (addr->mask[0] != ~0ULL || addr->mask[1] != ~0ULL) {
         EMIT(program, BPF_MOV32_IMM(BF_REG_3, addr->mask[0] >> 32));
         EMIT(program, BPF_ALU64_IMM(BPF_LSH, BF_REG_3, 32));
         EMIT(program, BPF_MOV32_IMM(BF_REG_4, addr->mask[0] & 0xffffffff));

--- a/tests/bpf/xdp_printk.bpf.c
+++ b/tests/bpf/xdp_printk.bpf.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 

--- a/tests/bpf/xdp_printk.c
+++ b/tests/bpf/xdp_printk.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
 #include <stdio.h>
 
 #include "xdp_printk.skeleton.h"


### PR DESCRIPTION
Pretty much what is described in the title, see commits for more details.