### PR TITLE
core: rule: remove `ifindex` field from `struct bf_rule`

### DIFF
--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -288,7 +288,10 @@ static int _bf_ipt_to_rule(const struct ipt_entry *ipt_rule,
                             ipt_rule->ip.iniface);
         }
 
-        _rule->ifindex = r;
+        r = bf_rule_add_matcher(_rule, BF_MATCHER_META_IFINDEX, BF_MATCHER_EQ,
+                                &r, sizeof(r));
+        if (r < 0)
+            return r;
     }
 
     _rule->counters = true;
@@ -428,8 +431,6 @@ static int _bf_ipt_xlate_set_rules(struct ipt_replace *ipt,
         if (r < 0)
             return r;
 
-        bf_dbg("created codegen for %s::%s", bf_front_to_str(cgen->front),
-               bf_hook_to_str(chain->hook));
         (*cgens)[hook] = TAKE_PTR(cgen);
     }
 

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -60,9 +60,8 @@ int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
     if (r < 0)
         return r;
 
-    r |= bf_marsh_add_child_raw(&_marsh, &rule->index, sizeof(rule->index));
-    r |= bf_marsh_add_child_raw(&_marsh, &rule->ifindex, sizeof(rule->ifindex));
-    if (r)
+    r = bf_marsh_add_child_raw(&_marsh, &rule->index, sizeof(rule->index));
+    if (r < 0)
         return r;
 
     {
@@ -120,10 +119,6 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
 
     if (!(rule_elem = bf_marsh_next_child(marsh, rule_elem)))
         return -EINVAL;
-    memcpy(&_rule->ifindex, rule_elem->data, sizeof(_rule->ifindex));
-
-    if (!(rule_elem = bf_marsh_next_child(marsh, rule_elem)))
-        return -EINVAL;
 
     {
         struct bf_marsh *matcher_elem = NULL;
@@ -169,7 +164,6 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
     bf_dump_prefix_push(prefix);
 
     DUMP(prefix, "index: %u", rule->index);
-    DUMP(prefix, "ifindex: %u", rule->ifindex);
 
     // Matchers
     DUMP(prefix, "matchers: %lu", bf_list_size(&rule->matchers));

--- a/src/core/rule.h
+++ b/src/core/rule.h
@@ -28,7 +28,6 @@ struct bf_marsh;
 struct bf_rule
 {
     uint32_t index;
-    uint32_t ifindex;
     bf_list matchers;
     bool counters;
     enum bf_verdict verdict;

--- a/tests/unit/harness/helper.c
+++ b/tests/unit/harness/helper.c
@@ -148,7 +148,6 @@ struct bf_rule *bf_test_get_rule(void)
     assert_int_equal(0, bf_rule_new(&rule));
 
     rule->index = 1;
-    rule->ifindex = 2;
 
     for (int i = 0; i < 10; ++i)
         assert_int_equal(

--- a/tests/unit/src/core/rule.c
+++ b/tests/unit/src/core/rule.c
@@ -54,7 +54,6 @@ Test(rule, marsh_unmarsh)
         assert_int_equal(0, bf_rule_unmarsh(marsh, &rule1));
 
         assert_int_equal(rule0->index, rule1->index);
-        assert_int_equal(rule0->ifindex, rule1->ifindex);
         assert_int_equal(bf_list_size(&rule0->matchers),
                          bf_list_size(&rule1->matchers));
         assert_int_equal(rule0->counters, rule1->counters);


### PR DESCRIPTION
`struct bf_rule` doesn't need to contain an interface index field anymore as a dedicated matcher type exists. Remove every reference to `bf_rule.ifindex` and create a matcher of type `BF_MATCHER_META_IFINDEX` from `ipt` front-end.