### PR TITLE
Add support for `cgroup_skb/ingress` and `cgroup_skb/egress`

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -49,6 +49,8 @@ With:
     - ``BF_HOOK_TC_INGRESS``: ingress TC hook.
     - ``BF_HOOK_NF_PRE_ROUTING``: similar to ``nftables`` and ``iptables`` prerouting hook.
     - ``BF_HOOK_NF_LOCAL_IN``: similar to ``nftables`` and ``iptables`` input hook.
+    - ``BF_HOOK_CGROUP_INGRESS``: ingress cgroup hook.
+    - ``BF_HOOK_CGROUP_EGRESS``: egress cgroup hook.
     - ``BF_HOOK_NF_FORWARD``: similar to ``nftables`` and ``iptables`` forward hook.
     - ``BF_HOOK_NF_LOCAL_OUT``: similar to ``nftables`` and ``iptables`` output hook.
     - ``BF_HOOK_NF_POST_ROUTING``: similar to ``nftables`` and ``iptables`` postrouting hook.
@@ -69,6 +71,9 @@ With:
    * - ``ifindex=$IFINDEX``
      - ``BF_HOOK_XDP``, ``BF_HOOK_TC_INGRESS``, ``BF_HOOK_TC_EGRESS``
      - Interface index to attach the program to.
