### PR TITLE
doc: modify the copyright template for Meta automatic validation

### DIFF
--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -156,11 +156,11 @@
             <div class="copyright">
               {%- if hasdoc('copyright') %}
                 {% trans path=pathto('copyright'), copyright=copyright|e -%}
-                  <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}
+                  <a href="{{ path }}">Copyright ©{{ copyright }}</a>
                 {%- endtrans %}
               {%- else %}
                 {% trans copyright=copyright|e -%}
-                  Copyright &#169; {{ copyright }}
+                  Copyright ©{{ copyright }}
                 {%- endtrans %}
               {%- endif %}
             </div>


### PR DESCRIPTION
A Meta internal bot will ensure the project's homepage contains a valid copyright. This requirement was failing because the copyright string contains the hex code for the copyright symbol, instead of the symbol itself. Use the symbol instead.