### PR TITLE
cgen: do not zero the runtime context

### DIFF
--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -851,18 +851,10 @@ int bf_program_emit_fixup_call(struct bf_program *program,
 
 static int _bf_program_generate_runtime_init(struct bf_program *program)
 {
-    int r;
-
     // Store the context's address in BF_REG_CTX.
     EMIT(program, BPF_MOV64_REG(BF_REG_CTX, BF_REG_FP));
     EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_REG_CTX,
                                 -(int)sizeof(struct bf_program_context)));
-
-    // Initialise the context to 0.
-    r = bf_stub_memclear(program, BF_REG_CTX,
-                         sizeof(struct bf_program_context));
-    if (r)
-        return r;
 
     // Save the program's argument into the context.
     EMIT(program,

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -31,20 +31,6 @@
 
 #include "external/filter.h"
 
-int bf_stub_memclear(struct bf_program *program, enum bf_reg addr_reg,
-                     size_t size)
-{
-    static const size_t write_size = 8;
-
-    bf_assert(program);
-    bf_assert(!(size % 8));
-
-    for (size_t i = 0; i < size; i += write_size)
-        EMIT(program, BPF_ST_MEM(BPF_DW, addr_reg, i, 0));
-
-    return 0;
-}
-
 /**
  * Generate stub to create a dynptr.
  *

--- a/src/bpfilter/cgen/stub.h
+++ b/src/bpfilter/cgen/stub.h
@@ -12,22 +12,6 @@
 struct bf_program;
 
 /**
- * Emit instructions to clear a memory region.
- *
- * Generate BPF instructions to clear (set to 0) a memory region, from a
- * register containing the address of the memory region to clear, and the size.
- *
- * @warning The memory area *must* be aligned on 8 bytes (address and size), as
- * the region is cleared 8 bytes at a time.
- *
- * @param program Program to emit instructions into.
- * @param addr_reg Register containing the address to clear.
- * @param size Size of the memory region to clear.
- * @return 0 on success, or negative errno value on error.
- */
-int bf_stub_memclear(struct bf_program *program, enum bf_reg addr_reg,
-                     size_t size);
-/**
  * Emit instructions to get a dynptr for an XDP program.
  *
  * Prepare arguments and call bpf_dynptr_from_xdp(). If the return value is


### PR DESCRIPTION
The runtime context used by the BPF programs is filled with zero at the very beginning to ensure no garbage value is used. However, the verifier wouldn't allow for a read to happen before a write, meaning it will prevent us from reading garbage value. Hence, it's better to not zero-out the runtime context.