+   * - ``cgroup=$CGROUP_PATH``
+     - ``BF_HOOK_CGROUP_INGRESS``, ``BF_HOOK_CGROUP_EGRESS``
+     - Path to the cgroup to attach to.
 
 
 Rules

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -43,7 +43,7 @@ counter         { return COUNTER; }
 BF_HOOK_[A-Z_]+ { BEGIN(STATE_HOOK_OPTS); yylval.sval = strdup(yytext); return HOOK; }
 <STATE_HOOK_OPTS>{
     (\{|\}) /* Ignore */
-    [a-zA-Z0-9_]+=[a-zA-Z0-9_]+ {
+    [a-zA-Z0-9_]+=[a-zA-Z0-9_\-\.\/]+ {
         yylval.sval = strdup(yytext);
         return HOOK_OPT;
     }

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -203,7 +203,8 @@ raw_hook_opts   : raw_hook_opts HOOK_OPT
                 }
                 ;
 
-rules           : rule
+rules           : %empty { $$ = NULL; }
+                | rule
                 {
                     _cleanup_bf_list_ bf_list *list = NULL;
 

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgen.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgen.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgroup.h            ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgroup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/dump.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/dump.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/fixup.h             ${CMAKE_CURRENT_SOURCE_DIR}/cgen/fixup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.h               ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.c

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bpfilter/cgen/cgroup.h"
+
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/if_ether.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/socket.h>
+
+#include "bpfilter/cgen/cgen.h"
+#include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
+#include "bpfilter/cgen/stub.h"
+#include "bpfilter/cgen/swich.h"
+#include "core/bpf.h"
+#include "core/btf.h"
+#include "core/flavor.h"
+#include "core/helper.h"
+#include "core/hook.h"
+#include "core/logger.h"
+#include "core/verdict.h"
+
+#include "external/filter.h"
+
+static int _bf_cgroup_gen_inline_prologue(struct bf_program *program);
+static int _bf_cgroup_gen_inline_epilogue(struct bf_program *program);
+static int _bf_cgroup_get_verdict(enum bf_verdict verdict);
+static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
+                                  struct bf_program *old_prog);
+static int _bf_cgroup_detach_prog(struct bf_program *program);
+
+const struct bf_flavor_ops bf_flavor_ops_cgroup = {
+    .gen_inline_prologue = _bf_cgroup_gen_inline_prologue,
+    .gen_inline_epilogue = _bf_cgroup_gen_inline_epilogue,
+    .get_verdict = _bf_cgroup_get_verdict,
+    .attach_prog = _bf_cgroup_attach_prog,
+    .detach_prog = _bf_cgroup_detach_prog,
+};
+
+// Forward definition to avoid headers clusterfuck.
+uint16_t htons(uint16_t hostshort);
+
+static int _bf_cgroup_gen_inline_prologue(struct bf_program *program)
+{
+    int offset;
+    int r;
+
+    bf_assert(program);
+
+    // Copy __sk_buff.family to l3_proto
+    if ((offset = bf_btf_get_field_off("__sk_buff", "family")) < 0)
+        return offset;
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, offset));
+    EMIT(program,
+         BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(l3_proto)));
+
+    // Copy __sk_buff.data into BF_REG_2
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1,
+                              offsetof(struct __sk_buff, data)));
+
+    // Copy __sk_buff.data_end into BF_REG_3
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_3, BF_REG_1,
+                              offsetof(struct __sk_buff, data_end)));
+
+    // Calculate packet size
+    EMIT(program, BPF_ALU64_REG(BPF_SUB, BF_REG_3, BF_REG_2));
+
+    // Add size of Ethernet header to BF_REG_3.
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_REG_3, ETH_HLEN));
+
+    // Copy packet size into context
+    EMIT(program,
+         BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
+
+    /** The @c __sk_buff structure contains two fields related to the interface
+     * index: @c ingress_ifindex and @c ifindex . @c ingress_ifindex is the
+     * interface index the packet has been received on. However, we use
+     * @c ifindex which is the interface index the packet is processed by: if
+     * a packet is redirected locally from interface #1 to interface #2, then
+     * @c ingress_ifindex will contain @c 1 but @c ifindex will contains @c 2 .
+     * For egress, only @c ifindex is used.
+     */
+    if ((r = bf_btf_get_field_off("__sk_buff", "ifindex")) < 0)
+        return r;
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, r));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(ifindex)));
+
+    r = bf_stub_make_ctx_skb_dynptr(program, BF_REG_1);
+    if (r)
+        return r;
+
+    /* BPF_PROG_TYPE_CGROUP_SKB doesn't provide access the the Ethernet header,
+     * so we can't parse it. Fill the runtime context's l3_proto and l3_offset
+     * manually instead. */
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l3_proto)));
+    {
+        _cleanup_bf_swich_ struct bf_swich swich =
+            bf_swich_get(program, BF_REG_1);
+
+        EMIT_SWICH_OPTION(
+            &swich, AF_INET, BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IP)),
+            BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)),
+            BPF_MOV64_IMM(BF_REG_1, 0),
+            BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
+                        BF_PROG_CTX_OFF(l3_offset)));
+        EMIT_SWICH_OPTION(
+            &swich, AF_INET6, BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IPV6)),
+            BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)),
+            BPF_MOV64_IMM(BF_REG_1, 0),
+            BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
+                        BF_PROG_CTX_OFF(l3_offset)));
+        EMIT_SWICH_DEFAULT(
+            &swich,
+            BPF_MOV64_IMM(BF_REG_RET,
+                          program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT)),
+            BPF_EXIT_INSN());
+
+        r = bf_swich_generate(&swich);
+        if (r)
+            return r;
+    }
+
+    r = bf_stub_parse_l3_hdr(program);
+    if (r)
+        return r;
+
+    r = bf_stub_parse_l4_hdr(program);
+    if (r)
+        return r;
+
+    return 0;
+}
+
+static int _bf_cgroup_gen_inline_epilogue(struct bf_program *program)
+{
+    UNUSED(program);
+
+    return 0;
+}
+
+/**
+ * Convert a standard verdict into a return value.
+ *
+ * @param verdict Verdict to convert. Must be valid.
+ * @return TC return code corresponding to the verdict, as an integer.
+ */
+static int _bf_cgroup_get_verdict(enum bf_verdict verdict)
+{
+    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+
+    static const int verdicts[] = {
+        [BF_VERDICT_ACCEPT] = 1,
+        [BF_VERDICT_DROP] = 0,
+    };
+
+    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+
+    return verdicts[verdict];
+}
+
+static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
+                                  struct bf_program *old_prog)
+{
+    _cleanup_close_ int prog_fd = -1;
+    _cleanup_close_ int link_fd = -1;
+    _cleanup_close_ int cgroup_fd = -1;
+    const char *cgroup_path;
+    int r;
+
+    bf_assert(new_prog);
+
+    r = bf_bpf_prog_load(new_prog->prog_name,
+                         bf_hook_to_bpf_prog_type(new_prog->hook),
+                         new_prog->img, new_prog->img_size,
+                         bf_hook_to_attach_type(new_prog->hook), &prog_fd);
+    if (r)
+        return bf_err_r(r, "failed to load new bf_program");
+
+    if (old_prog) {
+        r = bf_bpf_link_update(old_prog->runtime.prog_fd, prog_fd);
+        if (r) {
+            return bf_err_r(
+                r, "failed to updated existing link for cgroup bf_program");
+        }
+
+        new_prog->runtime.prog_fd = TAKE_FD(old_prog->runtime.prog_fd);
+    } else {
+        cgroup_path = new_prog->runtime.chain->hook_opts.cgroup;
+        cgroup_fd = open(cgroup_path, O_DIRECTORY | O_RDONLY);
+        if (cgroup_fd < 0)
+            return bf_err_r(errno, "failed to open cgroup '%s'", cgroup_path);
+
+        r = bf_bpf_cgroup_link_create(prog_fd, cgroup_fd,
+                                      bf_hook_to_attach_type(new_prog->hook),
+                                      &link_fd);
+        if (r) {
+            return bf_err_r(r,
+                            "failed to create new link for cgroup bf_program");
+        }
+
+        new_prog->runtime.prog_fd = TAKE_FD(link_fd);
+    }
+
+    return 0;
+}
+
+/**
+ * Detach the TC BPF program.
+ *
+ * @param program Attached TC BPF program. Can't be NULL.
+ * @return 0 on success, negative errno value on failure.
+ */
+static int _bf_cgroup_detach_prog(struct bf_program *program)
+{
+    bf_assert(program);
+
+    return bf_bpf_link_detach(program->runtime.prog_fd);
+}

