### PR TITLE
Support for interface index filtering

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -111,6 +111,11 @@ With:
       - Operator
       - Payload
       - Notes
+    * - Interface index
+      - ``meta.ifindex``
+      - ``eq``
+      - ``$IFINDEX``
+      - For chains attached to an ingress hook, ``$IFINDEX`` is the input interface index. For chains attached to an egress hook, ``$IFINDEX`` is the output interface index.
     * - L3 protocol
       - ``meta.l3_proto``
       - ``eq``

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -17,6 +17,7 @@
 %option noinput
 %option nounput
 
+%s STATE_MATCHER_META_IFINDEX
 %s STATE_MATCHER_META_L3_PROTO
 %s STATE_MATCHER_META_L4_PROTO
 %s STATE_MATCHER_IP_PROTO
@@ -44,6 +45,15 @@ BF_HOOK_[A-Z_]+ { yylval.sval = strdup(yytext); return HOOK; }
 (ACCEPT|DROP)   { yylval.sval = strdup(yytext); return VERDICT; }
 
     /* Matcher types */
+meta\.ifindex  { BEGIN(STATE_MATCHER_META_IFINDEX); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_META_IFINDEX>{
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    [0-9]+ {
+        yylval.sval = strdup(yytext);
+        return MATCHER_META_IFINDEX;
+    }
+}
+
 meta\.l3_proto  { BEGIN(STATE_MATCHER_META_L3_PROTO); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_META_L3_PROTO>{
     (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -19,6 +19,18 @@
 
 #include "external/filter.h"
 
+static int _bf_matcher_generate_meta_ifindex(struct bf_program *program,
+                                             const struct bf_matcher *matcher)
+{
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(ifindex)));
+    EMIT_FIXUP_JMP_NEXT_RULE(
+        program,
+        BPF_JMP_IMM(BPF_JNE, BF_REG_1, *(uint32_t *)&matcher->payload, 0));
+
+    return 0;
+}
+
 static int _bf_matcher_generate_meta_l3_proto(struct bf_program *program,
                                               const struct bf_matcher *matcher)
 {
@@ -49,6 +61,9 @@ int bf_matcher_generate_meta(struct bf_program *program,
     int r;
 
     switch (matcher->type) {
+    case BF_MATCHER_META_IFINDEX:
+        r = _bf_matcher_generate_meta_ifindex(program, matcher);
+        break;
     case BF_MATCHER_META_L3_PROTO:
         r = _bf_matcher_generate_meta_l3_proto(program, matcher);
         break;

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -551,6 +551,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
         struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
 
         switch (matcher->type) {
+        case BF_MATCHER_META_IFINDEX:
         case BF_MATCHER_META_L3_PROTO:
         case BF_MATCHER_META_L4_PROTO:
             r = bf_matcher_generate_meta(program, matcher);

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -150,6 +150,10 @@ struct bf_program_context
     /** Offset of the layer 4 protocol. */
     uint32_t l4_offset;
 
+    /** On ingress, index of the input interface. On egress, index of the
+     * output interface. */
+    uint32_t ifindex;
+
     /** Layer 3 protocol, set when processing layer 2 protocol header. Required
      * to process the layer 3 header. */
     uint16_t bf_aligned(8) l3_proto;

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -16,6 +16,7 @@
 #include "bpfilter/cgen/reg.h"
 #include "bpfilter/cgen/stub.h"
 #include "core/bpf.h"
+#include "core/btf.h"
 #include "core/flavor.h"
 #include "core/helper.h"
 #include "core/hook.h"
@@ -59,6 +60,20 @@ static int _bf_tc_gen_inline_prologue(struct bf_program *program)
     // Copy packet size into context
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
+
+    /** The @c __sk_buff structure contains two fields related to the interface
+     * index: @c ingress_ifindex and @c ifindex . @c ingress_ifindex is the
+     * interface index the packet has been received on. However, we use
+     * @c ifindex which is the interface index the packet is processed by: if
+     * a packet is redirected locally from interface #1 to interface #2, then
+     * @c ingress_ifindex will contain @c 1 but @c ifindex will contains @c 2 .
+     * For egress, only @c ifindex is used.
+     */
+    if ((r = bf_btf_get_field_off("__sk_buff", "ifindex")) < 0)
+        return r;
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, r));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(ifindex)));
 
     r = bf_stub_make_ctx_skb_dynptr(program, BF_REG_1);
     if (r)

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -45,14 +45,6 @@ static int _bf_tc_gen_inline_prologue(struct bf_program *program)
 
     bf_assert(program);
 
-    r = bf_stub_make_ctx_skb_dynptr(program, BF_REG_1);
-    if (r)
-        return r;
-
-    // Copy __sk_buff pointer into BF_REG_1
-    EMIT(program,
-         BPF_LDX_MEM(BPF_DW, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(arg)));
-
     // Copy __sk_buff.data into BF_REG_2
     EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1,
                               offsetof(struct __sk_buff, data)));
