### PR TITLE
Improvements to BPF maps management

### DIFF
--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -21,6 +21,12 @@
 #include "core/logger.h"
 #include "core/marsh.h"
 
+static const char _bf_map_type_key[] = {
+    [BF_MAP_TYPE_COUNTERS] = 'c',
+    [BF_MAP_TYPE_PRINTER] = 'p',
+    [BF_MAP_TYPE_SET] = 's',
+};
+
 int bf_map_new(struct bf_map **map, enum bf_map_type type,
                const char *name_suffix, enum bf_map_bpf_type bpf_type,
                size_t key_size, size_t value_size, size_t n_elems)
@@ -43,7 +49,8 @@ int bf_map_new(struct bf_map **map, enum bf_map_type type,
     _map->value_size = value_size;
     _map->n_elems = n_elems;
 
-    r = snprintf(_map->name, BPF_OBJ_NAME_LEN, "bf_map_%.6s", name_suffix);
+    r = snprintf(_map->name, BPF_OBJ_NAME_LEN, "bf_%cmap_%.6s",
+                 _bf_map_type_key[type], name_suffix);
     if (r < 0) {
         return bf_err_r(
             errno,

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -30,6 +30,8 @@ enum bf_map_type
 
 #define BF_PIN_PATH_LEN 64
 
+#define BF_MAP_N_ELEMS_UNKNOWN SIZE_MAX
+
 struct bf_map
 {
     enum bf_map_type type;
@@ -72,6 +74,9 @@ struct bf_marsh;
  * @param key_size Size (in bytes) of a key in the map. Can't be 0.
  * @param value_size Size (in bytes) of an element of the map. Can't be 0.
  * @param n_elems Number of elemets to reserve room for in the map. Can't be 0.
+ *        If you don't yet know the number of elements in the map, use
+ *        @ref BF_MAP_N_ELEMS_UNKNOWN , but @ref bf_map_create can't be called
+ *        until you set an actual size with @ref bf_map_set_n_elems .
  * @return 0 on success, or a negative errno value on error.
  */
 int bf_map_new(struct bf_map **map, enum bf_map_type type,
@@ -151,6 +156,19 @@ int bf_map_create(struct bf_map *map, uint32_t flags, bool pin);
  *              it.
  */
 void bf_map_destroy(struct bf_map *map, bool unpin);
+
+/**
+ * Set the number of elements in the map.
+ *
+ * This function can be used to change the number of element of a map, up
+ * until @ref bf_map_create is called. Once the map has been created, the
+ * number of elements can't be changed.
+ *
+ * @param map The map to set the number of elements for. Can't be NULL.
+ * @param n_elems Number of elements in the map. Can't be 0.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_map_set_n_elems(struct bf_map *map, size_t n_elems);
 
 /**
  * Insert or update an element to the map.

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -20,10 +20,19 @@ enum bf_map_bpf_type
     _BF_MAP_BPF_TYPE_MAX,
 };
 
+enum bf_map_type
+{
+    BF_MAP_TYPE_COUNTERS,
+    BF_MAP_TYPE_PRINTER,
+    BF_MAP_TYPE_SET,
+    _BF_MAP_TYPE_MAX,
+};
+
 #define BF_PIN_PATH_LEN 64
 
 struct bf_map
 {
+    enum bf_map_type type;
     int fd;
     char name[BPF_OBJ_NAME_LEN];
     char path[BF_PIN_PATH_LEN];
@@ -54,6 +63,7 @@ struct bf_marsh;
  * @param map BPF map object to allocate and initialize. Can't be NULL. On
  *            success, @c *map points to a valid @ref bf_map . On failure,
  *            @c *map remain unchanged.
+ * @param type Map type, defines the set of available operations.
  * @param name_suffix Suffix to use for the map name. Usually specify the
  *                    hook, front-end, or program type the map is used for.
  *                    Can't be NULL.
@@ -64,9 +74,9 @@ struct bf_marsh;
  * @param n_elems Number of elemets to reserve room for in the map. Can't be 0.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_map_new(struct bf_map **map, const char *name_suffix,
-               enum bf_map_bpf_type type, size_t key_size, size_t value_size,
-               size_t n_elems);
+int bf_map_new(struct bf_map **map, enum bf_map_type type,
+               const char *name_suffix, enum bf_map_bpf_type bpf_type,
+               size_t key_size, size_t value_size, size_t n_elems);
 
 /**
  * Create a new BPF map object from serialized data.

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -112,8 +112,8 @@ int bf_program_new(struct bf_program **program, unsigned int ifindex,
         struct bf_set *set = bf_list_node_get_data(set_node);
         _cleanup_bf_map_ struct bf_map *map = NULL;
 
-        r = bf_map_new(&map, suffix, BF_MAP_BPF_TYPE_HASH, set->elem_size, 1,
-                       bf_list_size(&set->elems));
+        r = bf_map_new(&map, BF_MAP_TYPE_SET, suffix, BF_MAP_BPF_TYPE_HASH,
+                       set->elem_size, 1, bf_list_size(&set->elems));
         if (r < 0)
             return r;
 

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -202,7 +202,7 @@ struct bf_program
     /// Pinter map pinning path.
     char pmap_pin_path[PIN_PATH_LEN];
 
-    /// List of @ref bf_bpf_map used to store the sets.
+    /// List of @ref bf_map used to store the sets.
     bf_list sets;
 
     /// Log messages printer.

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -110,6 +110,7 @@
     })
 
 struct bf_chain;
+struct bf_map;
 struct bf_marsh;
 struct bf_counter;
 
@@ -192,15 +193,14 @@ struct bf_program
     enum bf_hook hook;
     enum bf_front front;
     char prog_name[BPF_OBJ_NAME_LEN];
-    /// Counters map name.
-    char cmap_name[BPF_OBJ_NAME_LEN];
     /// Printer map name.
     char pmap_name[BPF_OBJ_NAME_LEN];
     char prog_pin_path[PIN_PATH_LEN];
-    /// Counters map pinning path.
-    char cmap_pin_path[PIN_PATH_LEN];
     /// Pinter map pinning path.
     char pmap_pin_path[PIN_PATH_LEN];
+
+    /// Counters map
+    struct bf_map *counters;
 
     /// List of @ref bf_map used to store the sets.
     bf_list sets;
@@ -226,8 +226,6 @@ struct bf_program
     {
         /** File descriptor of the program. */
         int prog_fd;
-        /** File descriptor of the counters map. */
-        int cmap_fd;
         /** File descriptor of the printer map. */
         int pmap_fd;
         /** Hook-specific ops to use to generate the program. */

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -21,11 +21,20 @@
 #include "core/opts.h"
 
 #define _bf_ptr_to_u64(ptr) ((unsigned long long)(ptr))
-#define BPF_SYSCALL_NR 321
+
+#if defined(__i386__)
+#define _BF_NR_bpf 357
+#elif defined(__x86_64__)
+#define _BF_NR_bpf 321
+#elif defined(__aarch64__)
+#define _BF_NR_bpf 280
+#else
+#error _BF_NR_bpf not defined. bpfilter does not support your arch.
+#endif
 
 int bf_bpf(enum bpf_cmd cmd, union bpf_attr *attr)
 {
-    int r = (int)syscall(BPF_SYSCALL_NR, cmd, attr, sizeof(*attr));
+    int r = (int)syscall(_BF_NR_bpf, cmd, attr, sizeof(*attr));
     if (r < 0)
         return -errno;
 

--- a/tests/unit/src/bpfilter/cgen/prog/map.c
+++ b/tests/unit/src/bpfilter/cgen/prog/map.c
@@ -11,68 +11,68 @@
 
 Test(map, create_delete_assert)
 {
-    expect_assert_failure(bf_bpf_map_new(NULL, NOT_NULL, BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
-    expect_assert_failure(bf_bpf_map_new(NOT_NULL, NULL, BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
-    expect_assert_failure(bf_bpf_map_new(NOT_NULL, NOT_NULL, BF_BPF_MAP_TYPE_ARRAY, 0, 1, 1));
-    expect_assert_failure(bf_bpf_map_new(NOT_NULL, NOT_NULL, BF_BPF_MAP_TYPE_ARRAY, 1, 0, 1));
-    expect_assert_failure(bf_bpf_map_new(NOT_NULL, NOT_NULL, BF_BPF_MAP_TYPE_ARRAY, 1, 1, 0));
-    expect_assert_failure(bf_bpf_map_free(NULL));
+    expect_assert_failure(bf_map_new(NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 0, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 0, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 0));
+    expect_assert_failure(bf_map_free(NULL));
 }
 
 Test(map, create_delete)
 {
     // Rely on the cleanup attribute
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map0 = NULL;
+    _cleanup_bf_map_ struct bf_map *map0 = NULL;
 
-    assert_success(bf_bpf_map_new(&map0, "", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map0, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map0);
 
     // Use the cleanup attribute, but free manually
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map1 = NULL;
+    _cleanup_bf_map_ struct bf_map *map1 = NULL;
 
-    assert_success(bf_bpf_map_new(&map1, "", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map1, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map1);
 
-    bf_bpf_map_free(&map1);
+    bf_map_free(&map1);
     assert_null(map1);
 
     // Free manually
-    struct bf_bpf_map *map2;
+    struct bf_map *map2;
 
-    assert_success(bf_bpf_map_new(&map2, "", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map2, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map2);
 
-    bf_bpf_map_free(&map2);
+    bf_map_free(&map2);
     assert_null(map2);
-    bf_bpf_map_free(&map2);
+    bf_map_free(&map2);
 }
 
 Test(map, marsh_unmarsh_assert)
 {
-    expect_assert_failure(bf_bpf_map_new_from_marsh(NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_new_from_marsh(NOT_NULL, NULL));
-    expect_assert_failure(bf_bpf_map_marsh(NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_marsh(NOT_NULL, NULL));
+    expect_assert_failure(bf_map_new_from_marsh(NULL, NOT_NULL));
+    expect_assert_failure(bf_map_new_from_marsh(NOT_NULL, NULL));
+    expect_assert_failure(bf_map_marsh(NULL, NOT_NULL));
+    expect_assert_failure(bf_map_marsh(NOT_NULL, NULL));
 }
 
 Test(map, marsh_unmarsh)
 {
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map0 = NULL;
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map1 = NULL;
+    _cleanup_bf_map_ struct bf_map *map0 = NULL;
+    _cleanup_bf_map_ struct bf_map *map1 = NULL;
     _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, 1);
 
-    assert_success(bf_bpf_map_new(&map0, "012345", BF_BPF_MAP_TYPE_ARRAY, 1, 2, 3));
+    assert_success(bf_map_new(&map0, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 2, 3));
 
-    assert_success(bf_bpf_map_marsh(map0, &marsh));
-    assert_success(bf_bpf_map_new_from_marsh(&map1, marsh));
+    assert_success(bf_map_marsh(map0, &marsh));
+    assert_success(bf_map_new_from_marsh(&map1, marsh));
 
     // Ensure we won't try to close a garbage FD
     map1->fd = -1;
 
     assert_string_equal(map0->name, map1->name);
     assert_string_equal(map0->path, map1->path);
-    assert_int_equal(map0->type, map1->type);
+    assert_int_equal(map0->bpf_type, map1->bpf_type);
     assert_int_equal(map0->key_size, map1->key_size);
     assert_int_equal(map0->value_size, map1->value_size);
     assert_int_equal(map0->n_elems, map1->n_elems);
@@ -80,81 +80,81 @@ Test(map, marsh_unmarsh)
 
 Test(map, dump_assert)
 {
-    expect_assert_failure(bf_bpf_map_dump(NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_dump(NOT_NULL, NULL));
+    expect_assert_failure(bf_map_dump(NULL, NOT_NULL));
+    expect_assert_failure(bf_map_dump(NOT_NULL, NULL));
 }
 
 Test(map, dump)
 {
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map = NULL;
+    _cleanup_bf_map_ struct bf_map *map = NULL;
 
-    assert_success(bf_bpf_map_new(&map, "012345", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
-    bf_bpf_map_dump(map, EMPTY_PREFIX);
+    assert_success(bf_map_new(&map, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    bf_map_dump(map, EMPTY_PREFIX);
 }
 
 Test(map, bpf_map_type_to_kernel_type_assert)
 {
-    expect_assert_failure(_bf_bpf_map_type_to_kernel_type(-1));
-    expect_assert_failure(_bf_bpf_map_type_to_kernel_type(_BF_BPF_MAP_TYPE_MAX));
+    expect_assert_failure(_bf_map_bpf_type_to_kernel_type(-1));
+    expect_assert_failure(_bf_map_bpf_type_to_kernel_type(_BF_MAP_BPF_TYPE_MAX));
 }
 
 Test(map, map_create_assert)
 {
-    expect_assert_failure(bf_bpf_map_create(NULL, 0, false));
+    expect_assert_failure(bf_map_create(NULL, 0, false));
 }
 
 Test(map, map_create)
 {
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map = NULL;
+    _cleanup_bf_map_ struct bf_map *map = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, 16);
 
-    assert_success(bf_bpf_map_new(&map, "suffix", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
-    assert_success(bf_bpf_map_create(map, 0, false));
+    assert_success(bf_map_new(&map, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_create(map, 0, false));
 
-    // So bf_bpf_map_free() doesn't try to close a random FD value
+    // So bf_map_free() doesn't try to close a random FD value
     map->fd = -1;
 }
 
 Test(map, map_create_failure)
 {
-    _cleanup_bf_bpf_map_ struct bf_bpf_map *map = NULL;
+    _cleanup_bf_map_ struct bf_map *map = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, -1);
 
-    assert_success(bf_bpf_map_new(&map, "suffix", BF_BPF_MAP_TYPE_ARRAY, 1, 1, 1));
-    assert_error(bf_bpf_map_create(map, 0, false));
+    assert_success(bf_map_new(&map, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_error(bf_map_create(map, 0, false));
 }
 
 Test(map, map_destroy_assert)
 {
-    expect_assert_failure(bf_bpf_map_destroy(NULL, false));
+    expect_assert_failure(bf_map_destroy(NULL, false));
 }
 
 Test(map, map_set_elem_assert)
 {
-    expect_assert_failure(bf_bpf_map_set_elem(NULL, NOT_NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_set_elem(NOT_NULL, NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_set_elem(NOT_NULL, NOT_NULL, NULL));
+    expect_assert_failure(bf_map_set_elem(NULL, NOT_NULL, NOT_NULL));
+    expect_assert_failure(bf_map_set_elem(NOT_NULL, NULL, NOT_NULL));
+    expect_assert_failure(bf_map_set_elem(NOT_NULL, NOT_NULL, NULL));
 }
 
 Test(map, bpf_map_type_to_from_assert)
 {
-    expect_assert_failure(bf_bpf_map_type_to_str(-1));
-    expect_assert_failure(bf_bpf_map_type_to_str(_BF_BPF_MAP_TYPE_MAX));
-    expect_assert_failure(bf_bpf_map_type_from_str(NULL, NOT_NULL));
-    expect_assert_failure(bf_bpf_map_type_from_str(NOT_NULL, NULL));
+    expect_assert_failure(bf_map_bpf_type_to_str(-1));
+    expect_assert_failure(bf_map_bpf_type_to_str(_BF_MAP_BPF_TYPE_MAX));
+    expect_assert_failure(bf_map_bpf_type_from_str(NULL, NOT_NULL));
+    expect_assert_failure(bf_map_bpf_type_from_str(NOT_NULL, NULL));
 }
 
 Test(map, bpf_map_type_to_from)
 {
-    enum bf_bpf_map_type type;
+    enum bf_map_bpf_type type;
 
-    for (size_t i = 0; i < _BF_BPF_MAP_TYPE_MAX; ++i) {
-        enum bf_bpf_map_type type;
-        const char *str = bf_bpf_map_type_to_str(i);
+    for (size_t i = 0; i < _BF_MAP_BPF_TYPE_MAX; ++i) {
+        enum bf_map_bpf_type type;
+        const char *str = bf_map_bpf_type_to_str(i);
         assert_non_null(str);
-        assert_success(bf_bpf_map_type_from_str(str, &type));
+        assert_success(bf_map_bpf_type_from_str(str, &type));
         assert_int_equal(i, type);
     }
 
-    assert_error(bf_bpf_map_type_from_str("invalid", &type));
+    assert_error(bf_map_bpf_type_from_str("invalid", &type));
 }

--- a/tests/unit/src/bpfilter/cgen/prog/map.c
+++ b/tests/unit/src/bpfilter/cgen/prog/map.c
@@ -99,6 +99,40 @@ Test(map, bpf_map_type_to_kernel_type_assert)
     expect_assert_failure(_bf_map_bpf_type_to_kernel_type(_BF_MAP_BPF_TYPE_MAX));
 }
 
+Test(map, btf_create_delete_assert)
+{
+    expect_assert_failure(_bf_btf_new(NULL));
+    expect_assert_failure(_bf_btf_free(NULL));
+}
+
+Test(map, btf_create_delete)
+{
+    // Rely on the cleanup attribute
+    _cleanup_bf_btf_ struct bf_btf *btf0 = NULL;
+
+    assert_success(_bf_btf_new(&btf0));
+    assert_non_null(btf0);
+
+    // Use the cleanup attribute, but free manually
+    _cleanup_bf_btf_ struct bf_btf *btf1 = NULL;
+
+    assert_success(_bf_btf_new(&btf1));
+    assert_non_null(btf1);
+
+    _bf_btf_free(&btf1);
+    assert_null(btf1);
+
+    // Free manually
+    struct bf_btf *btf2;
+
+    assert_success(_bf_btf_new(&btf2));
+    assert_non_null(btf2);
+
+    _bf_btf_free(&btf2);
+    assert_null(btf2);
+    _bf_btf_free(&btf2);     
+}
+
 Test(map, map_create_assert)
 {
     expect_assert_failure(bf_map_create(NULL, 0, false));

--- a/tests/unit/src/bpfilter/cgen/prog/map.c
+++ b/tests/unit/src/bpfilter/cgen/prog/map.c
@@ -109,8 +109,11 @@ Test(map, map_create)
     _cleanup_bf_map_ struct bf_map *map = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, 16);
 
-    assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, BF_MAP_N_ELEMS_UNKNOWN));
+    assert_error(bf_map_create(map, 0, false));
+    assert_success(bf_map_set_n_elems(map, 1));
     assert_success(bf_map_create(map, 0, false));
+    assert_error(bf_map_set_n_elems(map, 1));
 
     // So bf_map_free() doesn't try to close a random FD value
     map->fd = -1;

--- a/tests/unit/src/bpfilter/cgen/prog/map.c
+++ b/tests/unit/src/bpfilter/cgen/prog/map.c
@@ -11,11 +11,11 @@
 
 Test(map, create_delete_assert)
 {
-    expect_assert_failure(bf_map_new(NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
-    expect_assert_failure(bf_map_new(NOT_NULL, NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
-    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 0, 1, 1));
-    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 0, 1));
-    expect_assert_failure(bf_map_new(NOT_NULL, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 0));
+    expect_assert_failure(bf_map_new(NULL, BF_MAP_TYPE_SET, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, BF_MAP_TYPE_SET, NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, BF_MAP_TYPE_SET, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 0, 1, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, BF_MAP_TYPE_SET, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 0, 1));
+    expect_assert_failure(bf_map_new(NOT_NULL, BF_MAP_TYPE_SET, NOT_NULL, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 0));
     expect_assert_failure(bf_map_free(NULL));
 }
 
@@ -24,13 +24,13 @@ Test(map, create_delete)
     // Rely on the cleanup attribute
     _cleanup_bf_map_ struct bf_map *map0 = NULL;
 
-    assert_success(bf_map_new(&map0, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map0, BF_MAP_TYPE_SET, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map0);
 
     // Use the cleanup attribute, but free manually
     _cleanup_bf_map_ struct bf_map *map1 = NULL;
 
-    assert_success(bf_map_new(&map1, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map1, BF_MAP_TYPE_SET, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map1);
 
     bf_map_free(&map1);
@@ -39,7 +39,7 @@ Test(map, create_delete)
     // Free manually
     struct bf_map *map2;
 
-    assert_success(bf_map_new(&map2, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map2, BF_MAP_TYPE_SET, "", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map2);
 
     bf_map_free(&map2);
@@ -62,7 +62,7 @@ Test(map, marsh_unmarsh)
     _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf_obj_get, 1);
 
-    assert_success(bf_map_new(&map0, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 2, 3));
+    assert_success(bf_map_new(&map0, BF_MAP_TYPE_SET, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 2, 3));
 
     assert_success(bf_map_marsh(map0, &marsh));
     assert_success(bf_map_new_from_marsh(&map1, marsh));
@@ -70,6 +70,7 @@ Test(map, marsh_unmarsh)
     // Ensure we won't try to close a garbage FD
     map1->fd = -1;
 
+    assert_string_equal(map0->name, map1->name);
     assert_string_equal(map0->name, map1->name);
     assert_string_equal(map0->path, map1->path);
     assert_int_equal(map0->bpf_type, map1->bpf_type);
@@ -88,7 +89,7 @@ Test(map, dump)
 {
     _cleanup_bf_map_ struct bf_map *map = NULL;
 
-    assert_success(bf_map_new(&map, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "012345", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     bf_map_dump(map, EMPTY_PREFIX);
 }
 
@@ -108,7 +109,7 @@ Test(map, map_create)
     _cleanup_bf_map_ struct bf_map *map = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, 16);
 
-    assert_success(bf_map_new(&map, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_success(bf_map_create(map, 0, false));
 
     // So bf_map_free() doesn't try to close a random FD value
@@ -120,7 +121,7 @@ Test(map, map_create_failure)
     _cleanup_bf_map_ struct bf_map *map = NULL;
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, -1);
 
-    assert_success(bf_map_new(&map, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
+    assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_error(bf_map_create(map, 0, false));
 }
 


### PR DESCRIPTION
Multiple improvements related to the management of the BPF maps:
- Rename `bf_bpf_map` to `bf_map`.
- Define a type for the `bf_map` object: counters, set, or printer.
- Allow for `bf_map` of unknown size to be created: we don't know the size of the counters map until the rules are generated, so the `BF_MAP_N_ELEMS_UNKNOWN` placeholder is used, and the size is updated before the map is created.
- Improved memory management.
- Use `bf_map` to manage the counters map: remove a lot of bloat from `bf_program` object.
- Generate the BTF data for the counters map. Quite useful for debugging, as we have the actual counters value instead of a little-endian set of hex values.
- Fix the BPF syscall number: the x64 number was used until I realized I should deal properly with different arches.