--- a/src/bpfilter/cgen/cgroup.h
+++ b/src/bpfilter/cgen/cgroup.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/flavor.h"
+
+extern const struct bf_flavor_ops bf_flavor_ops_cgroup;

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -131,6 +131,12 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
             BPF_MOV64_IMM(BF_REG_1, 0),
             BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
                         BF_PROG_CTX_OFF(l3_offset)));
+        EMIT_SWICH_OPTION(
+            &swich, AF_INET6, BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IPV6)),
+            BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)),
+            BPF_MOV64_IMM(BF_REG_1, 0),
+            BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
+                        BF_PROG_CTX_OFF(l3_offset)));
         EMIT_SWICH_DEFAULT(
             &swich,
             BPF_MOV64_IMM(BF_REG_RET,

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "bpfilter/cgen/cgroup.h"
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/jmp.h"
 #include "bpfilter/cgen/matcher/ip4.h"
@@ -61,6 +62,7 @@ static const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
         [BF_FLAVOR_TC] = &bf_flavor_ops_tc,
         [BF_FLAVOR_NF] = &bf_flavor_ops_nf,
         [BF_FLAVOR_XDP] = &bf_flavor_ops_xdp,
+        [BF_FLAVOR_CGROUP] = &bf_flavor_ops_cgroup,
     };
 
     bf_assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);

--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -110,6 +110,9 @@ static struct bf_cgen *(*_bf_cgen_getters[])(
     [BF_HOOK_TC_EGRESS] = _bf_ctx_get_xdp_cgen,
 };
 