@@ -67,6 +59,10 @@ static int _bf_tc_gen_inline_prologue(struct bf_program *program)
     // Copy packet size into context
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
+
+    r = bf_stub_make_ctx_skb_dynptr(program, BF_REG_1);
+    if (r)
+        return r;
 
     r = bf_stub_parse_l2_ethhdr(program);
     if (r)

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -12,6 +12,7 @@
 #include "bpfilter/cgen/reg.h"
 #include "bpfilter/cgen/stub.h"
 #include "core/bpf.h"
+#include "core/btf.h"
 #include "core/flavor.h"
 #include "core/helper.h"
 #include "core/hook.h"
@@ -68,6 +69,13 @@ static int _bf_xdp_gen_inline_prologue(struct bf_program *program)
     // Copy packet size into context
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
+
+    // Copy the ingress ifindex into the runtime context
+    if ((r = bf_btf_get_field_off("xdp_md", "ingress_ifindex")) < 0)
+        return r;
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, r));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(ifindex)));
 
     r = bf_stub_make_ctx_xdp_dynptr(program, BF_REG_1);
     if (r)

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -69,9 +69,6 @@ static int _bf_xdp_gen_inline_prologue(struct bf_program *program)
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 
-    EMIT(program,
-         BPF_LDX_MEM(BPF_DW, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(arg)));
-
     r = bf_stub_make_ctx_xdp_dynptr(program, BF_REG_1);
     if (r)
         return r;

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -132,6 +132,7 @@ void bf_matcher_dump(const struct bf_matcher *matcher, prefix_t *prefix)
 }
 
 static const char *_bf_matcher_type_strs[] = {
+    [BF_MATCHER_META_IFINDEX] = "meta.ifindex",
     [BF_MATCHER_META_L3_PROTO] = "meta.l3_proto",
     [BF_MATCHER_META_L4_PROTO] = "meta.l4_proto",
     [BF_MATCHER_IP4_SRC_ADDR] = "ip4.saddr",

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -41,6 +41,9 @@ struct bf_marsh;
  */
 enum bf_matcher_type
 {
+    /// Matches the packet's network interface index. On ingress it represents
+    /// the input interface, on egress the output interface.
+    BF_MATCHER_META_IFINDEX,
     /// Matches the L3 protocol.
     BF_MATCHER_META_L3_PROTO,
     /// Matches the L4 protocol, idependently from the L3 protocol.

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -1,6 +1,10 @@
 # Create an XDP chain
 chain BF_HOOK_XDP policy ACCEPT
     rule
+        meta.ifindex 1
+        counter
+        ACCEPT
+    rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
         counter
         ACCEPT
@@ -52,6 +56,10 @@ chain BF_HOOK_XDP policy ACCEPT
 # Create a TC chain
 chain BF_HOOK_TC_INGRESS policy ACCEPT
     rule
+        meta.ifindex 1
+        counter
+        ACCEPT
+    rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
         counter
         ACCEPT
@@ -90,6 +98,10 @@ chain BF_HOOK_TC_INGRESS policy ACCEPT
 
 # Create a BPF_NETFILTER chain
 chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
+    rule
+        meta.ifindex 1
+        counter
+        ACCEPT
     rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
         counter


### PR DESCRIPTION
Interface index filtering doesn't work for XDP/TC, and is a badly implemented for `BPF_NETFILTER` programs. This PR improves the situation by creating a dedicated `ifindex` matcher. 

The behaviour of the matcher depends on the location of the hook: a hook located on the RX path will filter on the ingress interface, while a hook located on the TX path will filter on the egress interface.