### PR TITLE
Some bug fixes!

### DIFF
--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -199,6 +199,13 @@ static int _bf_nf_attach_prog(struct bf_program *new_prog,
         if (r)
             return bf_err_r(r, "failed to create temporary link");
 
+        /* As we perform a two-steps replacement of the link, we need to detach
+         * the link from the hook: if the link FD is pinned, closing it won't
+         * detach it and will prevent the creation of a link with the same
+         * priority. */
+        r = bf_bpf_link_detach(old_prog->runtime.prog_fd);
+        if (r < 0)
+            bf_warn_r(r, "failed to detach existing BPF_NETFILTER link");
         closep(&old_prog->runtime.prog_fd);
 
         r = bf_bpf_nf_link_create(prog_fd, new_prog->hook, 1, &link_fd);

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -137,11 +137,9 @@ void bf_map_dump(const struct bf_map *map, prefix_t *prefix);
  * @param map BPF map to create. Can't be NULL.
  * @param flags Flags to use during map creation. All the flags supported by
  *              @c BPF_MAP_CREATE can be used.
- * @param pin If true, the map will be pinned to the filesystem. This will
- *            ensure it remains once bpfilter is stopped.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_map_create(struct bf_map *map, uint32_t flags, bool pin);
+int bf_map_create(struct bf_map *map, uint32_t flags);
 
 /**
  * Destroy the BPF map.
@@ -151,11 +149,20 @@ int bf_map_create(struct bf_map *map, uint32_t flags, bool pin);
  * it is pinned to the filesystem.
  *
  * @param map BPF map to destroy. Can't be NULL.
- * @param unpin If true, unpin the map from the filesystem: the map will be
- *              removed from the kernel as soon as no other program or map uses
- *              it.
  */
-void bf_map_destroy(struct bf_map *map, bool unpin);
+void bf_map_destroy(struct bf_map *map);
+
+/**
+ * Pin the map to the filesystem.
+ *
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_map_pin(const struct bf_map *map);
+
+/**
+ * Unpin the map from the filesystem.
+ */
+void bf_map_unpin(const struct bf_map *map);
 
 /**
  * Set the number of elements in the map.

--- a/src/core/marsh.h
+++ b/src/core/marsh.h
@@ -27,6 +27,19 @@ struct bf_marsh
 #define _cleanup_bf_marsh_ __attribute__((__cleanup__(bf_marsh_free)))
 
 /**
+ * Returns true if a marsh object is empty (only contains a header).
+ *
+ * @param marsh Marsh object to check for empty. Can't be NULL.
+ * @return True if the @c marsh object is empty, false otherwise.
+ */
+static inline bool bf_marsh_is_empty(const struct bf_marsh *marsh)
+{
+    bf_assert(marsh);
+
+    return marsh->data_len == 0;
+}
+
+/**
  * Get the total size of marshalled data.
  *
  * @param marsh Marshalled data.

--- a/tests/unit/src/bpfilter/cgen/cgen.c
+++ b/tests/unit/src/bpfilter/cgen/cgen.c
@@ -76,9 +76,6 @@ Test(cgen, marsh_unmarsh)
     _cleanup_bf_cgen_ struct bf_cgen *cgen0 = NULL;
     _cleanup_bf_cgen_ struct bf_cgen *cgen1 = NULL;
     _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_mock_ bf_mock _0 = bf_mock_empty(bf_bpf_obj_get);
-
-    bf_mock_will_return_always(_0, 0);
 
     /* Create a codegen without any program, other bf_program_unmarsh()
      * will try to open the pinned BPF objects.

--- a/tests/unit/src/bpfilter/cgen/prog/map.c
+++ b/tests/unit/src/bpfilter/cgen/prog/map.c
@@ -135,7 +135,7 @@ Test(map, btf_create_delete)
 
 Test(map, map_create_assert)
 {
-    expect_assert_failure(bf_map_create(NULL, 0, false));
+    expect_assert_failure(bf_map_create(NULL, 0));
 }
 
 Test(map, map_create)
@@ -144,9 +144,9 @@ Test(map, map_create)
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, 16);
 
     assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, BF_MAP_N_ELEMS_UNKNOWN));
-    assert_error(bf_map_create(map, 0, false));
+    assert_error(bf_map_create(map, 0));
     assert_success(bf_map_set_n_elems(map, 1));
-    assert_success(bf_map_create(map, 0, false));
+    assert_success(bf_map_create(map, 0));
     assert_error(bf_map_set_n_elems(map, 1));
 
     // So bf_map_free() doesn't try to close a random FD value
@@ -159,12 +159,12 @@ Test(map, map_create_failure)
     _cleanup_bf_mock_ bf_mock _ = bf_mock_get(bf_bpf, -1);
 
     assert_success(bf_map_new(&map, BF_MAP_TYPE_SET, "suffix", BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
-    assert_error(bf_map_create(map, 0, false));
+    assert_error(bf_map_create(map, 0));
 }
 
 Test(map, map_destroy_assert)
 {
-    expect_assert_failure(bf_map_destroy(NULL, false));
+    expect_assert_failure(bf_map_destroy(NULL));
 }
 
 Test(map, map_set_elem_assert)


### PR DESCRIPTION
- Decouple the BPF map creation and pinning.
- Fix `BPF_NETFILTER` program update for pinned programs.
- Add function to check if a `bf_marsh` object is empty.