+static_assert(ARRAY_SIZE(_bf_cgen_getters) == _BF_HOOK_MAX,
+              "missing entries in _bf_cgen_getters array");
+
 /**
  * Create and initialize a new context.
  *

--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -83,12 +83,27 @@ static struct bf_cgen *_bf_ctx_get_nf_cgen(const bf_list *list,
     return node ? bf_list_node_get_data(node->data) : NULL;
 }
 
-static struct bf_cgen *(*_bf_cgen_getters[_BF_HOOK_MAX])(
+static struct bf_cgen *_bf_ctx_get_cgroup_cgen(const bf_list *list,
+                                               const struct bf_hook_opts *opts)
+{
+    bf_list_foreach (list, cgen_node) {
+        struct bf_cgen *cgen = bf_list_node_get_data(cgen_node);
+
+        if (bf_streq(cgen->chain->hook_opts.cgroup, opts->cgroup))
+            return cgen;
+    }
+
+    return NULL;
+}
+
+static struct bf_cgen *(*_bf_cgen_getters[])(
     const bf_list *list, const struct bf_hook_opts *opts) = {
     [BF_HOOK_XDP] = _bf_ctx_get_xdp_cgen,
     [BF_HOOK_TC_INGRESS] = _bf_ctx_get_xdp_cgen,
     [BF_HOOK_NF_PRE_ROUTING] = _bf_ctx_get_nf_cgen,
     [BF_HOOK_NF_LOCAL_IN] = _bf_ctx_get_nf_cgen,
+    [BF_HOOK_CGROUP_INGRESS] = _bf_ctx_get_cgroup_cgen,
+    [BF_HOOK_CGROUP_EGRESS] = _bf_ctx_get_cgroup_cgen,
     [BF_HOOK_NF_FORWARD] = _bf_ctx_get_nf_cgen,
     [BF_HOOK_NF_LOCAL_OUT] = _bf_ctx_get_nf_cgen,
     [BF_HOOK_NF_POST_ROUTING] = _bf_ctx_get_nf_cgen,

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -220,6 +220,27 @@ int bf_bpf_xdp_link_create(int prog_fd, unsigned int ifindex, int *link_fd,
     return 0;
 }
 
+int bf_bpf_cgroup_link_create(int prog_fd, int cgroup_fd,
+                              enum bpf_attach_type type, int *link_fd)
+{
+    union bpf_attr attr = {};
+    int r;
+
+    bf_assert(link_fd);
+
+    attr.link_create.prog_fd = prog_fd;
+    attr.link_create.target_fd = cgroup_fd;
+    attr.link_create.attach_type = type;
+
+    r = bf_bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    *link_fd = r;
+
+    return 0;
+}
+
 int bf_bpf_xdp_link_update(int link_fd, int prog_fd)
 {
     union bpf_attr attr = {};

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -143,6 +143,20 @@ int bf_bpf_xdp_link_create(int prog_fd, unsigned int ifindex, int *link_fd,
                            enum bf_xdp_attach_mode mode);
 
 /**
+ * Create a cgroup skb link.
+ *
+ * @param prog_fd File descriptor of the program to attach to the link.
+ * @param cgroup_fd File descriptor of the cgroup to attach the program to.
+ * @param type Hook type, defines if the program is attached to the ingress or
+ *        egress path.
+ * @param link_fd Link file descriptor, only valid if the return value of the
+ *        function is 0.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_bpf_cgroup_link_create(int prog_fd, int cgroup_fd,
+                              enum bpf_attach_type type, int *link_fd);
+
+/**
  * Update the program attached to an XDP BPF link.
  *
  * The type, interface, or XDP mode of the link are left unchanged.

--- a/src/core/flavor.c
+++ b/src/core/flavor.c
@@ -13,6 +13,7 @@ const char *bf_flavor_to_str(enum bf_flavor flavor)
         [BF_FLAVOR_TC] = "BF_FLAVOR_TC",
         [BF_FLAVOR_NF] = "BF_FLAVOR_NF",
         [BF_FLAVOR_XDP] = "BF_FLAVOR_XDP",
+        [BF_FLAVOR_CGROUP] = "BF_FLAVOR_GROUP",
     };
 
     bf_assert(0 <= flavor && flavor < _BF_FLAVOR_MAX);

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -35,6 +35,14 @@ enum bf_flavor
     BF_FLAVOR_TC,
     BF_FLAVOR_NF,
     BF_FLAVOR_XDP,
+
+    /** cgroup BPF programs are a middle ground between TC and BPF_NETFILTER
+     * programs:
+     * - Input: <tt>struct __sk_buff</tt>
+     * - Headers available: from L3
+     * - Return code: 0 to drop, 1 to accept
+     */
+    BF_FLAVOR_CGROUP,
     _BF_FLAVOR_MAX,
 };
 

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -27,6 +27,8 @@ enum bf_hook
     BF_HOOK_NF_PRE_ROUTING,
     BF_HOOK_NF_LOCAL_IN,
     BF_HOOK_NF_FORWARD,
