### PR TITLE
Big clean-up PR!

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,30 +4,67 @@
 # check-by-check basis.
 #
 # Disabled checks:
+# - bugprone-assignment-in-if-condition
+#   Very carefully used, but useful when reading a bf_marsh.
+# - bugprone-easily-swappable-parameters
+#   Too many false positives, especially when swapable arguments are of different
+#   types (which will be flagged by the compiler).
+# - cert-dcl37-c
+#   Handled by bugprone-reserved-identifier.AllowedIdentifiers.
+# - cert-dcl51-cpp
+#   Handled by bugprone-reserved-identifier.AllowedIdentifiers.
 # - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
 #   Avoid usage of Annex K functions for portability reasons.
+# - clang-analyzer-unix.Malloc
+#   Generates false positives.
+# - modernize-macro-to-enum
+#   No benefit.
+# - readability-function-cognitive-complexity
+#   Functions generating BPF bytecode will trigger this rule anytime, but they're
+#   not that complex due to heavy use of macros.
+# - readability-isolate-declaration
+#   Rely on manual check: it's uncommon in bpfilter for multiple variable to be
+#   defined on a single line, but it's sometimes for the better.
 Checks: >
   -*,
   bugprone-*,
+    -bugprone-assignment-in-if-condition,
+    -bugprone-easily-swappable-parameters,
   cert-*,
+    -cert-dcl37-c,
+    -cert-dcl51-cpp,
   clang-analyzer-*,
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
-  concurrency-*,
+    -clang-analyzer-unix.Malloc,
   misc-*,
   modernize-*,
+    -modernize-macro-to-enum,
   performance-*,
   portability-*,
-  readability-*
+  readability-*,
+    -readability-function-cognitive-complexity,
+    -readability-isolate-declaration
 
 WarningsAsErrors: ''
-HeaderFilterRegex: '^(?!external\/filter.h).*'
 FormatStyle: none
 UseColor: yes
 
 CheckOptions:
-  # Allowed short variable names
-  - key: readability-identifier-length.IgnoredVariableNames
-    value: 'fd|r'
+  # Allow use of reserved identifiers as long as they start with "_bf_"
+  - key: bugprone-reserved-identifier.AllowedIdentifiers
+    value: _(bf|BF)_[a-zA-Z0-9_]+
   # Unless a *statement* takes 1 line, it should be in braces
   - key: readability-braces-around-statements.ShortStatementLines
-    value: 2
+    value: 6
+  # Allowed short variable names
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: '_|i|fd|r|j[0-9]|op'
+  # Allowed short parameter names
+  - key: readability-identifier-length.IgnoredParameterNames
+    value: 'ip|fd|op'
+  # Allow for magic constants that are power of 2.
+  - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
+    value: true
+  # Allow specific masks
+  - key: readability-magic-numbers.IgnoredIntegerValues
+    value: 255;65535

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
             libcmocka-devel \
             doxygen \
             git \
+            jq \
             lcov \
             libasan \
             libbpf-devel \
@@ -90,6 +91,7 @@ jobs:
             doxygen \
             flex \
             git \
+            jq \
             lcov \
             libasan \
             libbpf-devel \
@@ -113,8 +115,9 @@ jobs:
             cmake \
             doxygen \
             flex \
-            git \
             furo \
+            git \
+            jq \
             lcov \
             libbpf-dev \
             libcmocka-dev \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Check style
-        run: make -C $GITHUB_WORKSPACE/build checkstyle
+        run: make -C $GITHUB_WORKSPACE/build check
       - name: Generate documentation
         run: make -C $GITHUB_WORKSPACE/build doc
 

--- a/.github/workflows/fork.yaml
+++ b/.github/workflows/fork.yaml
@@ -54,6 +54,6 @@ jobs:
       # Skip unit tests, the GitHub-hosted runners' kernel is too old.
       # Skip coverage as unit tests are not run.
       - name: Check style
-        run: make -C $GITHUB_WORKSPACE/build checkstyle
+        run: make -C $GITHUB_WORKSPACE/build check
       - name: Generate documentation
         run: make -C $GITHUB_WORKSPACE/build doc

--- a/.github/workflows/fork.yaml
+++ b/.github/workflows/fork.yaml
@@ -35,6 +35,7 @@ jobs:
             doxygen \
             flex \
             git \
+            jq \
             lcov \
             libasan \
             libbpf-devel \

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -38,6 +38,7 @@ jobs:
             doxygen \
             flex \
             git \
+            jq \
             lcov \
             libasan \
             libbpf-devel \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ find_program(CLANG_TIDY_BIN clang-tidy REQUIRED)
 find_program(CLANG_FORMAT_BIN clang-format REQUIRED)
 find_program(CLANG_BIN clang REQUIRED)
 find_program(BPFTOOL_BIN bpftool REQUIRED)
+find_program(JQ_BIN jq REQUIRED)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Detailed information can be found in the [documentation](https://bpfilter.io).
         clang-tools-extra \
         cmake \
         flex \
+        jq \
         libcmocka-devel \
         doxygen \
         git \

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -54,3 +54,8 @@ GENERATE_PERLMOD        = NO
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 INCLUDE_PATH            = "@CMAKE_SOURCE_DIR@/src"
+
+#---------------------------------------------------------------------------
+# Configuration options related to diagram generator tools
+#---------------------------------------------------------------------------
+HAVE_DOT                = NO

--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -8,11 +8,10 @@ Required dependencies on Fedora and Ubuntu:
 .. code-block:: shell
 
     # Fedora
-    sudo dnf install -y bison bpftool clang clang-tools-extra cmake doxygen flex git lcov libasan libbpf-devel libcmocka-devel libnl3-devel libubsan python3-breathe python3-furo python3-linuxdoc python3-sphinx pkgconf
+    sudo dnf install -y bison bpftool clang clang-tools-extra cmake doxygen flex git jq lcov libasan libbpf-devel libcmocka-devel libnl3-devel libubsan python3-breathe python3-furo python3-linuxdoc python3-sphinx pkgconf
 
     # Ubuntu
-    sudo apt-get install -y bison clang clang-format clang-tidy cmake doxygen flex git furo lcov libpf-dev libcmocka-dev libnl-3-dev linux-tools-common python3-breathe python3-pip python3-sphinx pkgconf
-    pip3 install linuxdoc
+    sudo apt-get install -y bison clang clang-format clang-tidy cmake doxygen flex furo git jq lcov libpf-dev libcmocka-dev libnl-3-dev linux-tools-common python3-breathe python3-pip python3-sphinx pkgconf pip3 install linuxdoc
 
 You can then use CMake to generate the build system:
 

--- a/doc/developers/style.rst
+++ b/doc/developers/style.rst
@@ -5,7 +5,7 @@ Coding style
 
     This document is not yet complete, it will evolve gradually over time. If you are unsure about a specific rule: check ClangFormat's configuration (``.clang-format``), check this document, and check the existing code. If none of those can answer your question, do as you want.
 
-``bpfilter`` coding style is enforced by ClangFormat, as defined in its configuration file ``.clang-format`` at the root of the repository. The ``checkstyle`` build target can be used to validate all the source files under ``src``, but the issues won't be resolved automatically: changes performed by ClangFormat should be controlled by a developer.
+``bpfilter`` coding style is enforced by ClangFormat, as defined in its configuration file ``.clang-format`` at the root of the repository. The ``check`` build target can be used to validate all the source files under ``src``, but the issues won't be resolved automatically: changes performed by ClangFormat should be controlled by a developer.
 
 To format a source file using ClangFormat (from the root of the repository):
 

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -47,11 +47,11 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
     case 'f':
         opts->input_file = strdup(arg);
         if (!opts->input_file)
-            return bf_err_code(-ENOMEM, "failed to copy input file path");
+            return bf_err_r(-ENOMEM, "failed to copy input file path");
         break;
     case ARGP_KEY_END:
         if (!opts->input_file)
-            return bf_err_code(-EINVAL, "--file argument is required");
+            return bf_err_r(-EINVAL, "--file argument is required");
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     r = argp_parse(&argp, argc, argv, 0, 0, &_bf_opts);
     if (r) {
         r = errno;
-        bf_err_code(r, "failed to parse arguments");
+        bf_err_r(r, "failed to parse arguments");
         goto end_clean;
     }
 
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     FILE *rules = fopen(_bf_opts.input_file, "r");
     if (!rules) {
         r = errno;
-        bf_err_code(r, "failed to read rules from %s:", _bf_opts.input_file);
+        bf_err_r(r, "failed to read rules from %s:", _bf_opts.input_file);
         goto end_clean;
     }
 
@@ -119,13 +119,13 @@ int main(int argc, char *argv[])
 
         r = bf_chain_marsh(chain, &marsh);
         if (r) {
-            bf_err_code(r, "failed to marsh chain, skipping");
+            bf_err_r(r, "failed to marsh chain, skipping");
             continue;
         }
 
         r = bf_request_new(&request, marsh, bf_marsh_size(marsh));
         if (r) {
-            bf_err_code(r, "failed to create request for chain, skipping");
+            bf_err_r(r, "failed to create request for chain, skipping");
             continue;
         }
 
@@ -134,12 +134,12 @@ int main(int argc, char *argv[])
 
         r = bf_send(request, &response);
         if (r) {
-            bf_err_code(r, "failed to send chain creation request, skipping");
+            bf_err_r(r, "failed to send chain creation request, skipping");
             continue;
         }
 
         if (response->type == BF_RES_FAILURE) {
-            bf_err_code(response->error, "chain creation request failed");
+            bf_err_r(response->error, "chain creation request failed");
             continue;
         }
     }

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -73,7 +73,6 @@ int main(int argc, char *argv[])
 
     r = argp_parse(&argp, argc, argv, 0, 0, &_bf_opts);
     if (r) {
-        r = errno;
         bf_err_r(r, "failed to parse arguments");
         goto end_clean;
     }
@@ -160,7 +159,6 @@ void yyerror(struct bf_ruleset *ruleset, const char *fmt, ...)
     va_list args;
 
     va_start(args, fmt);
-    (void)vfprintf(stderr, fmt, args);
-    (void)fprintf(stderr, "\n");
+    bf_err_v(fmt, args);
     va_end(args);
 }

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -73,15 +73,29 @@
 
 // Grammar types
 %type <bval> counter
+
 %type <hook> hook
+
 %type <verdict> verdict
+
 %type <matcher_type> matcher_type
+
 %type <matcher_op> matcher_op
+
 %type <list> matchers
+%destructor { bf_list_free(&$$); } matchers
+
 %type <matcher> matcher
+%destructor { bf_matcher_free(&$$); } matcher
+
 %type <list> rules
+%destructor { bf_list_free(&$$); } rules
+
 %type <rule> rule
+%destructor { bf_rule_free(&$$); } rule
+
 %type <chain> chain
+%destructor { bf_chain_free(&$$); } chain
 
 %%
 chains          : chain

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -14,7 +14,9 @@
     extern int yyparse();
     extern FILE *yyin;
 
-    void yyerror(bf_list *chains, bf_list *sets, const char *fmt, ...);
+    struct bf_ruleset;
+
+    void yyerror(struct bf_ruleset *ruleset, const char *fmt, ...);
 %}
 
 %code requires {
@@ -41,10 +43,22 @@
         __typeof__ (b) _b = (b); \
         _a < _b ? _a : _b;       \
     })
+
+    #define bf_parse_err(fmt, ...)                                             \
+    ({                                                                         \
+        yyerror(ruleset, fmt, ##__VA_ARGS__);                                  \
+        YYABORT;                                                               \
+    })
+
+    struct bf_ruleset
+    {
+        bf_list chains;
+        bf_list sets;
+    };
 }
 
 %define parse.error detailed
