### PR TITLE
tests: fix `clang-tidy` warnings

### DIFF
--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -10,6 +10,7 @@
 #include <linux/if_ether.h>
 #include <linux/netfilter.h>
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/socket.h>

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -9,7 +9,6 @@
 
 #include <bpf/btf.h>
 #include <errno.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -7,7 +7,6 @@
 
 #include <linux/bpf.h>
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/src/bpfilter/cgen/stub.h
+++ b/src/bpfilter/cgen/stub.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <stddef.h>
-
 #include "bpfilter/cgen/reg.h"
 
 struct bf_program;


### PR DESCRIPTION
`clang-tidy` on Fedora 39 noticed some headers are not directly used. Fix the warnings by removing the `#include` directive for those headers.