+    BF_HOOK_CGROUP_INGRESS,
+    BF_HOOK_CGROUP_EGRESS,
     BF_HOOK_NF_LOCAL_OUT,
     BF_HOOK_NF_POST_ROUTING,
     BF_HOOK_TC_EGRESS,
@@ -36,6 +38,7 @@ enum bf_hook
 enum bf_hook_opt
 {
     BF_HOOK_OPT_IFINDEX,
+    BF_HOOK_OPT_CGROUP,
     _BF_HOOK_OPT_MAX,
 };
 
@@ -45,6 +48,7 @@ struct bf_hook_opts
 
     // Options
     uint32_t ifindex;
+    const char *cgroup;
 };
 
 /**
@@ -100,6 +104,13 @@ enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook);
  */
 int bf_hook_opts_init(struct bf_hook_opts *opts, enum bf_hook hook,
                       bf_list *raw_opts);
+
+/**
+ * Clean up a hook options structure.
+ *
+ * @param opts Hook options structure to clean up. Can't be NULL.
+ */
+void bf_hook_opts_clean(struct bf_hook_opts *opts);
 
 void bf_hook_opts_dump(const struct bf_hook_opts *opts, prefix_t *prefix,
                        enum bf_hook hook);

--- a/tests/bpf/CMakeLists.txt
+++ b/tests/bpf/CMakeLists.txt
@@ -50,3 +50,4 @@ endfunction()
 
 bf_test_make_bpf_example(xdp_printk)
 bf_test_make_bpf_example(xdp_ipfilter)
+bf_test_make_bpf_example(cgroup_skb_ingress)