-%parse-param {bf_list *chains} {bf_list *sets}
+%parse-param {struct bf_ruleset *ruleset}
 
 %union {
     bool bval;
@@ -100,19 +114,15 @@
 %%
 chains          : chain
                 {
-                    if (bf_list_add_tail(chains, $1) < 0) {
-                        yyerror(chains, sets, "failed to add chain into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail(&ruleset->chains, $1) < 0)
+                        bf_parse_err("failed to add chain into bf_list\n");
 
                     TAKE_PTR($1);
                 }
                 | chains chain
                 {
-                    if (bf_list_add_tail(chains, $2) < 0) {
-                        yyerror(chains, sets, "failed to insert chain into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail(&ruleset->chains, $2) < 0)
+                        bf_parse_err("failed to insert chain into bf_list\n");
 
                     TAKE_PTR($2);
                 }
@@ -122,10 +132,8 @@ chain           : CHAIN hook POLICY verdict rules
                 {
                     _cleanup_bf_chain_ struct bf_chain *chain = NULL;
 
-                    if (bf_chain_new(&chain, $2, $4, sets, $5) < 0) {
-                        yyerror(chains, sets, "failed to create a new bf_chain\n");
-                        YYABORT;
-                    }
+                    if (bf_chain_new(&chain, $2, $4, &ruleset->sets, $5) < 0)
+                        bf_parse_err("failed to create a new bf_chain\n");
 
                     bf_list_free(&$5);
                     $$ = TAKE_PTR(chain);
@@ -135,11 +143,8 @@ verdict         : VERDICT
                 {
                     enum bf_verdict verdict;
 
-                    if (bf_verdict_from_str($1, &verdict) < 0) {
-                        yyerror(chains, sets, "unknown verdict '%s'\n", $1);
-                        free($1);
-                        YYABORT;
-                    }
+                    if (bf_verdict_from_str($1, &verdict) < 0)
+                        bf_parse_err("unknown verdict '%s'\n", $1);
 
                     free($1);
                     $$ = verdict;
@@ -149,11 +154,8 @@ hook            : HOOK
                 {
                     enum bf_hook hook;
 
-                    if (bf_hook_from_str($1, &hook) < 0) {
-                        yyerror(chains, sets, "unknown hook '%s'\n", $1);
-                        free($1);
-                        YYABORT;
-                    }
+                    if (bf_hook_from_str($1, &hook) < 0)
+                        bf_parse_err("unknown hook '%s'\n", $1);
 
                     free($1);
                     $$ = hook;
@@ -163,25 +165,19 @@ rules           : rule
                 {
                     _cleanup_bf_list_ bf_list *list = NULL;
 
-                    if (bf_list_new(&list, (bf_list_ops[]){{.free = (bf_list_ops_free)bf_rule_free}}) < 0) {
-                        yyerror(chains, sets, "failed to allocate a new bf_list for bf_rule\n");
-                        YYABORT;
-                    }
+                    if (bf_list_new(&list, (bf_list_ops[]){{.free = (bf_list_ops_free)bf_rule_free}}) < 0)
+                        bf_parse_err("failed to allocate a new bf_list for bf_rule\n");
 
-                    if (bf_list_add_tail(list, $1) < 0) {
-                        yyerror(chains, sets, "failed to add rule into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail(list, $1) < 0)
+                        bf_parse_err("failed to add rule into bf_list\n");
 
                     TAKE_PTR($1);
                     $$ = TAKE_PTR(list);
                 }
                 | rules rule
                 {
-                    if (bf_list_add_tail($1, $2) < 0) {
-                        yyerror(chains, sets, "failed to insert rule into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail($1, $2) < 0)
+                        bf_parse_err("failed to insert rule into bf_list\n");
 
                     TAKE_PTR($2);
                     $$ = TAKE_PTR($1);
@@ -191,10 +187,8 @@ rule            : RULE matchers counter verdict
                 {
                     _cleanup_bf_rule_ struct bf_rule *rule = NULL;
 
-                    if (bf_rule_new(&rule) < 0) {
-                        yyerror(chains, sets, "failed to create a new bf_rule\n");
-                        YYABORT;
-                    }
+                    if (bf_rule_new(&rule) < 0)
+                        bf_parse_err("failed to create a new bf_rule\n");
 
                     rule->counters = $3;
                     rule->verdict = $4;
@@ -202,10 +196,8 @@ rule            : RULE matchers counter verdict
                     bf_list_foreach ($2, matcher_node) {
                         struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
 
-                        if (bf_list_add_tail(&rule->matchers, matcher) < 0) {
-                            yyerror(chains, sets, "failed to add matcher to the rule\n");
-                            YYABORT;
-                        }
+                        if (bf_list_add_tail(&rule->matchers, matcher) < 0)
+                            bf_parse_err("failed to add matcher to the rule\n");
 
                         bf_list_node_take_data(matcher_node);
                     }
@@ -219,25 +211,19 @@ matchers        : matcher
                 {
                     _cleanup_bf_list_ bf_list *list = NULL;
 
-                    if (bf_list_new(&list, (bf_list_ops[]){{.free = (bf_list_ops_free)bf_matcher_free}}) < 0) {
-                        yyerror(chains, sets, "failed to allocate a new bf_list for bf_matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_list_new(&list, (bf_list_ops[]){{.free = (bf_list_ops_free)bf_matcher_free}}) < 0)
+                        bf_parse_err("failed to allocate a new bf_list for bf_matcher\n");
 
-                    if (bf_list_add_tail(list, $1) < 0) {
-                        yyerror(chains, sets, "failed to insert matcher into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail(list, $1) < 0)
+                        bf_parse_err("failed to insert matcher into bf_list\n");
 
                     TAKE_PTR($1);
                     $$ = TAKE_PTR(list);
                 }
                 | matchers matcher
                 {
-                    if (bf_list_add_tail($1, $2) < 0) {
-                        yyerror(chains, sets, "failed to insert matcher into bf_list\n");
-                        YYABORT;
-                    }
+                    if (bf_list_add_tail($1, $2) < 0)
+                        bf_parse_err("failed to insert matcher into bf_list\n");
 
                     TAKE_PTR($2);
                     $$ = TAKE_PTR($1);
@@ -248,21 +234,17 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint16_t proto;
 
-                    if (bf_streq($3, "ipv4")) {
+                    if (bf_streq($3, "ipv4"))
                         proto = ETH_P_IP;
-                    } else if (bf_streq($3, "ipv6")) {
+                    else if (bf_streq($3, "ipv6"))
                         proto = ETH_P_IPV6;
-                    } else {
-                        yyerror(chains, sets, "unsupported L3 protocol to match '%s'\n", $3);
-                        YYABORT;
-                    }
+                    else
+                        bf_parse_err("unsupported L3 protocol to match '%s'\n", $3);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0)
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -271,25 +253,21 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint8_t proto;
 
-                    if (bf_streq($3, "icmp")) {
+                    if (bf_streq($3, "icmp"))
                         proto = IPPROTO_ICMP;
-                    } else if (bf_streq($3, "tcp")) {
+                    else if (bf_streq($3, "tcp"))
                         proto = IPPROTO_TCP;
-                    } else if (bf_streq($3, "udp")) {
+                    else if (bf_streq($3, "udp"))
                         proto = IPPROTO_UDP;
-                    } else if (bf_streq($3, "icmp6")) {
+                    else if (bf_streq($3, "icmp6"))
                         proto = IPPROTO_ICMPV6;
-                    } else {
-                        yyerror(chains, sets, "unsupported L4 protocol to match '%s'\n", $3);
-                        YYABORT;
-                    }
+                    else
+                        bf_parse_err("unsupported L4 protocol to match '%s'\n", $3);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0)
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -298,19 +276,15 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint8_t proto;
 
-                    if (bf_streq($3, "icmp")) {
+                    if (bf_streq($3, "icmp"))
                         proto = IPPROTO_ICMP;
-                    } else {
-                        yyerror(chains, sets, "unsupported ip4.proto value '%s'\n", $3);
-                        YYABORT;
-                    }
+                    else
+                        bf_parse_err("unsupported ip4.proto value '%s'\n", $3);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &proto, sizeof(proto)) < 0)
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -328,10 +302,8 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                         ++mask;
 
                         int m = atoi(mask);
-                        if (m == 0) {
-                            yyerror(chains, sets, "failed to parse IPv4 mask: %s\n", mask);
-                            YYABORT;
-                        }
+                        if (m == 0)
+                            bf_parse_err("failed to parse IPv4 mask: %s\n", mask);
 
                         addr.mask = ((uint32_t)~0) << (32 - m);
                     } else {
@@ -340,17 +312,13 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
 
                     // Convert the IPv4 from string to uint32_t.
                     r = inet_pton(AF_INET, $3, &addr.addr);
-                    if (r != 1) {
-                        yyerror(chains, sets, "failed to parse IPv4 adddress: %s\n", $3);
-                        YYABORT;
-                    }
+                    if (r != 1)
+                        bf_parse_err("failed to parse IPv4 adddress: %s\n", $3);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &addr, sizeof(addr))) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &addr, sizeof(addr)))
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -359,17 +327,15 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
                     _cleanup_bf_set_ struct bf_set *set = NULL;
                     struct bf_matcher_ip4_addr addr;
-                    uint32_t set_id = bf_list_size(sets);
+                    uint32_t set_id = bf_list_size(&ruleset->sets);
                     int r;
 
                     char *data = $3 + 1;
                     data[strlen(data) - 1] = '\0';
 
                     r = bf_set_new(&set, BF_SET_IP4);
-                    if (r < 0) {
-                        yyerror(chains, sets, "failed to create a new set\n");
-                        YYABORT;
-                    }
+                    if (r < 0)
+                        bf_parse_err("failed to create a new set\n");
 
                     fprintf(stderr, "set matching for: %s\n", data);
 
@@ -377,10 +343,8 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     char *next = data;
                     do {
                         _cleanup_free_ uint32_t *value = malloc(sizeof(uint32_t));
-                        if (!value) {
-                            yyerror(chains, sets, "failed to allocate memory for IPv4 address\n");
-                            YYABORT;
-                        }
+                        if (!value)
+                            bf_parse_err("failed to allocate memory for IPv4 address\n");
 
                         ip = next;
                         next = strchr(ip, ',');
@@ -396,8 +360,7 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
 
                         r = inet_pton(AF_INET, ip, value);
                         if (r != 1) {
-                            yyerror(chains, sets, "failed to parse IPv4 address: %s\n", ip);
-                            YYABORT;
+                            bf_parse_err("failed to parse IPv4 address: %s\n", ip);
                         } else {
                             uint8_t *i = (void *)&addr.addr;
 
@@ -405,26 +368,20 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                         }
 
                         r = bf_set_add_elem(set, value);
-                        if (r < 0) {
-                            yyerror(chains, sets, "failed to add element to set\n");
-                            YYABORT;
-                        }
+                        if (r < 0)
+                            bf_parse_err("failed to add element to set\n");
                     } while (next);
 
-                    r = bf_list_add_tail(sets, set);
-                    if (r < 0) {
-                        yyerror(chains, sets, "failed to add new set to list of sets\n");
-                        YYABORT;
-                    }
+                    r = bf_list_add_tail(&ruleset->sets, set);
+                    if (r < 0)
+                        bf_parse_err("failed to add new set to list of sets\n");
 
                     TAKE_PTR(set);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &set_id, sizeof(set_id))) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &set_id, sizeof(set_id)))
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -443,10 +400,8 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                         ++mask;
 
                         int m = atoi(mask);
-                        if (m == 0) {
-                            yyerror(chains, sets, "failed to parse IPv6 mask: %s\n", mask);
-                            YYABORT;
-                        }
+                        if (m == 0)
+                            bf_parse_err("failed to parse IPv6 mask: %s\n", mask);
 
                         shift = 128 - m;
                         lsb_shift = min(64, shift);
@@ -461,17 +416,13 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
 
                     // Convert the IPv6 from string to uint64_t[2].
                     r = inet_pton(AF_INET6, $3, addr.addr);
-                    if (r != 1) {
-                        yyerror(chains, sets, "failed to parse IPv6 adddress: %s\n", $3);
-                        YYABORT;
-                    }
+                    if (r != 1)
+                        bf_parse_err("failed to parse IPv6 adddress: %s\n", $3);
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &addr, sizeof(addr))) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &addr, sizeof(addr)))
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -482,19 +433,15 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
                     uint16_t port;
 
                     raw_val = atol($3);
-                    if (raw_val <= 0 || USHRT_MAX < raw_val) {
-                        yyerror(chains, sets, "invalid port value: %s\n", $3);
-                        YYABORT;
-                    }
+                    if (raw_val <= 0 || USHRT_MAX < raw_val)
+                        bf_parse_err("invalid port value: %s\n", $3);
 
                     port = (uint16_t)raw_val;
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &port, sizeof(port))) {
-                        yyerror(chains, sets, "failed to create new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &port, sizeof(port)))
+                        bf_parse_err("failed to create new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -516,7 +463,7 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
 
                         r = bf_matcher_tcp_flag_from_str(token, &flag);
                         if (r) {
-                            yyerror(chains, sets, "Unknown TCP flag '%s', ignoring\n", token);
+                            bf_parse_err("Unknown TCP flag '%s', ignoring\n", token);
                             continue;
                         }
 
@@ -525,10 +472,8 @@ matcher         : matcher_type matcher_op MATCHER_META_L3_PROTO
 
                     free($3);
 
-                    if (bf_matcher_new(&matcher, $1, $2, &flags, sizeof(flags))) {
-                        yyerror(chains, sets, "failed to create a new matcher\n");
-                        YYABORT;
-                    }
+                    if (bf_matcher_new(&matcher, $1, $2, &flags, sizeof(flags)))
+                        bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
@@ -537,11 +482,8 @@ matcher_type    : MATCHER_TYPE
                 {
                     enum bf_matcher_type type;
 
-                    if (bf_matcher_type_from_str($1, &type) < 0) {
-                        yyerror(chains, sets, "unknown matcher type '%s'\n", $1);
-                        free($1);
-                        YYABORT;
-                    }
+                    if (bf_matcher_type_from_str($1, &type) < 0)
+                        bf_parse_err("unknown matcher type '%s'\n", $1);
 
                     free($1);
                     $$ = type;
@@ -551,10 +493,8 @@ matcher_op      : %empty { $$ = BF_MATCHER_EQ; }
                 {
                     enum bf_matcher_op op;
 
-                    if (bf_matcher_op_from_str($1, &op) < 0) {
-                        yyerror(chains, sets, "unknown matcher operator '%s'\n", $1);
-                        YYABORT;
-                    }
+                    if (bf_matcher_op_from_str($1, &op) < 0)
+                        bf_parse_err("unknown matcher operator '%s'\n", $1);
 
                     free($1);
                     $$ = op;

--- a/src/bpfilter/cgen/codegen.c
+++ b/src/bpfilter/cgen/codegen.c
@@ -71,7 +71,7 @@ int bf_codegen_unload(struct bf_codegen *codegen)
         struct bf_program *program = bf_list_node_get_data(program_node);
         r = bf_program_unload(program);
         if (r)
-            return bf_err_code(r, "failed to unload program");
+            return bf_err_r(r, "failed to unload program");
     }
 
     return 0;
@@ -141,7 +141,7 @@ int bf_codegen_marsh(const struct bf_codegen *codegen, struct bf_marsh **marsh)
                                 sizeof(codegen->policy));
 
     if (r)
-        return bf_err_code(r, "failed to serialize codegen");
+        return bf_err_r(r, "failed to serialize codegen");
 
     *marsh = TAKE_PTR(_marsh);
 
@@ -160,7 +160,7 @@ int bf_codegen_unmarsh(const struct bf_marsh *marsh,
 
     r = bf_codegen_new(&_codegen);
     if (r)
-        return bf_err_code(r, "failed to allocate codegen object");
+        return bf_err_r(r, "failed to allocate codegen object");
 
     if (!(marsh_elem = bf_marsh_next_child(marsh, NULL)))
         return -EINVAL;
@@ -316,12 +316,12 @@ int bf_codegen_up(struct bf_codegen *codegen)
 
     n_ifaces = bf_if_get_ifaces(&ifaces);
     if (n_ifaces < 0) {
-        return bf_err_code((int)n_ifaces,
-                           "failed to fetch interfaces for codegen");
+        return bf_err_r((int)n_ifaces,
+                        "failed to fetch interfaces for codegen");
     }
 
     if (n_ifaces == 0)
-        return bf_err_code(-ENOENT, "no interface found!");
+        return bf_err_r(-ENOENT, "no interface found!");
 
     for (ssize_t i = 0; i < n_ifaces; ++i) {
         _cleanup_bf_program_ struct bf_program *prog = NULL;
@@ -336,8 +336,8 @@ int bf_codegen_up(struct bf_codegen *codegen)
 
         r = bf_program_generate(prog, &codegen->rules, codegen->policy);
         if (r) {
-            return bf_err_code(r, "failed to generate bf_program for %s",
-                               ifaces[i].name);
+            return bf_err_r(r, "failed to generate bf_program for %s",
+                            ifaces[i].name);
         }
 
         r = bf_program_load(prog, NULL);
@@ -367,19 +367,19 @@ int bf_codegen_update(struct bf_codegen *codegen)
         r = bf_program_new(&new_prog, old_prog->ifindex, codegen->hook,
                            codegen->front);
         if (r)
-            return bf_err_code(r, "failed to create a new bf_program");
+            return bf_err_r(r, "failed to create a new bf_program");
 
         r = bf_program_generate(new_prog, &codegen->rules, codegen->policy);
         if (r) {
             {
-                return bf_err_code(
+                return bf_err_r(
                     r, "failed to generate the bytecode for a new bf_program");
             }
         }
 
         r = bf_program_load(new_prog, old_prog);
         if (r) {
-            return bf_err_code(
+            return bf_err_r(
                 r, "failed to attach the new bf_program, keeping the old one");
         }
 

--- a/src/bpfilter/cgen/codegen.h
+++ b/src/bpfilter/cgen/codegen.h
@@ -15,6 +15,7 @@
 #include "core/verdict.h"
 
 struct bf_marsh;
+struct bf_program;
 
 #define _cleanup_bf_codegen_ __attribute__((cleanup(bf_codegen_free)))
 

--- a/src/bpfilter/cgen/dump.c
+++ b/src/bpfilter/cgen/dump.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+// NOLINTBEGIN
+
 #include "bpfilter/cgen/dump.h"
 
 #include <linux/bpf.h>
@@ -390,3 +392,5 @@ void bf_program_dump_bytecode(const struct bf_program *program, bool with_raw)
     // Force flush, otherwise output on stderr might appear.
     fflush(stdout);
 }
+
+// NOLINTEND

--- a/src/bpfilter/cgen/jmp.c
+++ b/src/bpfilter/cgen/jmp.c
@@ -5,10 +5,21 @@
 
 #include "bpfilter/cgen/jmp.h"
 
+#include <linux/bpf.h>
+
+#include <limits.h>
+#include <stdint.h>
+
 #include "bpfilter/cgen/program.h"
+#include "core/logger.h"
 
 void bf_jmpctx_cleanup(struct bf_jmpctx *ctx)
 {
     struct bpf_insn *insn = &ctx->program->img[ctx->insn_idx];
-    insn->off = ctx->program->img_size - ctx->insn_idx - 1U;
+    size_t off = ctx->program->img_size - ctx->insn_idx - 1U;
+
+    if (off > SHRT_MAX)
+        bf_warn("jump offset overflow: %ld", off);
+
+    insn->off = (int16_t)off;
 }

--- a/src/bpfilter/cgen/jmp.h
+++ b/src/bpfilter/cgen/jmp.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <linux/bpf.h>
-
 #include <stddef.h>
 
 /**
@@ -58,11 +56,11 @@ struct bf_program;
  */
 #define bf_jmpctx_get(program, insn)                                           \
     ({                                                                         \
-        size_t __idx = program->img_size;                                      \
+        size_t __idx = (program)->img_size;                                    \
         int __r = bf_program_emit((program), (insn));                          \
         if (__r < 0)                                                           \
             return __r;                                                        \
-        (struct bf_jmpctx) {.program = program, .insn_idx = __idx};            \
+        (struct bf_jmpctx) {.program = (program), .insn_idx = __idx};          \
     })
 
 /**

--- a/src/bpfilter/cgen/matcher/ip4.c
+++ b/src/bpfilter/cgen/matcher/ip4.c
@@ -5,12 +5,23 @@
 
 #include "bpfilter/cgen/matcher/ip4.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/if_ether.h>
+#include <linux/ip.h>
+
 #include <endian.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/logger.h"
 #include "core/matcher.h"
+
+#include "external/filter.h"
 
 static int
 _bf_matcher_generate_ip4_addr_unique(struct bf_program *program,
@@ -24,7 +35,7 @@ _bf_matcher_generate_ip4_addr_unique(struct bf_program *program,
     EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_1, BF_REG_L3, offset));
     EMIT(program, BPF_MOV32_IMM(BF_REG_2, addr->addr));
 
-    if (addr->mask != 0xffffffff) {
+    if (addr->mask != ~0U) {
         EMIT(program, BPF_MOV32_IMM(BF_REG_3, addr->mask));
         EMIT(program, BPF_ALU32_REG(BPF_AND, BF_REG_2, BF_REG_3));
     }

--- a/src/bpfilter/cgen/matcher/ip4.c
+++ b/src/bpfilter/cgen/matcher/ip4.c
@@ -96,7 +96,7 @@ int bf_matcher_generate_ip4(struct bf_program *program,
         r = _bf_matcher_generate_ip4_proto(program, matcher);
         break;
     default:
-        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
     };
 
     if (r)

--- a/src/bpfilter/cgen/matcher/ip6.c
+++ b/src/bpfilter/cgen/matcher/ip6.c
@@ -124,7 +124,7 @@ int bf_matcher_generate_ip6(struct bf_program *program,
         r = _bf_matcher_generate_ip6_addr(program, matcher);
         break;
     default:
-        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
     };
 
     return r;

--- a/src/bpfilter/cgen/matcher/ip6.c
+++ b/src/bpfilter/cgen/matcher/ip6.c
@@ -5,13 +5,23 @@
 
 #include "bpfilter/cgen/matcher/ip6.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/if_ether.h>
+#include <linux/ipv6.h>
+
 #include <endian.h>
+#include <errno.h>
+#include <stddef.h>
 
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/jmp.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/logger.h"
 #include "core/matcher.h"
+
+#include "external/filter.h"
 
 static int _bf_matcher_generate_ip6_addr(struct bf_program *program,
                                          const struct bf_matcher *matcher)

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -5,12 +5,20 @@
 
 #include "bpfilter/cgen/matcher/meta.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+
 #include <endian.h>
+#include <errno.h>
+#include <stdint.h>
 
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/logger.h"
 #include "core/matcher.h"
+
+#include "external/filter.h"
 
 static int _bf_matcher_generate_meta_l3_proto(struct bf_program *program,
                                               const struct bf_matcher *matcher)

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -57,7 +57,7 @@ int bf_matcher_generate_meta(struct bf_program *program,
         r = _bf_matcher_generate_meta_l4_proto(program, matcher);
         break;
     default:
-        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
     };
 
     if (r)

--- a/src/bpfilter/cgen/matcher/tcp.c
+++ b/src/bpfilter/cgen/matcher/tcp.c
@@ -66,8 +66,8 @@ static int _bf_matcher_generate_tcp_flags(struct bf_program *program,
                    BPF_JMP_IMM(BPF_JNE, BPF_REG_1, flags, 0));
         break;
     default:
-        return bf_err_code(-EINVAL, "unsupported matcher for tcp.flags: %s",
-                           bf_matcher_op_to_str(matcher->op));
+        return bf_err_r(-EINVAL, "unsupported matcher for tcp.flags: %s",
+                        bf_matcher_op_to_str(matcher->op));
     }
 
     return 0;
@@ -92,7 +92,7 @@ int bf_matcher_generate_tcp(struct bf_program *program,
         r = _bf_matcher_generate_tcp_flags(program, matcher);
         break;
     default:
-        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
     };
 
     return r;

--- a/src/bpfilter/cgen/matcher/tcp.c
+++ b/src/bpfilter/cgen/matcher/tcp.c
@@ -5,18 +5,23 @@
 
 #include "bpfilter/cgen/matcher/tcp.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/in.h> // NOLINT
+#include <linux/tcp.h>
+
 #include <endian.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "bpfilter/cgen/fixup.h"
-#include "bpfilter/cgen/printer.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/logger.h"
 #include "core/matcher.h"
 
-// clang-format off
-// Required because of conflicting definitions from glibc
-#include <linux/in.h>
-// clang-format on
+#include "external/filter.h"
 
 static int _bf_matcher_generate_tcp_port(struct bf_program *program,
                                          const struct bf_matcher *matcher)

--- a/src/bpfilter/cgen/matcher/udp.c
+++ b/src/bpfilter/cgen/matcher/udp.c
@@ -5,19 +5,23 @@
 
 #include "bpfilter/cgen/matcher/udp.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/in.h> // NOLINT
 #include <linux/udp.h>
 
 #include <endian.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/logger.h"
 #include "core/matcher.h"
 
-// clang-format off
-// Required because of conflicting definitions from glibc
-#include <linux/in.h>
-// clang-format on
+#include "external/filter.h"
 
 static int _bf_matcher_generate_udp_port(struct bf_program *program,
                                          const struct bf_matcher *matcher)

--- a/src/bpfilter/cgen/matcher/udp.c
+++ b/src/bpfilter/cgen/matcher/udp.c
@@ -55,7 +55,7 @@ int bf_matcher_generate_udp(struct bf_program *program,
         r = _bf_matcher_generate_udp_port(program, matcher);
         break;
     default:
-        return bf_err_code(-EINVAL, "unknown matcher type %d", matcher->type);
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
     };
 
     return r;

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -188,26 +188,26 @@ static int _bf_nf_attach_prog(struct bf_program *new_prog,
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)
-        return bf_err_code(r, "failed to load new bf_program");
+        return bf_err_r(r, "failed to load new bf_program");
 
     if (old_prog) {
         r = bf_bpf_nf_link_create(prog_fd, new_prog->hook, 1, &tmp_fd);
         if (r)
-            return bf_err_code(r, "failed to create temporary link");
+            return bf_err_r(r, "failed to create temporary link");
 
         closep(&old_prog->runtime.prog_fd);
 
         r = bf_bpf_nf_link_create(prog_fd, new_prog->hook,
                                   (int)new_prog->ifindex, &link_fd);
         if (r)
-            return bf_err_code(r, "failed to create final link");
+            return bf_err_r(r, "failed to create final link");
 
         new_prog->runtime.prog_fd = TAKE_FD(link_fd);
     } else {
         r = bf_bpf_nf_link_create(prog_fd, new_prog->hook,
                                   (int)new_prog->ifindex, &link_fd);
         if (r) {
-            return bf_err_code(
+            return bf_err_r(
                 r, "failed to create a new link for BPF_NETFILTER bf_program");
         }
 

--- a/src/bpfilter/cgen/printer.c
+++ b/src/bpfilter/cgen/printer.c
@@ -5,9 +5,11 @@
 
 #include "bpfilter/cgen/printer.h"
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "core/bpf.h"
+#include "core/dump.h"
 #include "core/helper.h"
 #include "core/list.h"
 #include "core/logger.h"
@@ -231,6 +233,9 @@ int bf_printer_new_from_marsh(struct bf_printer **printer,
             return r;
 
         r = bf_list_add_tail(&_printer->msgs, msg);
+        if (r < 0)
+            return r;
+
         TAKE_PTR(msg);
     }
 

--- a/src/bpfilter/cgen/printer.c
+++ b/src/bpfilter/cgen/printer.c
@@ -91,7 +91,7 @@ static int _bf_printer_msg_new_from_marsh(struct bf_printer_msg **msg,
 
     r = _bf_printer_msg_new(&_msg);
     if (r)
-        return bf_err_code(r, "failed to allocate a new bf_printer_msg object");
+        return bf_err_r(r, "failed to allocate a new bf_printer_msg object");
 
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
@@ -158,7 +158,7 @@ static int _bf_printer_msg_marsh(const struct bf_printer_msg *msg,
     r |= bf_marsh_add_child_raw(&_marsh, &msg->len, sizeof(msg->len));
     r |= bf_marsh_add_child_raw(&_marsh, msg->str, msg->len);
     if (r)
-        return bf_err_code(r, "failed to serialize bf_printer_msg object");
+        return bf_err_r(r, "failed to serialize bf_printer_msg object");
 
     *marsh = TAKE_PTR(_marsh);
 
@@ -223,7 +223,7 @@ int bf_printer_new_from_marsh(struct bf_printer **printer,
 
     r = bf_printer_new(&_printer);
     if (r)
-        return bf_err_code(r, "failed to allocate a new bf_printer object");
+        return bf_err_r(r, "failed to allocate a new bf_printer object");
 
     while ((child = bf_marsh_next_child(marsh, child))) {
         _cleanup_bf_printer_msg_ struct bf_printer_msg *msg = NULL;

--- a/src/bpfilter/cgen/printer.h
+++ b/src/bpfilter/cgen/printer.h
@@ -5,9 +5,12 @@
 
 #pragma once
 
+#include <linux/bpf.h>
+
 #include <stddef.h>
 
 #include "bpfilter/context.h"
+#include "core/dump.h"
 
 /**
  * @file printer.h
@@ -67,7 +70,7 @@ struct bf_printer_msg;
     ({                                                                         \
         int __r;                                                               \
         const struct bf_printer_msg *__msg =                                   \
-            bf_printer_add_msg(program->printer, msg);                         \
+            bf_printer_add_msg((program)->printer, (msg));                     \
         struct bpf_insn __ld_insn[2] = {                                       \
             BPF_LD_MAP_FD(BF_ARG_1, 0),                                        \
         };                                                                     \

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -19,12 +19,15 @@
 
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/printer.h"
-#include "bpfilter/cgen/reg.h"
 #include "core/dump.h"
+#include "core/flavor.h"
 #include "core/front.h"
+#include "core/helper.h"
 #include "core/hook.h"
 #include "core/list.h"
 #include "core/verdict.h"
+
+#include "external/filter.h"
 
 #define PIN_PATH_LEN 64
 
@@ -199,8 +202,8 @@ struct bf_program
 
 #define _cleanup_bf_program_ __attribute__((__cleanup__(bf_program_free)))
 
-int bf_program_new(struct bf_program **program, int ifindex, enum bf_hook hook,
-                   enum bf_front front);
+int bf_program_new(struct bf_program **program, unsigned int ifindex,
+                   enum bf_hook hook, enum bf_front front);
 void bf_program_free(struct bf_program **program);
 int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh);
 int bf_program_unmarsh(const struct bf_marsh *marsh,

--- a/src/bpfilter/cgen/swich.c
+++ b/src/bpfilter/cgen/swich.c
@@ -5,9 +5,23 @@
 
 #include "bpfilter/cgen/swich.h"
 
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "bpfilter/cgen/jmp.h"
 #include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
 #include "core/helper.h"
+#include "core/list.h"
+#include "core/logger.h"
+
+#include "external/filter.h"
 
 /// Cleanup attribute for a @ref bf_swich_option variable.
 #define _cleanup_bf_swich_option_                                              \

--- a/src/bpfilter/cgen/swich.h
+++ b/src/bpfilter/cgen/swich.h
@@ -5,9 +5,12 @@
 
 #pragma once
 
+#include <linux/bpf.h>
+
 #include <stdint.h>
 
 #include "bpfilter/cgen/reg.h"
+#include "core/helper.h"
 #include "core/list.h"
 
 /**

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -124,12 +124,12 @@ static int _bf_tc_attach_prog(struct bf_program *new_prog,
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)
-        return bf_err_code(r, "failed to load new bf_program");
+        return bf_err_r(r, "failed to load new bf_program");
 
     if (old_prog) {
         r = bf_bpf_link_update(old_prog->runtime.prog_fd, prog_fd);
         if (r) {
-            return bf_err_code(
+            return bf_err_r(
                 r, "failed to updated existing link for TC bf_program");
         }
 
@@ -139,8 +139,7 @@ static int _bf_tc_attach_prog(struct bf_program *new_prog,
                                   bf_hook_to_attach_type(new_prog->hook),
                                   &link_fd);
         if (r) {
-            return bf_err_code(r,
-                               "failed to create new link for TC bf_program");
+            return bf_err_r(r, "failed to create new link for TC bf_program");
         }
 
         new_prog->runtime.prog_fd = TAKE_FD(link_fd);

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -126,12 +126,12 @@ static int _bf_xdp_attach_prog(struct bf_program *new_prog,
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)
-        return bf_err_code(r, "failed to load new bf_program");
+        return bf_err_r(r, "failed to load new bf_program");
 
     if (old_prog) {
         r = bf_bpf_xdp_link_update(old_prog->runtime.prog_fd, prog_fd);
         if (r) {
-            return bf_err_code(
+            return bf_err_r(
                 r, "failed to update existing link for XDP bf_program");
         }
 
@@ -140,8 +140,7 @@ static int _bf_xdp_attach_prog(struct bf_program *new_prog,
         r = bf_bpf_xdp_link_create(prog_fd, new_prog->ifindex, &link_fd,
                                    BF_XDP_MODE_SKB);
         if (r) {
-            return bf_err_code(r,
-                               "failed to create new link for XDP bf_program");
+            return bf_err_r(r, "failed to create new link for XDP bf_program");
         }
 
         new_prog->runtime.prog_fd = TAKE_FD(link_fd);

--- a/src/bpfilter/context.h
+++ b/src/bpfilter/context.h
@@ -11,7 +11,6 @@
 #include "core/dump.h"
 #include "core/front.h"
 #include "core/hook.h"
-#include "core/list.h"
 
 /**
  * @file context.h

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -3,11 +3,16 @@
  * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
  */
 
+#include <errno.h>
+#include <stdlib.h>
+
 #include "bpfilter/cgen/codegen.h"
 #include "bpfilter/context.h"
 #include "bpfilter/xlate/front.h"
 #include "core/chain.h"
-#include "core/dump.h"
+#include "core/front.h"
+#include "core/helper.h"
+#include "core/logger.h"
 #include "core/marsh.h"
 #include "core/request.h"
 #include "core/response.h"

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -54,7 +54,7 @@ int _bf_cli_set_rules(const struct bf_request *request,
 
     r = bf_chain_new_from_marsh(&chain, (void *)request->data);
     if (r)
-        return bf_err_code(r, "failed to create chain from marsh");
+        return bf_err_r(r, "failed to create chain from marsh");
 
     codegen = bf_context_get_codegen(chain->hook, BF_FRONT_CLI);
     if (!codegen) {
@@ -72,15 +72,15 @@ int _bf_cli_set_rules(const struct bf_request *request,
     if (bf_context_get_codegen(chain->hook, BF_FRONT_CLI)) {
         r = bf_codegen_update(codegen);
         if (r)
-            return bf_err_code(r, "failed to update codegen");
+            return bf_err_r(r, "failed to update codegen");
     } else {
         r = bf_codegen_up(codegen);
         if (r)
-            return bf_err_code(r, "failed to load codegen");
+            return bf_err_r(r, "failed to load codegen");
 
         r = bf_context_set_codegen(chain->hook, BF_FRONT_CLI, codegen);
         if (r)
-            return bf_err_code(r, "failed to set codegen in context");
+            return bf_err_r(r, "failed to set codegen in context");
     }
 
     return bf_response_new_success(response, NULL, 0);
@@ -102,8 +102,8 @@ static int _bf_cli_request_handler(struct bf_request *request,
         r = _bf_cli_set_rules(request, response);
         break;
     default:
-        r = bf_err_code(-EINVAL, "unsupported command %d for CLI front-end",
-                        request->cmd);
+        r = bf_err_r(-EINVAL, "unsupported command %d for CLI front-end",
+                     request->cmd);
         break;
     }
 

--- a/src/bpfilter/xlate/front.c
+++ b/src/bpfilter/xlate/front.c
@@ -5,6 +5,7 @@
 
 #include "bpfilter/xlate/front.h"
 
+#include "core/front.h"
 #include "core/helper.h"
 
 extern const struct bf_front_ops ipt_front;

--- a/src/bpfilter/xlate/ipt/dump.c
+++ b/src/bpfilter/xlate/ipt/dump.c
@@ -231,5 +231,5 @@ void bf_ipt_dump_replace(struct ipt_replace *ipt, prefix_t *prefix)
     bf_dump_prefix_pop(prefix);
 
     // Force flush, otherwise output on stderr might appear.
-    fflush(stdout);
+    (void)fflush(stdout);
 }

--- a/src/bpfilter/xlate/nft/nfgroup.c
+++ b/src/bpfilter/xlate/nft/nfgroup.c
@@ -11,8 +11,12 @@
 #include <errno.h>
 #include <limits.h>
 #include <netlink/msg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "bpfilter/xlate/nft/nfmsg.h"
+#include "core/helper.h"
 #include "core/list.h"
 #include "core/response.h"
 
@@ -148,9 +152,9 @@ int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
         return r;
 
     if (msg)
-        *msg = TAKE_PTR(_msg);
-    else
-        TAKE_PTR(_msg);
+        *msg = _msg;
+
+    TAKE_PTR(_msg);
 
     return 0;
 }

--- a/src/bpfilter/xlate/nft/nfmsg.c
+++ b/src/bpfilter/xlate/nft/nfmsg.c
@@ -143,11 +143,11 @@ int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr)
     nlh = nlmsg_put(_msg->msg, 0, seqnr, NFNL_SUBSYS_NFTABLES << 8 | command, 0,
                     0);
     if (!nlh)
-        return bf_err_code(-ENOMEM, "failed to insert Netlink header");
+        return bf_err_r(-ENOMEM, "failed to insert Netlink header");
 
     r = nlmsg_append(_msg->msg, &extra_hdr, sizeof(extra_hdr), NLMSG_ALIGNTO);
     if (r)
-        return bf_err_code(r, "failed to insert Netfilter extra header");
+        return bf_err_r(r, "failed to insert Netfilter extra header");
 
     *msg = TAKE_PTR(_msg);
 
@@ -177,11 +177,11 @@ int bf_nfmsg_new_done(struct bf_nfmsg **msg)
 
     nlh = nlmsg_put(_msg->msg, 0, 0, NLMSG_DONE, 0, NLM_F_MULTI);
     if (!nlh)
-        return bf_err_code(-ENOMEM, "failed to insert Netlink header");
+        return bf_err_r(-ENOMEM, "failed to insert Netlink header");
 
     r = nlmsg_append(_msg->msg, &extra_hdr, sizeof(extra_hdr), NLMSG_ALIGNTO);
     if (r)
-        return bf_err_code(r, "failed to insert Netfilter extra header");
+        return bf_err_r(r, "failed to insert Netfilter extra header");
 
     *msg = TAKE_PTR(_msg);
 
@@ -196,13 +196,13 @@ int bf_nfmsg_new_from_nlmsghdr(struct bf_nfmsg **msg, struct nlmsghdr *nlh)
     _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
 
     if (nlh->nlmsg_type >> 8 != NFNL_SUBSYS_NFTABLES) {
-        return bf_err_code(-EINVAL, "invalid Netlink message type: %u",
-                           nlh->nlmsg_type);
+        return bf_err_r(-EINVAL, "invalid Netlink message type: %u",
+                        nlh->nlmsg_type);
     }
 
     if ((size_t)nlmsg_datalen(nlh) < sizeof(struct nfgenmsg)) {
-        return bf_err_code(-EINVAL, "invalid Netlink message payload size: %d",
-                           nlmsg_datalen(nlh));
+        return bf_err_r(-EINVAL, "invalid Netlink message payload size: %d",
+                        nlmsg_datalen(nlh));
     }
 
     _msg = calloc(1, sizeof(*_msg));

--- a/src/bpfilter/xlate/nft/nfmsg.c
+++ b/src/bpfilter/xlate/nft/nfmsg.c
@@ -10,8 +10,13 @@
 #include <linux/netlink.h>
 
 #include <errno.h>
+#include <libnl3/netlink/attr.h>
 #include <limits.h>
 #include <netlink/msg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/socket.h>
 
 #include "core/helper.h"
 #include "core/logger.h"
@@ -243,7 +248,7 @@ size_t bf_nfmsg_len(const struct bf_nfmsg *msg)
 {
     bf_assert(msg);
 
-    return nlmsg_total_size(bf_nfmsg_data_len(msg));
+    return nlmsg_total_size((int)bf_nfmsg_data_len(msg));
 }
 
 uint8_t bf_nfmsg_command(const struct bf_nfmsg *msg)
@@ -266,7 +271,7 @@ int bf_nfmsg_attr_push(struct bf_nfmsg *msg, uint16_t type, const void *data,
     bf_assert(msg);
     bf_assert(data);
 
-    return nla_put(msg->msg, type, len, data);
+    return nla_put(msg->msg, type, (int)len, data);
 }
 
 int bf_nfmsg_parse(const struct bf_nfmsg *msg, bf_nfattr **attrs, int maxtype,

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -71,8 +71,8 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
 
     r = _bf_bpf(BPF_PROG_LOAD, &attr);
     if (r < 0) {
-        return bf_err_code(r, "failed to load BPF program (%lu bytes):\n%s\n",
-                           img_len, log_buf ?: "(no log buffer available)");
+        return bf_err_r(r, "failed to load BPF program (%lu bytes):\n%s\n",
+                        img_len, log_buf ?: "(no log buffer available)");
     }
 
     *fd = r;

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <linux/bpf.h>
 #include <linux/if_link.h>
 
 #include <stddef.h>
@@ -102,8 +103,8 @@ int bf_bpf_obj_get(const char *path, int *fd);
  *        function is 0.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_bpf_tc_link_create(int prog_fd, int ifindex, enum bpf_attach_type hook,
-                          int *link_fd);
+int bf_bpf_tc_link_create(int prog_fd, unsigned int ifindex,
+                          enum bpf_attach_type hook, int *link_fd);
 
 /**
  * Create a Netfilter BPF link.
@@ -128,7 +129,7 @@ int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
  * @param mode XDP program attach mode. See @ref bf_xdp_attach_mode.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_bpf_xdp_link_create(int prog_fd, int ifindex, int *link_fd,
+int bf_bpf_xdp_link_create(int prog_fd, unsigned int ifindex, int *link_fd,
                            enum bf_xdp_attach_mode mode);
 
 /**

--- a/src/core/btf.c
+++ b/src/core/btf.c
@@ -21,7 +21,7 @@ int bf_btf_setup(void)
 {
     _bf_btf = btf__load_vmlinux_btf();
     if (!_bf_btf)
-        return bf_err_code(errno, "failed to load vmlinux BTF");
+        return bf_err_r(errno, "failed to load vmlinux BTF");
 
     return 0;
 }
@@ -40,7 +40,7 @@ int bf_btf_get_id(const char *name)
 
     id = btf__find_by_name(_bf_btf, name);
     if (id < 0)
-        return bf_err_code(errno, "failed to find BTF type for \"%s\"", name);
+        return bf_err_r(errno, "failed to find BTF type for \"%s\"", name);
 
     return id;
 }
@@ -54,13 +54,13 @@ int bf_btf_get_field_off(const char *struct_name, const char *field_name)
 
     struct_id = btf__find_by_name_kind(_bf_btf, struct_name, BTF_KIND_STRUCT);
     if (struct_id < 0) {
-        return bf_err_code(struct_id, "can't find structure '%s' in kernel BTF",
-                           struct_name);
+        return bf_err_r(struct_id, "can't find structure '%s' in kernel BTF",
+                        struct_name);
     }
 
     type = btf__type_by_id(_bf_btf, struct_id);
     if (!type)
-        return bf_err_code(errno, "can't get btf_type for '%s'", struct_name);
+        return bf_err_r(errno, "can't get btf_type for '%s'", struct_name);
 
     member = (struct btf_member *)(type + 1);
     for (size_t i = 0; i < BTF_INFO_VLEN(type->info); ++i, ++member) {
@@ -72,8 +72,8 @@ int bf_btf_get_field_off(const char *struct_name, const char *field_name)
             offset = BTF_MEMBER_BIT_OFFSET(member->offset);
         } else {
             if (member->offset > INT_MAX) {
-                return bf_err_code(-E2BIG, "BTF member offset is too big: %u",
-                                   member->offset);
+                return bf_err_r(-E2BIG, "BTF member offset is too big: %u",
+                                member->offset);
             }
             offset = (int)member->offset;
         }

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -158,7 +158,7 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
 
         r = bf_marsh_new(&child, NULL, 0);
         if (r < 0)
-            return bf_err_code(r, "failed to create marsh for bf_chain");
+            return bf_err_r(r, "failed to create marsh for bf_chain");
 
         bf_list_foreach (&chain->sets, set_node) {
             _cleanup_bf_marsh_ struct bf_marsh *subchild = NULL;
@@ -183,7 +183,7 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
 
         r = bf_marsh_new(&child, NULL, 0);
         if (r < 0)
-            return bf_err_code(r, "failed to create marsh for bf_chain");
+            return bf_err_r(r, "failed to create marsh for bf_chain");
 
         bf_list_foreach (&chain->rules, rule_node) {
             _cleanup_bf_marsh_ struct bf_marsh *subchild = NULL;

--- a/src/core/dump.c
+++ b/src/core/dump.c
@@ -6,11 +6,13 @@
 #include "dump.h"
 
 #include <stddef.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "core/opts.h"
 
-#define _DUMP_HEXDUMP_LEN 8
+#define BF_DUMP_HEXDUMP_LEN 8
+#define BF_DUMP_TOKEN_LEN 5
 
 void bf_dump_prefix_push(prefix_t *prefix)
 {
@@ -22,13 +24,13 @@ void bf_dump_prefix_push(prefix_t *prefix)
          * continue the previous branch (with a pipe), or remove
          * it altogether if it stopped. */
         strncpy(&_prefix[len - 4], _prefix[len - 4] == '`' ? "    " : "|   ",
-                5);
+                BF_DUMP_TOKEN_LEN);
     }
 
-    if (len + 5 > DUMP_PREFIX_LEN)
+    if (len + BF_DUMP_TOKEN_LEN > DUMP_PREFIX_LEN)
         return;
 
-    strncpy(&_prefix[len], "|-- ", 5);
+    strncpy(&_prefix[len], "|-- ", BF_DUMP_TOKEN_LEN);
 }
 
 prefix_t *bf_dump_prefix_last(prefix_t *prefix)
@@ -37,7 +39,7 @@ prefix_t *bf_dump_prefix_last(prefix_t *prefix)
     size_t len = strlen(_prefix);
 
     if (len)
-        strncpy(&_prefix[len - 4], "`-- ", 5);
+        strncpy(&_prefix[len - 4], "`-- ", BF_DUMP_TOKEN_LEN);
 
     return prefix;
 }
@@ -54,13 +56,13 @@ void bf_dump_prefix_pop(prefix_t *prefix)
 
     // Ensure we have a branch to the next item.
     if (len - 4)
-        strncpy(&_prefix[len - 8], "|-- ", 5);
+        strncpy(&_prefix[len - 8], "|-- ", BF_DUMP_TOKEN_LEN);
 }
 
 void bf_dump_hex(prefix_t *prefix, const void *data, size_t len)
 {
     // 5 characters per byte (0x%02x) + 1 for the null terminator.
-    char buf[_DUMP_HEXDUMP_LEN * 5 + 1];
+    char buf[BF_DUMP_HEXDUMP_LEN * BF_DUMP_TOKEN_LEN + 1];
     const void *end = data + len;
 
     /* DUMP() won't print anything if we're not verbose, so we might as well
@@ -70,7 +72,7 @@ void bf_dump_hex(prefix_t *prefix, const void *data, size_t len)
 
     while (data < end) {
         char *line = buf;
-        for (size_t i = 0; i < _DUMP_HEXDUMP_LEN && data < end; ++i, ++data)
+        for (size_t i = 0; i < BF_DUMP_HEXDUMP_LEN && data < end; ++i, ++data)
             line += sprintf(line, "0x%02x ", *(unsigned char *)data);
 
         DUMP((data == end ? bf_dump_prefix_last(prefix) : prefix), "%s", buf);

--- a/src/core/flavor.c
+++ b/src/core/flavor.c
@@ -5,9 +5,6 @@
 
 #include "core/flavor.h"
 
-#include "bpfilter/cgen/nf.h"
-#include "bpfilter/cgen/tc.h"
-#include "bpfilter/cgen/xdp.h"
 #include "core/helper.h"
 
 const char *bf_flavor_to_str(enum bf_flavor flavor)

--- a/src/core/helper.c
+++ b/src/core/helper.c
@@ -29,20 +29,20 @@ int bf_read_file(const char *path, void **buf, size_t *len)
 
     fd = open(path, O_RDONLY);
     if (fd < 0)
-        return bf_err_code(errno, "failed to open %s", path);
+        return bf_err_r(errno, "failed to open %s", path);
 
     _len = lseek(fd, 0, SEEK_END);
     lseek(fd, 0, SEEK_SET);
 
     _buf = malloc(_len);
     if (!_buf)
-        return bf_err_code(errno, "failed to allocate memory");
+        return bf_err_r(errno, "failed to allocate memory");
 
     r = read(fd, _buf, _len);
     if (r < 0)
-        return bf_err_code(errno, "failed to read serialized data");
+        return bf_err_r(errno, "failed to read serialized data");
     if ((size_t)r != _len)
-        return bf_err_code(EIO, "can't read full serialized data");
+        return bf_err_r(EIO, "can't read full serialized data");
 
     closep(&fd);
 
@@ -62,13 +62,13 @@ int bf_write_file(const char *path, const void *buf, size_t len)
 
     fd = open(path, O_TRUNC | O_CREAT | O_WRONLY, OPEN_MODE_644);
     if (fd < 0)
-        return bf_err_code(errno, "failed to open %s", path);
+        return bf_err_r(errno, "failed to open %s", path);
 
     r = write(fd, buf, len);
     if (r < 0)
-        return bf_err_code(errno, "failed to write to %s", path);
+        return bf_err_r(errno, "failed to write to %s", path);
     if ((size_t)r != len)
-        return bf_err_code(EIO, "can't write full data to %s", path);
+        return bf_err_r(EIO, "can't write full data to %s", path);
 
     closep(&fd);
 

--- a/src/core/helper.c
+++ b/src/core/helper.c
@@ -9,9 +9,12 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "core/logger.h"
+
+#define OPEN_MODE_644 (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)
 
 int bf_read_file(const char *path, void **buf, size_t *len)
 {
@@ -57,7 +60,7 @@ int bf_write_file(const char *path, const void *buf, size_t len)
     bf_assert(path);
     bf_assert(buf);
 
-    fd = open(path, O_TRUNC | O_CREAT | O_WRONLY, 0644);
+    fd = open(path, O_TRUNC | O_CREAT | O_WRONLY, OPEN_MODE_644);
     if (fd < 0)
         return bf_err_code(errno, "failed to open %s", path);
 

--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -11,7 +11,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 extern const char *strerrordesc_np(int errnum);
@@ -45,9 +44,11 @@ extern const char *strerrordesc_np(int errnum);
  */
 #define TAKE_GENERIC(var, type, nullvalue)                                     \
     ({                                                                         \
+        /* NOLINTBEGIN: do not enclose 'type' in parentheses */                \
         type *_pvar_ = &(var);                                                 \
         type _var_ = *_pvar_;                                                  \
         type _nullvalue_ = nullvalue;                                          \
+        /* NOLINTEND */                                                        \
         *_pvar_ = _nullvalue_;                                                 \
         _var_;                                                                 \
     })
@@ -200,13 +201,13 @@ static inline int bf_realloc(void **ptr, size_t size)
 /**
  * Returns true if @p a is equal to @p b.
  *
- * @param a First string.
- * @param b Second string.
+ * @param lhs First string.
+ * @param rhs Second string.
  * @return True if @p a == @p b, false otherwise.
  */
-static inline bool bf_streq(const char *a, const char *b)
+static inline bool bf_streq(const char *lhs, const char *rhs) // NOLINT
 {
-    return strcmp(a, b) == 0;
+    return strcmp(lhs, rhs) == 0;
 }
 
 /**

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -5,6 +5,11 @@
 
 #include "core/hook.h"
 
+#include <linux/bpf.h>
+
+#include <errno.h>
+
+#include "core/flavor.h"
 #include "core/helper.h"
 
 static const char *_bf_hook_strs[] = {

--- a/src/core/if.c
+++ b/src/core/if.c
@@ -29,12 +29,12 @@ int bf_if_index_from_name(const char *name)
 
     r = if_nametoindex(name);
     if (r == 0) {
-        return bf_err_code(errno, "failed to get ifindex for interface '%s'",
-                           name);
+        return bf_err_r(errno, "failed to get ifindex for interface '%s'",
+                        name);
     }
 
     if (r > INT_MAX)
-        return bf_err_code(-E2BIG, "ifindex is too big: %d", r);
+        return bf_err_r(-E2BIG, "ifindex is too big: %d", r);
 
     return (int)r;
 }
@@ -42,7 +42,7 @@ int bf_if_index_from_name(const char *name)
 const char *bf_if_name_from_index(int index)
 {
     if (!if_indextoname(index, _bf_if_name)) {
-        bf_warn_code(errno, "failed to get ifname for interface '%d'", index);
+        bf_warn_r(errno, "failed to get ifname for interface '%d'", index);
         strncpy(_bf_if_name, "<unknown>", IFNAMSIZ);
     }
 
@@ -60,7 +60,7 @@ ssize_t bf_if_get_ifaces(struct bf_if_iface **ifaces)
 
     if_ni = if_nameindex();
     if (!if_ni)
-        return bf_err_code(errno, "failed to fetch interfaces details");
+        return bf_err_r(errno, "failed to fetch interfaces details");
 
     // Gather the number of interfaces to allocate the memory.
     for (it = if_ni; it->if_index != 0 || it->if_name != NULL; ++it)
@@ -72,8 +72,8 @@ ssize_t bf_if_get_ifaces(struct bf_if_iface **ifaces)
     _ifaces = malloc(n_ifaces * sizeof(*_ifaces));
     if (!_ifaces) {
         if_freenameindex(if_ni);
-        return bf_err_code(-ENOMEM,
-                           "failed to allocate memory for interfaces buffer");
+        return bf_err_r(-ENOMEM,
+                        "failed to allocate memory for interfaces buffer");
     }
 
     for (it = if_ni; it->if_index != 0 || it->if_name != NULL; ++it) {

--- a/src/core/if.h
+++ b/src/core/if.h
@@ -8,6 +8,7 @@
 #include <linux/if.h>
 
 #include <stddef.h>
+#include <sys/types.h>
 
 /**
  * @file if.h

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
+#include <unistd.h>
 
 #include "core/helper.h"
 #include "core/request.h"
@@ -24,8 +24,8 @@ static ssize_t _bf_recv_in_buff(int fd, void *buf, size_t buf_len)
         /// @todo Add a timeout to the socket to prevent blocking forever.
         r = read(fd, buf + bytes_read, buf_len - bytes_read);
         if (r < 0) {
-            fprintf(stderr, "can't read from the socket: %s\n",
-                    bf_strerror(errno));
+            (void)fprintf(stderr, "can't read from the socket: %s\n",
+                          bf_strerror(errno));
             return -errno;
         }
 
@@ -45,7 +45,8 @@ static ssize_t _bf_send_from_buff(int fd, void *buf, size_t buf_len)
     while ((size_t)bytes_sent < buf_len) {
         r = write(fd, buf + bytes_sent, buf_len - bytes_sent);
         if (r < 0) {
-            fprintf(stderr, "can't write to socket: %s\n", bf_strerror(errno));
+            (void)fprintf(stderr, "can't write to socket: %s\n",
+                          bf_strerror(errno));
             return -errno;
         }
 
@@ -63,14 +64,15 @@ int bf_send_request(int fd, const struct bf_request *request)
 
     r = _bf_send_from_buff(fd, (void *)request, bf_request_size(request));
     if (r < 0) {
-        fprintf(stderr, "Failed to send request: %s\n", bf_strerror(errno));
+        (void)fprintf(stderr, "Failed to send request: %s\n",
+                      bf_strerror(errno));
         return -errno;
     }
 
     if ((size_t)r != bf_request_size(request)) {
-        fprintf(stderr,
-                "Failed to send request: %lu bytes sent, %ld expected\n",
-                (size_t)r, bf_request_size(request));
+        (void)fprintf(stderr,
+                      "Failed to send request: %lu bytes sent, %ld expected\n",
+                      (size_t)r, bf_request_size(request));
         return -EIO;
     }
 
@@ -90,15 +92,16 @@ int bf_recv_request(int fd, struct bf_request **request)
         return (int)r;
 
     if ((size_t)r != sizeof(req)) {
-        fprintf(stderr,
-                "failed to read request: %lu bytes read, %lu expected\n",
-                (size_t)r, sizeof(req));
+        (void)fprintf(stderr,
+                      "failed to read request: %lu bytes read, %lu expected\n",
+                      (size_t)r, sizeof(req));
         return -EIO;
     }
 
     _request = malloc(bf_request_size(&req));
     if (!_request) {
-        fprintf(stderr, "failed to allocate request: %s\n", bf_strerror(errno));
+        (void)fprintf(stderr, "failed to allocate request: %s\n",
+                      bf_strerror(errno));
         return -errno;
     }
 
@@ -109,9 +112,9 @@ int bf_recv_request(int fd, struct bf_request **request)
         return (int)r;
 
     if ((size_t)r != _request->data_len) {
-        fprintf(stderr,
-                "failed to read request: %lu bytes read, %lu expected\n",
-                (size_t)r, _request->data_len);
+        (void)fprintf(stderr,
+                      "failed to read request: %lu bytes read, %lu expected\n",
+                      (size_t)r, _request->data_len);
         return -EIO;
     }
 
@@ -128,14 +131,15 @@ int bf_send_response(int fd, struct bf_response *response)
 
     r = _bf_send_from_buff(fd, (void *)response, bf_response_size(response));
     if (r < 0) {
-        fprintf(stderr, "Failed to send response: %s\n", bf_strerror(errno));
+        (void)fprintf(stderr, "Failed to send response: %s\n",
+                      bf_strerror(errno));
         return -errno;
     }
 
     if ((size_t)r != bf_response_size(response)) {
-        fprintf(stderr,
-                "Failed to send response: %lu bytes sent, %ld expected\n", r,
-                bf_response_size(response));
+        (void)fprintf(stderr,
+                      "Failed to send response: %lu bytes sent, %ld expected\n",
+                      r, bf_response_size(response));
         return -EIO;
     }
 
@@ -155,16 +159,16 @@ int bf_recv_response(int fd, struct bf_response **response)
         return -errno;
 
     if ((size_t)r != sizeof(res)) {
-        fprintf(stderr,
-                "failed to read response: %lu bytes read, %lu expected\n",
-                (size_t)r, sizeof(res));
+        (void)fprintf(stderr,
+                      "failed to read response: %lu bytes read, %lu expected\n",
+                      (size_t)r, sizeof(res));
         return -EIO;
     }
 
     _response = malloc(bf_response_size(&res));
     if (!_response) {
-        fprintf(stderr, "failed to allocate response: %s\n",
-                bf_strerror(errno));
+        (void)fprintf(stderr, "failed to allocate response: %s\n",
+                      bf_strerror(errno));
         return -errno;
     }
 
@@ -175,9 +179,9 @@ int bf_recv_response(int fd, struct bf_response **response)
         return (int)r;
 
     if (_response->type == BF_RES_SUCCESS && (size_t)r != _response->data_len) {
-        fprintf(stderr,
-                "failed to read response: %lu bytes read, %lu expected\n",
-                (size_t)r, _response->data_len);
+        (void)fprintf(stderr,
+                      "failed to read response: %lu bytes read, %lu expected\n",
+                      (size_t)r, _response->data_len);
         return -EIO;
     }
 

--- a/src/core/list.c
+++ b/src/core/list.c
@@ -8,6 +8,8 @@
 #include <errno.h>
 #include <stdlib.h>
 
+#include "core/helper.h"
+
 /**
  * Create a new list node, with the given data.
  *

--- a/src/core/list.h
+++ b/src/core/list.h
@@ -87,9 +87,9 @@ typedef struct
  * 	      access the node.
  */
 #define bf_list_foreach(list, node)                                            \
-    for (bf_list_node *node = (list)->head,                                    \
-                      *__next = (list)->head ? (list)->head->next : NULL;      \
-         node; node = __next, __next = __next ? __next->next : NULL)
+    for (bf_list_node * (node) = (list)->head,                                 \
+                        *__next = (list)->head ? (list)->head->next : NULL;    \
+         (node); (node) = __next, __next = __next ? __next->next : NULL)
 
 /**
  * Reverse iterate over a @ref bf_list.
@@ -103,9 +103,9 @@ typedef struct
  * 	      access the node.
  */
 #define bf_list_foreach_rev(list, node)                                        \
-    for (bf_list_node *node = (list)->tail,                                    \
-                      *__next = (list)->tail ? (list)->tail->prev : NULL;      \
-         node; node = __next, __next = __next ? __next->prev : NULL)
+    for (bf_list_node * (node) = (list)->tail,                                 \
+                        *__next = (list)->tail ? (list)->tail->prev : NULL;    \
+         (node); (node) = __next, __next = __next ? __next->prev : NULL)
 
 /**
  * Returns an initialised @ref bf_list.
@@ -114,7 +114,7 @@ typedef struct
  *        non-NULL.
  * @return An initialised @ref bf_list.
  */
-#define bf_list_default(list_ops) ((bf_list) {.ops = list_ops})
+#define bf_list_default(list_ops) ((bf_list) {.ops = list_ops /* NOLINT */})
 
 /**
  * Allocate and initialise a new list.

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -6,19 +6,20 @@
 #include "core/logger.h"
 
 #include <stdbool.h>
+#include <stdio.h>
 #include <unistd.h>
 
 /// If true, log messages will be printed in colors.
-static bool _can_print_color = false;
+static bool _bf_can_print_color = false;
 
 void bf_logger_setup(void)
 {
-    _can_print_color = isatty(fileno(stdout)) && isatty(fileno(stderr));
+    _bf_can_print_color = isatty(fileno(stdout)) && isatty(fileno(stderr));
 }
 
 const char *bf_logger_get_color(enum bf_color color, enum bf_style style)
 {
-    if (!_can_print_color) {
+    if (!_bf_can_print_color) {
         return "";
     }
 

--- a/src/core/logger.c
+++ b/src/core/logger.c
@@ -16,47 +16,47 @@ void bf_logger_setup(void)
     _can_print_color = isatty(fileno(stdout)) && isatty(fileno(stderr));
 }
 
-const char *bf_logger_get_color(enum bf_style style)
+const char *bf_logger_get_color(enum bf_color color, enum bf_style style)
 {
     if (!_can_print_color) {
         return "";
     }
 
-    switch (style & ~BF_STYLE_BOLD) {
-    case BF_STYLE_DEFAULT:
-        return (style & BF_STYLE_BOLD) ? "\033[1;39m" : "\033[0;39m";
-    case BF_STYLE_BLACK:
-        return (style & BF_STYLE_BOLD) ? "\033[1;30m" : "\033[0;30m";
-    case BF_STYLE_RED:
-        return (style & BF_STYLE_BOLD) ? "\033[1;31m" : "\033[0;31m";
-    case BF_STYLE_GREEN:
-        return (style & BF_STYLE_BOLD) ? "\033[1;32m" : "\033[0;32m";
-    case BF_STYLE_YELLOW:
-        return (style & BF_STYLE_BOLD) ? "\033[1;33m" : "\033[0;33m";
-    case BF_STYLE_BLUE:
-        return (style & BF_STYLE_BOLD) ? "\033[1;34m" : "\033[0;34m";
-    case BF_STYLE_MAGENTA:
-        return (style & BF_STYLE_BOLD) ? "\033[1;35m" : "\033[0;35m";
-    case BF_STYLE_CYAN:
-        return (style & BF_STYLE_BOLD) ? "\033[1;36m" : "\033[0;36m";
-    case BF_STYLE_LIGHT_GRAY:
-        return (style & BF_STYLE_BOLD) ? "\033[1;37m" : "\033[0;37m";
-    case BF_STYLE_DARK_GRAY:
-        return (style & BF_STYLE_BOLD) ? "\033[1;90m" : "\033[0;90m";
-    case BF_STYLE_LIGHT_RED:
-        return (style & BF_STYLE_BOLD) ? "\033[1;91m" : "\033[0;91m";
-    case BF_STYLE_LIGHT_GREEN:
-        return (style & BF_STYLE_BOLD) ? "\033[1;92m" : "\033[0;92m";
-    case BF_STYLE_LIGHT_YELLOW:
-        return (style & BF_STYLE_BOLD) ? "\033[1;93m" : "\033[0;93m";
-    case BF_STYLE_LIGHT_BLUE:
-        return (style & BF_STYLE_BOLD) ? "\033[1;94m" : "\033[0;94m";
-    case BF_STYLE_LIGHT_MAGENTA:
-        return (style & BF_STYLE_BOLD) ? "\033[1;95m" : "\033[0;95m";
-    case BF_STYLE_LIGHT_CYAN:
-        return (style & BF_STYLE_BOLD) ? "\033[1;96m" : "\033[0;96m";
-    case BF_STYLE_WHITE:
-        return (style & BF_STYLE_BOLD) ? "\033[1;97m" : "\033[0;97m";
+    switch (color) {
+    case BF_COLOR_DEFAULT:
+        return (style == BF_STYLE_BOLD) ? "\033[1;39m" : "\033[0;39m";
+    case BF_COLOR_BLACK:
+        return (style == BF_STYLE_BOLD) ? "\033[1;30m" : "\033[0;30m";
+    case BF_COLOR_RED:
+        return (style == BF_STYLE_BOLD) ? "\033[1;31m" : "\033[0;31m";
+    case BF_COLOR_GREEN:
+        return (style == BF_STYLE_BOLD) ? "\033[1;32m" : "\033[0;32m";
+    case BF_COLOR_YELLOW:
+        return (style == BF_STYLE_BOLD) ? "\033[1;33m" : "\033[0;33m";
+    case BF_COLOR_BLUE:
+        return (style == BF_STYLE_BOLD) ? "\033[1;34m" : "\033[0;34m";
+    case BF_COLOR_MAGENTA:
+        return (style == BF_STYLE_BOLD) ? "\033[1;35m" : "\033[0;35m";
+    case BF_COLOR_CYAN:
+        return (style == BF_STYLE_BOLD) ? "\033[1;36m" : "\033[0;36m";
+    case BF_COLOR_LIGHT_GRAY:
+        return (style == BF_STYLE_BOLD) ? "\033[1;37m" : "\033[0;37m";
+    case BF_COLOR_DARK_GRAY:
+        return (style == BF_STYLE_BOLD) ? "\033[1;90m" : "\033[0;90m";
+    case BF_COLOR_LIGHT_RED:
+        return (style == BF_STYLE_BOLD) ? "\033[1;91m" : "\033[0;91m";
+    case BF_COLOR_LIGHT_GREEN:
+        return (style == BF_STYLE_BOLD) ? "\033[1;92m" : "\033[0;92m";
+    case BF_COLOR_LIGHT_YELLOW:
+        return (style == BF_STYLE_BOLD) ? "\033[1;93m" : "\033[0;93m";
+    case BF_COLOR_LIGHT_BLUE:
+        return (style == BF_STYLE_BOLD) ? "\033[1;94m" : "\033[0;94m";
+    case BF_COLOR_LIGHT_MAGENTA:
+        return (style == BF_STYLE_BOLD) ? "\033[1;95m" : "\033[0;95m";
+    case BF_COLOR_LIGHT_CYAN:
+        return (style == BF_STYLE_BOLD) ? "\033[1;96m" : "\033[0;96m";
+    case BF_COLOR_WHITE:
+        return (style == BF_STYLE_BOLD) ? "\033[1;97m" : "\033[0;97m";
     default:
         return "\033[0m";
     }

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -70,15 +70,11 @@ enum bf_style
 #define bf_info(fmt, ...)                                                      \
     _bf_log_impl("info", BF_COLOR_GREEN, fmt, ##__VA_ARGS__)
 
-#ifndef NDEBUG
 #define bf_dbg(fmt, ...)                                                       \
     ({                                                                         \
         if (bf_opts_verbose())                                                 \
             _bf_log_impl("debug", BF_COLOR_BLUE, fmt, ##__VA_ARGS__);          \
     })
-#else
-#define bf_dbg(...)
-#endif
 
 /**
  * Log an error message to stderr, append the detail of the error code
@@ -118,12 +114,8 @@ enum bf_style
 #define bf_info_code(code, fmt, ...)                                           \
     _bf_log_code_impl("info", BF_COLOR_GREEN, code, fmt, ##__VA_ARGS__)
 
-#ifndef NDEBUG
 #define bf_dbg_code(code, fmt, ...)                                            \
     _bf_log_code_impl("debug", BF_COLOR_BLUE, code, fmt, ##__VA_ARGS__)
-#else
-#define bf_dbg_code(code, fmt, ...)
-#endif
 
 /**
  * Initialise the logging system.

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -118,6 +118,32 @@ enum bf_style
     _bf_log_code_impl("debug", BF_COLOR_BLUE, code, fmt, ##__VA_ARGS__)
 
 /**
+ * Identical to @ref _bf_log_impl but for @p va_list arguments.
+ *
+ * @param level Log level, as a string. Will prefix the log message.
+ * @param color Color to print the prefix with, as a @ref bf_color .
+ * @param fmt Format string.
+ * @param vargs @p va_list of arguments.
+ */
+#define _bf_log_v_impl(level, color, fmt, vargs)                               \
+    do {                                                                       \
+        (void)fprintf(                                                         \
+            stderr, "%s%-7s%s: ", bf_logger_get_color((color), BF_STYLE_BOLD), \
+            (level), bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));     \
+        (void)vfprintf(stderr, (fmt), (vargs));                                \
+        (void)fprintf(stderr, "\n");                                           \
+    } while (0)
+
+#define bf_err_v(fmt, vargs) _bf_log_v_impl("error", BF_COLOR_RED, fmt, vargs)
+
+#define bf_warn_v(fmt, vargs)                                                  \
+    _bf_log_v_impl("warning", BF_COLOR_YELLOW, fmt, vargs)
+
+#define bf_info_v(fmt, vargs) _bf_log_v_impl("info", BF_COLOR_GREEN, fmt, vargs)
+
+#define bf_dbg_v(fmt, vargs) _bf_log_v_impl("debug", BF_COLOR_BLUE, fmt, vargs)
+
+/**
  * Initialise the logging system.
  *
  * Defines whether the logging system will print in colors or not. If both

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include <stdio.h>
+#include <stdio.h>          // NOLINT: fprintf is used
 
 #include "core/helper.h"
-#include "core/opts.h"
+#include "core/opts.h"      // NOLINT: bf_opts_verbose() is used
 
 enum bf_color
 {
@@ -161,7 +161,7 @@ enum bf_style
  * Initialise the logging system.
  *
  * Defines whether the logging system will print in colors or not. If both
- * `stdout` and `stderr` are TTYs, then @ref _can_print_color is set to true.
+ * `stdout` and `stderr` are TTYs, then @ref _bf_can_print_color is set to true.
  */
 void bf_logger_setup(void);
 
@@ -169,8 +169,8 @@ void bf_logger_setup(void);
  * Get color string for a given style.
  *
  * @p style can be a combination of @ref bf_style weight and color. If
- * @ref _can_print_color is set to false, then an empty string will be returned
- * so to not modify the output style.
+ * @ref _bf_can_print_color is set to false, then an empty string will be
+ * returned so to not modify the output style.
  *
  * @param color Color identifier.
  * @param style Style identifier.

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -10,6 +10,29 @@
 #include "core/helper.h"
 #include "core/opts.h"
 
+enum bf_color
+{
+    BF_COLOR_RESET = 0,
+
+    BF_COLOR_DEFAULT = 1 << 1,
+    BF_COLOR_BLACK = 1 << 2,
+    BF_COLOR_RED = 1 << 3,
+    BF_COLOR_GREEN = 1 << 4,
+    BF_COLOR_YELLOW = 1 << 5,
+    BF_COLOR_BLUE = 1 << 6,
+    BF_COLOR_MAGENTA = 1 << 7,
+    BF_COLOR_CYAN = 1 << 8,
+    BF_COLOR_LIGHT_GRAY = 1 << 9,
+    BF_COLOR_DARK_GRAY = 1 << 10,
+    BF_COLOR_LIGHT_RED = 1 << 11,
+    BF_COLOR_LIGHT_GREEN = 1 << 12,
+    BF_COLOR_LIGHT_YELLOW = 1 << 13,
+    BF_COLOR_LIGHT_BLUE = 1 << 14,
+    BF_COLOR_LIGHT_MAGENTA = 1 << 15,
+    BF_COLOR_LIGHT_CYAN = 1 << 16,
+    BF_COLOR_WHITE = 1 << 17,
+};
+
 enum bf_style
 {
     BF_STYLE_RESET = 0,
@@ -17,25 +40,6 @@ enum bf_style
     // First bit is for the weight.
     BF_STYLE_NORMAL = 0,
     BF_STYLE_BOLD = 1,
-
-    // Next 17 bits are for the color.
-    BF_STYLE_DEFAULT = 1 << 1,
-    BF_STYLE_BLACK = 1 << 2,
-    BF_STYLE_RED = 1 << 3,
-    BF_STYLE_GREEN = 1 << 4,
-    BF_STYLE_YELLOW = 1 << 5,
-    BF_STYLE_BLUE = 1 << 6,
-    BF_STYLE_MAGENTA = 1 << 7,
-    BF_STYLE_CYAN = 1 << 8,
-    BF_STYLE_LIGHT_GRAY = 1 << 9,
-    BF_STYLE_DARK_GRAY = 1 << 10,
-    BF_STYLE_LIGHT_RED = 1 << 11,
-    BF_STYLE_LIGHT_GREEN = 1 << 12,
-    BF_STYLE_LIGHT_YELLOW = 1 << 13,
-    BF_STYLE_LIGHT_BLUE = 1 << 14,
-    BF_STYLE_LIGHT_MAGENTA = 1 << 15,
-    BF_STYLE_LIGHT_CYAN = 1 << 16,
-    BF_STYLE_WHITE = 1 << 17,
 };
 
 /**
@@ -49,30 +53,34 @@ enum bf_style
 #define bf_abort(fmt, ...)                                                     \
     ({                                                                         \
         _bf_log_impl("%sabort%s  : " fmt,                                      \
-                     bf_logger_get_color(BF_STYLE_RED | BF_STYLE_BOLD),        \
-                     bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);      \
+                     bf_logger_get_color(BF_COLOR_RED, BF_STYLE_BOLD),         \
+                     bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),      \
+                     ##__VA_ARGS__);                                           \
         abort();                                                               \
     })
 
 #define bf_err(fmt, ...)                                                       \
     ({                                                                         \
         _bf_log_impl("%serror%s  : " fmt,                                      \
-                     bf_logger_get_color(BF_STYLE_RED | BF_STYLE_BOLD),        \
-                     bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);      \
+                     bf_logger_get_color(BF_COLOR_RED, BF_STYLE_BOLD),         \
+                     bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),      \
+                     ##__VA_ARGS__);                                           \
     })
 
 #define bf_warn(fmt, ...)                                                      \
     ({                                                                         \
         _bf_log_impl("%swarning%s: " fmt,                                      \
-                     bf_logger_get_color(BF_STYLE_YELLOW | BF_STYLE_BOLD),     \
-                     bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);      \
+                     bf_logger_get_color(BF_COLOR_YELLOW, BF_STYLE_BOLD),      \
+                     bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),      \
+                     ##__VA_ARGS__);                                           \
     })
 
 #define bf_info(fmt, ...)                                                      \
     ({                                                                         \
         _bf_log_impl("%sinfo%s   : " fmt,                                      \
-                     bf_logger_get_color(BF_STYLE_GREEN | BF_STYLE_BOLD),      \
-                     bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);      \
+                     bf_logger_get_color(BF_COLOR_GREEN, BF_STYLE_BOLD),       \
+                     bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),      \
+                     ##__VA_ARGS__);                                           \
     })
 
 #ifndef NDEBUG
@@ -80,8 +88,9 @@ enum bf_style
     ({                                                                         \
         if (bf_opts_verbose()) {                                               \
             _bf_log_impl("%sdebug%s  : " fmt,                                  \
-                         bf_logger_get_color(BF_STYLE_BLUE | BF_STYLE_BOLD),   \
-                         bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);  \
+                         bf_logger_get_color(BF_COLOR_BLUE, BF_STYLE_BOLD),    \
+                         bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),  \
+                         ##__VA_ARGS__);                                       \
         }                                                                      \
     })
 #else
@@ -115,31 +124,34 @@ enum bf_style
 #define bf_err_code(code, fmt, ...)                                            \
     ({                                                                         \
         _bf_log_code_impl(code, "%serror%s  : " fmt,                           \
-                          bf_logger_get_color(BF_STYLE_RED | BF_STYLE_BOLD),   \
-                          bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__); \
+                          bf_logger_get_color(BF_COLOR_RED, BF_STYLE_BOLD),    \
+                          bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), \
+                          ##__VA_ARGS__);                                      \
     })
 
 #define bf_warn_code(code, fmt, ...)                                           \
     ({                                                                         \
-        _bf_log_code_impl(                                                     \
-            code, "%swarning%s: " fmt,                                         \
-            bf_logger_get_color(BF_STYLE_YELLOW | BF_STYLE_BOLD),              \
-            bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__);               \
+        _bf_log_code_impl(code, "%swarning%s: " fmt,                           \
+                          bf_logger_get_color(BF_COLOR_YELLOW, BF_STYLE_BOLD), \
+                          bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), \
+                          ##__VA_ARGS__);                                      \
     })
 
 #define bf_info_code(code, fmt, ...)                                           \
     ({                                                                         \
         _bf_log_code_impl(code, "%sinfo%s   : " fmt,                           \
-                          bf_logger_get_color(BF_STYLE_GREEN | BF_STYLE_BOLD), \
-                          bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__); \
+                          bf_logger_get_color(BF_COLOR_GREEN, BF_STYLE_BOLD),  \
+                          bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), \
+                          ##__VA_ARGS__);                                      \
     })
 
 #ifndef NDEBUG
 #define bf_dbg_code(code, fmt, ...)                                            \
     ({                                                                         \
         _bf_log_code_impl(code, "%sdebug%s  : " fmt,                           \
-                          bf_logger_get_color(BF_STYLE_BLUE | BF_STYLE_BOLD),  \
-                          bf_logger_get_color(BF_STYLE_RESET), ##__VA_ARGS__); \
+                          bf_logger_get_color(BF_COLOR_BLUE, BF_STYLE_BOLD),   \
+                          bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), \
+                          ##__VA_ARGS__);                                      \
     })
 #else
 #define bf_dbg_code(code, fmt, ...)
@@ -160,7 +172,8 @@ void bf_logger_setup(void);
  * @ref _can_print_color is set to false, then an empty string will be returned
  * so to not modify the output style.
  *
- * @param style Style to get the color of
+ * @param color Color identifier.
+ * @param style Style identifier.
  * @return Style string.
  */
-const char *bf_logger_get_color(enum bf_style style);
+const char *bf_logger_get_color(enum bf_color color, enum bf_style style);

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -86,7 +86,7 @@ enum bf_style
  *
  * @code{.c}
  *  if (ret < 0)
- *    return bf_err_code(ret, "failed to do something");
+ *    return bf_err_r(ret, "failed to do something");
  * @endcode
  *
  * @param level Log level, as a string. Will prefix the log message.
@@ -105,16 +105,16 @@ enum bf_style
         -abs(code);                                                            \
     })
 
-#define bf_err_code(code, fmt, ...)                                            \
+#define bf_err_r(code, fmt, ...)                                               \
     _bf_log_code_impl("error", BF_COLOR_RED, code, fmt, ##__VA_ARGS__)
 
-#define bf_warn_code(code, fmt, ...)                                           \
+#define bf_warn_r(code, fmt, ...)                                              \
     _bf_log_code_impl("warning", BF_COLOR_YELLOW, code, fmt, ##__VA_ARGS__)
 
-#define bf_info_code(code, fmt, ...)                                           \
+#define bf_info_r(code, fmt, ...)                                              \
     _bf_log_code_impl("info", BF_COLOR_GREEN, code, fmt, ##__VA_ARGS__)
 
-#define bf_dbg_code(code, fmt, ...)                                            \
+#define bf_dbg_r(code, fmt, ...)                                               \
     _bf_log_code_impl("debug", BF_COLOR_BLUE, code, fmt, ##__VA_ARGS__)
 
 /**

--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "core/helper.h"
+
 int bf_marsh_new(struct bf_marsh **marsh, const void *data, size_t data_len)
 {
     struct bf_marsh *_marsh = NULL;

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -5,7 +5,13 @@
 
 #include "core/matcher.h"
 
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "core/dump.h"
 #include "core/helper.h"
+#include "core/logger.h"
 #include "core/marsh.h"
 
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -69,8 +69,7 @@ int bf_matcher_new_from_marsh(struct bf_matcher **matcher,
 
     r = bf_matcher_new(matcher, type, op, payload, payload_len);
     if (r)
-        return bf_err_code(r,
-                           "failed to restore bf_matcher from serialised data");
+        return bf_err_r(r, "failed to restore bf_matcher from serialised data");
 
     return 0;
 }
@@ -104,7 +103,7 @@ int bf_matcher_marsh(const struct bf_matcher *matcher, struct bf_marsh **marsh)
     r |= bf_marsh_add_child_raw(&_marsh, matcher->payload,
                                 matcher->len - sizeof(struct bf_matcher));
     if (r)
-        return bf_err_code(r, "failed to serialise bf_matcher object");
+        return bf_err_r(r, "failed to serialise bf_matcher object");
 
     *marsh = TAKE_PTR(_marsh);
 

--- a/src/core/nf.c
+++ b/src/core/nf.c
@@ -5,11 +5,14 @@
 
 #include "core/nf.h"
 
+#include <linux/netfilter.h>
+
 #include "core/helper.h"
+#include "core/hook.h"
 
 enum nf_inet_hooks bf_hook_to_nf_hook(enum bf_hook hook)
 {
-    bf_assert(hook >= BF_HOOK_NF_PRE_ROUTING ||
+    bf_assert(hook >= BF_HOOK_NF_PRE_ROUTING &&
               hook <= BF_HOOK_NF_POST_ROUTING);
 
     enum nf_inet_hooks hooks[] = {

--- a/src/core/opts.c
+++ b/src/core/opts.c
@@ -94,15 +94,15 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
         errno = 0;
         pow = strtol(arg, &end, 0);
         if (errno == ERANGE) {
-            return bf_err_code(EINVAL, "failed to convert '%s' into an integer",
-                               arg);
+            return bf_err_r(EINVAL, "failed to convert '%s' into an integer",
+                            arg);
         }
         if (pow > UINT_MAX) {
-            return bf_err_code(EINVAL, "--buffer-len can't be bigger than %d",
-                               UINT_MAX);
+            return bf_err_r(EINVAL, "--buffer-len can't be bigger than %d",
+                            UINT_MAX);
         }
         if (pow < 0)
-            return bf_err_code(EINVAL, "--buffer-len can't be negative");
+            return bf_err_r(EINVAL, "--buffer-len can't be negative");
         args->bpf_log_buf_len_pow = (unsigned int)pow;
         break;
     case BF_OPT_NO_IPTABLES_KEY:

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -94,7 +94,7 @@ int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
     r |= bf_marsh_add_child_raw(&_marsh, &rule->verdict,
                                 sizeof(enum bf_verdict));
     if (r)
-        return bf_err_code(r, "Failed to serialize rule");
+        return bf_err_r(r, "Failed to serialize rule");
 
     *marsh = TAKE_PTR(_marsh);
 

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -6,8 +6,12 @@
 #include "core/set.h"
 
 #include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "core/dump.h"
 #include "core/helper.h"
+#include "core/list.h"
 #include "core/marsh.h"
 
 size_t _bf_set_type_elem_size(enum bf_set_type type)
@@ -85,7 +89,7 @@ void bf_set_free(struct bf_set **set)
         return;
 
     bf_list_clean(&(*set)->elems);
-    freep(set);
+    freep((void *)set);
 }
 
 int bf_set_marsh(const struct bf_set *set, struct bf_marsh **marsh)

--- a/src/core/verdict.c
+++ b/src/core/verdict.c
@@ -5,6 +5,8 @@
 
 #include "core/verdict.h"
 
+#include <errno.h>
+
 #include "core/helper.h"
 
 static const char *_bf_verdict_strs[] = {

--- a/src/libbpfilter/bpfilter.h
+++ b/src/libbpfilter/bpfilter.h
@@ -13,7 +13,6 @@ struct ipt_replace;
 struct xt_counters_info;
 struct nlmsghdr;
 
-
 /**
  * Send iptable's ipt_replace data to bpfilter daemon.
  *

--- a/src/libbpfilter/generic.h
+++ b/src/libbpfilter/generic.h
@@ -5,8 +5,16 @@
 
 #pragma once
 
-#include "core/front.h"
+#include <stdio.h> // NOLINT: header is used in bf_err().
+
+#include "core/helper.h"
 #include "core/request.h"
 #include "core/response.h"
+
+#define bf_err(r, fmt, ...)                                                    \
+    ({                                                                         \
+        (void)fprintf(stderr, fmt ": %s\n", ##__VA_ARGS__, bf_strerror(r));    \
+        r < 0 ? r : -r;                                                        \
+    })
 
 int bf_send(const struct bf_request *request, struct bf_response **response);

--- a/src/libbpfilter/ipt.c
+++ b/src/libbpfilter/ipt.c
@@ -12,9 +12,9 @@
 #include <string.h>
 
 #include "core/front.h"
+#include "core/helper.h"
 #include "core/request.h"
 #include "core/response.h"
-#include "core/helper.h"
 #include "libbpfilter/generic.h"
 
 /**
@@ -65,9 +65,9 @@ int bf_ipt_replace(struct ipt_replace *ipt_replace)
 
     if (response->type == BF_RES_SUCCESS) {
         if (response->data_len != request->data_len) {
-            fprintf(stdout, "Response data has wrong size: %lu instead of %lu",
-                    response->data_len, request->data_len);
-            return -EINVAL;
+            return bf_err(EINVAL,
+                          "bpfilter: response size is %lu, expected %lu",
+                          response->data_len, request->data_len);
         }
 
         memcpy(ipt_replace, response->data, response->data_len);
@@ -97,9 +97,9 @@ int bf_ipt_add_counters(struct xt_counters_info *counters)
 
     if (response->type == BF_RES_SUCCESS) {
         if (response->data_len != request->data_len) {
-            fprintf(stdout, "Response data has wrong size: %lu instead of %lu",
-                    response->data_len, request->data_len);
-            return -EINVAL;
+            return bf_err(EINVAL,
+                          "bpfilter: response size is %lu, expected %lu",
+                          response->data_len, request->data_len);
         }
 
         memcpy(counters, response->data, response->data_len);
@@ -130,9 +130,9 @@ int bf_ipt_get_info(struct ipt_getinfo *info)
 
     if (response->type == BF_RES_SUCCESS) {
         if (response->data_len != request->data_len) {
-            fprintf(stdout, "Response data has wrong size: %lu instead of %lu",
-                    response->data_len, request->data_len);
-            return -EINVAL;
+            return bf_err(EINVAL,
+                          "bpfilter: response size is %lu, expected %lu",
+                          response->data_len, request->data_len);
         }
 
         memcpy(info, response->data, response->data_len);
@@ -163,9 +163,9 @@ int bf_ipt_get_entries(struct ipt_get_entries *entries)
 
     if (response->type == BF_RES_SUCCESS) {
         if (response->data_len != request->data_len) {
-            fprintf(stdout, "Response data has wrong size: %lu instead of %lu",
-                    response->data_len, request->data_len);
-            return -EINVAL;
+            return bf_err(EINVAL,
+                          "bpfilter: response size is %lu, expected %lu",
+                          response->data_len, request->data_len);
         }
 
         memcpy(entries, response->data, response->data_len);

--- a/src/libbpfilter/nft.c
+++ b/src/libbpfilter/nft.c
@@ -7,10 +7,12 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <string.h>
 
+#include "core/front.h"
+#include "core/request.h"
+#include "core/response.h"
 #include "libbpfilter/generic.h"
-
-int bf_send(const struct bf_request *request, struct bf_response **response);
 
 int bf_nft_send(const void *data, size_t len)
 {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,9 @@ file(GLOB_RECURSE bf_srcs
     ${CMAKE_SOURCE_DIR}/src/bfcli/*.h       ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
 )
 
-add_custom_target(lint
+add_custom_command(
+    DEPENDS
+        ${CMAKE_BINARY_DIR}/compile_commands.json
     COMMAND
         # Create a new compile_commands.json file without tests/unit files,
         # as they use specific build flags to file include mock_assert(), which
@@ -22,26 +24,54 @@ add_custom_target(lint
         ${JQ_BIN}
             "del(.[] | select((.directory == \"${CMAKE_CURRENT_BINARY_DIR}/unit\")))"
             ${CMAKE_BINARY_DIR}/compile_commands.json > ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
-    COMMAND
-        ${CLANG_TIDY_BIN}
-            --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
-            -p ${CMAKE_CURRENT_BINARY_DIR}
-            ${bf_srcs}
-    COMMENT "Lint source files"
+    OUTPUT
+        ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+    COMMENT
+        "Generating filtered compile_commands.json"
     VERBATIM
 )
 
-add_custom_target(checkstyle
-    COMMAND
-        ${CLANG_FORMAT_BIN}
-            --style=file:${CMAKE_SOURCE_DIR}/.clang-format
-            --dry-run
-            ${bf_srcs}
-    COMMENT "Check source code formatting"
-)
+set(check_stamps "")
 
-add_custom_target(test
-    COMMAND $<TARGET_FILE:unit_tests>
-    DEPENDS unit_tests
-    COMMENT "Running tests"
+foreach (filepath ${bf_srcs})
+    get_filename_component(directory ${filepath} DIRECTORY)
+    file(RELATIVE_PATH rel_directory ${CMAKE_SOURCE_DIR} ${directory})
+    set(stamp_dir ${CMAKE_CURRENT_BINARY_DIR}/check_stamps/${rel_directory})
+
+    get_filename_component(filename ${filepath} NAME)
+    set(stamp_file ${stamp_dir}/${filename}.checked)
+
+    file(MAKE_DIRECTORY ${stamp_dir})
+
+    add_custom_command(
+        DEPENDS
+            ${filepath}
+            ${CMAKE_SOURCE_DIR}/.clang-tidy
+            ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+        COMMAND
+            ${CLANG_TIDY_BIN}
+                --quiet
+                --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
+                -p ${CMAKE_CURRENT_BINARY_DIR}
+                --extra-arg=-fno-caret-diagnostics
+                ${filepath}
+        COMMAND
+            ${CLANG_FORMAT_BIN}
+                --style=file:${CMAKE_SOURCE_DIR}/.clang-format
+                --dry-run
+                ${filepath}
+        COMMAND
+            ${CMAKE_COMMAND} -E touch ${stamp_file}
+        OUTPUT ${stamp_file}
+        COMMENT "Checking ${rel_directory}/${filename}"
+    )
+
+    list(APPEND check_stamps ${stamp_file})
+endforeach ()
+
+# Generated files (especially from Bison and Flex) are required.
+add_custom_target(check
+    DEPENDS
+        bfcli
+        ${check_stamps}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,8 +8,10 @@ add_subdirectory(bpf)
 # It's OK to use GLOB_RECURSE here, as it's not the main target for the source
 # files but a secondary one.
 file(GLOB_RECURSE bf_srcs
-	${CMAKE_SOURCE_DIR}/src/*.c
-	${CMAKE_SOURCE_DIR}/src/*.h
+    ${CMAKE_SOURCE_DIR}/src/core/*.h        ${CMAKE_SOURCE_DIR}/src/core/*.c
+    ${CMAKE_SOURCE_DIR}/src/bpfilter/*.h    ${CMAKE_SOURCE_DIR}/src/bpfilter/*.c
+    ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
+    ${CMAKE_SOURCE_DIR}/src/bfcli/*.h       ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
 )
 
 add_custom_target(lint

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,3 +75,12 @@ add_custom_target(check
         bfcli
         ${check_stamps}
 )
+
+add_custom_target(fixstyle
+    COMMAND
+        ${CLANG_FORMAT_BIN}
+            --style=file:${CMAKE_SOURCE_DIR}/.clang-format
+            -i
+            ${bf_srcs}
+    COMMENT "Fixing style for all the source files"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,11 +14,19 @@ file(GLOB_RECURSE bf_srcs
 
 add_custom_target(lint
     COMMAND
+        # Create a new compile_commands.json file without tests/unit files,
+        # as they use specific build flags to file include mock_assert(), which
+        # creates false positive with clang-tidy.
+        ${JQ_BIN}
+            "del(.[] | select((.directory == \"${CMAKE_CURRENT_BINARY_DIR}/unit\")))"
+            ${CMAKE_BINARY_DIR}/compile_commands.json > ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+    COMMAND
         ${CLANG_TIDY_BIN}
             --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
-            -p ${CMAKE_BINARY_DIR}
+            -p ${CMAKE_CURRENT_BINARY_DIR}
             ${bf_srcs}
-    COMMENT "Run linter on source files"
+    COMMENT "Lint source files"
+    VERBATIM
 )
 
 add_custom_target(checkstyle

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -178,3 +178,9 @@ bf_test_mock(unit_tests
         nlmsg_append
         bf_bpf_obj_get
 )
+
+add_custom_target(test
+    COMMAND $<TARGET_FILE:unit_tests>
+    DEPENDS unit_tests
+    COMMENT "Running tests"
+)

--- a/tests/unit/src/bpfilter/cgen/jmp.c
+++ b/tests/unit/src/bpfilter/cgen/jmp.c
@@ -9,6 +9,8 @@
 #include "harness/helper.h"
 #include "harness/mock.h"
 
+#include "bpfilter/cgen/reg.h"
+
 /**
  * Create a context and emit a given number of instructions.
  *

--- a/tests/unit/src/core/btf.c
+++ b/tests/unit/src/core/btf.c
@@ -11,19 +11,19 @@
 Test(btf, init)
 {
     assert_success(bf_btf_setup());
-    assert_non_null(_btf);
+    assert_non_null(_bf_btf);
 
     bf_btf_teardown();
-    assert_null(_btf);
+    assert_null(_bf_btf);
 }
 
 Test(btf, failed_init)
 {
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(btf__load_vmlinux_btf, NULL);
 
-    assert_null(_btf);
+    assert_null(_bf_btf);
     assert_error(bf_btf_setup());
-    assert_null(_btf);
+    assert_null(_bf_btf);
 }
 
 Test(btf, get_field_offset)

--- a/tests/unit/src/core/opts.c
+++ b/tests/unit/src/core/opts.c
@@ -13,7 +13,7 @@ Test(opts, no_nftables)
 {
     char *opt0[] = {"tests_unit", "--no-nftables"};
 
-    _opts.fronts = 0xffff;
+    _bf_opts.fronts = 0xffff;
     assert_success(bf_opts_init(ARRAY_SIZE(opt0), opt0));
-    assert(0 == (_opts.fronts & (1 << BF_FRONT_NFT)));
+    assert(0 == (_bf_opts.fronts & (1 << BF_FRONT_NFT)));
 }


### PR DESCRIPTION
Fix all existing `clang-tidy` warnings (or update the configuration file if needed), so `make check` can run `clang-format` and `clang-tidy` and be used from the CI. Main changes:
- Use `jq` (added as a dependency) to copy `compile_commands.json` and remove files under `tests/`, otherwise `clang-tidy` would analyse the same file twice (once for `src/` and once for `tests/unit/`).
- Update logger implementation to distinguish between colour and style of the prefix: both would share the same enum and would be combined (e.g. `BF_STYLE_GREEN | BF_STYLE_BOLD`), creating invalid enum values.
- Add destructors to custom types in `parser.y`.
- Improve `bfcli`'s parser error management logic: wrap calls to `yyerror()` and log through `bpfilter`'s logger.
- Move `make test` target into `tests/unit/CMakeLists.txt`, with the `tests_unit` target.
- Create `make check` to run ClangFormat and ClangTidy. Add custom commands to run `clang-tidy` for each source file, allowing `make check` to benefit from parallel builds.
- Explicitly disable DOT in Doxygen configuration file, otherwise Ubuntu would generate the DOT graphs.
- Add `bf_err_v()` (for other log levels too) to log from a format and a `va_list` of arguments.
- Fix all the `clang-tidy` warnings, update `.clang-tidy` accordingly.