### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center">
-    <img src="doc/_static/logo-light-mode.png" height="250" alt="bpfilter"/>
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="doc/_static/logo-dark-mode.png">
+        <source media="(prefers-color-scheme: light)" srcset="doc/_static/logo-light-mode.png">
+        <img src="doc/_static/logo-light-mode.png"  height="250" alt="bpfilter">
+    </picture>
 </p>
 
 <h3 align="center">An <a href="https://ebpf.io/">eBPF</a>-based packet filtering framework.</h3>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -1,4 +1,4 @@
-{% extends "furo/page.html" %}
+{% extends "furo/base.html" %}
 
 {% block body -%}
 {{ super() }}


### PR DESCRIPTION
- Change `page.html` to extend `furo/base.html`, not `furo/page.html`. This prevents the `bpfilter` website's pages from being duplicated.
- Configure the logo in `README.md` to follow the user's color mode.