--- a/tests/bpf/cgroup_skb_ingress.bpf.c
+++ b/tests/bpf/cgroup_skb_ingress.bpf.c
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include "cgroup_skb_ingress.h"
+
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, __u32);
+    __type(value, struct counters);
+    __uint(max_entries, 1);
+} counters_map SEC(".maps");
+
+SEC("cgroup_skb/ingress")
+int cgroup_skb_ingress(struct __sk_buff *skb) {
+	void *data     = (void *)(long)skb->data;
+    void *data_end = (void *)(long)skb->data_end;
+    struct counters *counters;
+    __u32 key = 0;
+
+    counters = bpf_map_lookup_elem(&counters_map, &key);
+    if (counters) {
+        counters->packets += 1;
+        counters->bytes += (__u64)(data_end - data);
+    }
+
+    return 1;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/tests/bpf/cgroup_skb_ingress.c
+++ b/tests/bpf/cgroup_skb_ingress.c
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <bpf/bpf.h>
+#include <endian.h>
+#include <linux/if_link.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "cgroup_skb_ingress.h"
+#include "cgroup_skb_ingress.skeleton.h"
+
+static volatile bool run = true;
+
+void int_handler(int sig)
+{
+    run = false;
+}
+
+int main(int argc, char *argv[])
+{
+    struct cgroup_skb_ingress_bpf *obj;
+    struct bpf_link *link;
+    struct counters counters = {};
+    __u32 key = 0;
+    int cg_fd;
+    const char *cg_path;
+    int r;
+
+    signal(SIGINT, int_handler);
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: %s PATH_TO_CGROUP\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    cg_path = argv[1];
+    cg_fd = open(cg_path, O_DIRECTORY | O_RDONLY);
+    if (cg_fd < 0) {
+        fprintf(stderr, "failed to open cgroup '%s'\n", cg_path);
+        return EXIT_FAILURE;
+    }
+
+    obj = cgroup_skb_ingress_bpf__open_and_load();
+    if (!obj) {
+        fprintf(stderr, "failed to open BPF object\n");
+        r = 1;
+        goto end_close_cg;
+    }
+
+    r = bpf_map__update_elem(obj->maps.counters_map, &key,
+                             sizeof(key), &counters, sizeof(counters),
+                             BPF_ANY);
+    if (r < 0) {
+        fprintf(stderr, "failed to insert value in the IPs map\n");
+        goto end_destroy_skel;
+    }
+
+    link = bpf_program__attach_cgroup(obj->progs.cgroup_skb_ingress, cg_fd);
+    if (!link) {
+        fprintf(stderr, "failed to attach cgroup_skb_ingress.bpf.o to cgroup '%s'\n",
+                cg_path);
+        r = 1;
+        goto end_destroy_skel;
+    }
+
+    printf("Running cgroup_skb_ingress, press Ctrl+C to stop...\n");
+    while (run) {
+        r = bpf_map__lookup_elem(obj->maps.counters_map, &key, sizeof(key),
+                                 &counters, sizeof(counters), 0);
+        if (r < 0)
+            continue;
+
+        printf("\rpackets: %10llu, bytes: %10llu", counters.packets,
+               counters.bytes);
+        usleep(10000);
+    }
+    printf("\n");
+
+    r = bpf_link__destroy(link);
+    if (r < 0)
+        fprintf(stderr, "failed to destroy BPF link for cgroup_skb_ingress.bpf.o\n");
+
+end_destroy_skel:
+    cgroup_skb_ingress_bpf__destroy(obj);
+end_close_cg:
+    close(cg_fd);
+
+    return r ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tests/bpf/cgroup_skb_ingress.h
+++ b/tests/bpf/cgroup_skb_ingress.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+
+struct counters
+{
+    __u64 packets;
+    __u64 bytes;
+};

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -138,3 +138,58 @@ chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
         udp.dport 22
         counter
         ACCEPT
+
+# Create a cgroup chain
+chain BF_HOOK_CGROUP_INGRESS{cgroup=/sys/fs/cgroup/user.slice} policy ACCEPT
+    rule
+        meta.ifindex 1
+        counter
+        ACCEPT
+    rule
+        ip4.saddr in {192.168.1.131,192.168.1.132}
+        counter
+        ACCEPT
+    rule
+        ip6.saddr fc00::fbaf:7b6b:ba41:abce
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto ipv6
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto tcp
+        counter
+        ACCEPT
+    rule
+        ip4.saddr 192.168.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr 192.168.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.proto icmp
+        counter
+        ACCEPT
+    rule
+        tcp.sport 22
+        counter
+        ACCEPT
+    rule
+        tcp.dport 22
+        counter
+        ACCEPT
+    rule
+        tcp.flags any SYN,ACK
+        counter
+        ACCEPT
+    rule
+        udp.sport 22
+        counter
+        ACCEPT
+    rule
+        udp.dport 22
+        counter
+        ACCEPT


### PR DESCRIPTION
This PR introduces support for cgroup hooks in `bpfilter` (using `bfcli`):
- Add a new flavour. cgroup BPF programs are a mix between TC and BPF_NETFILTER programs: they accept `struct __sk_buff`, but they don't have access to the L2 header, and return codes are 0 to drop and 1 to accept.
- Add `bf_bpf_cgroup_link_create()` to create a cgroup link, atomic update of the program is supported. A file descriptor to the cgroup (`open(..., O_DIRECTORY)`) defines which cgroup to attach the program to.
- Add new `cgroup` hook option, only valid for cgroup hooks.

A few other things have been fixed/improved on the way:
- Fix IPv6 support for BPF_NETFILTER program: `AF_INET` was recognized but not `AF_INET6`, this is now fixed.
- Allow a chain defined in `bfcli` to be empty. A empty chain will only count the packets.