### PR TITLE
core: opts: make verbosity more granular

### DIFF
--- a/doc/usage/daemon.rst
+++ b/doc/usage/daemon.rst
@@ -10,7 +10,10 @@ It is possible to customize the daemon's behavior using the following command-li
 - ``--no-nftables``: disable ``nftables`` support.
 - ``--no-iptables``: disable ``iptables`` support.
 - ``-b``, ``--buffer-len=BUF_LEN_POW``: size of the ``BPF_PROG_LOAD`` buffer as a power of 2. Only available if ``--verbose`` is used. ``BPF_PROG_LOAD`` system call can be provided a buffer for the BPF verifier to provide details in case the program can't be loaded. The required size for the buffer being hardly predictable, this option allows for the user to control it. The final buffer will have a size of ``1 << BUF_LEN_POWER``.
-- ``-v``, ``--verbose``: print more detailed log messages.
-- ``--debug``: generate the BPF programs in debug mode: if a call to a kfunc or a BPF helper fails, a log message will be printed to ``/sys/kernel/debug/tracing/trace_pipe``.
+- ``-v=VERBOSE_FLAG``, ``--verbose=VERBOSE_FLAG``: enable verbose logs for ``VERBOSE_FLAG``. Currently, 2 verbose flags are supported:
+
+  - ``debug``: enable all the debug logs in the application.
+  - ``bpf``: insert log messages into the BPF programs to log failed kernel function calls. Those messages can be printed with ``bpftool prog tracelog`` or ``cat /sys/kernel/debug/tracing/trace_pipe``.
+
 - ``--usage``: print a short usage message.
 - ``-?``, ``--help``: print the help message.

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -619,7 +619,7 @@ static int _bf_program_generate_update_counters(struct bf_program *program)
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_0, 0, 0));
 
-        if (bf_opts_debug())
+        if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to fetch the rule's counters");
 
         EMIT(program, BPF_MOV32_IMM(BF_REG_0, 1));

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -67,7 +67,7 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program,
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 0));
 
-        if (bf_opts_debug())
+        if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create a new dynamic pointer");
 
         EMIT(program,
@@ -117,7 +117,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
 
-        if (bf_opts_debug())
+        if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L2 dynamic pointer slice");
 
         EMIT(program,
@@ -188,7 +188,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
 
-        if (bf_opts_debug())
+        if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L3 dynamic pointer slice");
 
         EMIT(program,
@@ -283,7 +283,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
 
-        if (bf_opts_debug())
+        if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L4 dynamic pointer slice");
 
         EMIT(program,

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -58,7 +58,7 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
     bf_assert(img);
     bf_assert(fd);
 
-    if (bf_opts_verbose()) {
+    if (bf_opts_is_verbose(BF_VERBOSE_BPF)) {
         log_buf = malloc(1 << bf_opts_bpf_log_buf_len_pow());
         if (!log_buf)
             return -ENOMEM;

--- a/src/core/dump.c
+++ b/src/core/dump.c
@@ -9,8 +9,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "core/opts.h"
-
 #define BF_DUMP_HEXDUMP_LEN 8
 #define BF_DUMP_TOKEN_LEN 5
 
@@ -64,11 +62,6 @@ void bf_dump_hex(prefix_t *prefix, const void *data, size_t len)
     // 5 characters per byte (0x%02x) + 1 for the null terminator.
     char buf[BF_DUMP_HEXDUMP_LEN * BF_DUMP_TOKEN_LEN + 1];
     const void *end = data + len;
-
-    /* DUMP() won't print anything if we're not verbose, so we might as well
-     * skip the dump generation too. */
-    if (!bf_opts_verbose())
-        return;
 
     while (data < end) {
         char *line = buf;

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -72,7 +72,7 @@ enum bf_style
 
 #define bf_dbg(fmt, ...)                                                       \
     ({                                                                         \
-        if (bf_opts_verbose())                                                 \
+        if (bf_opts_is_verbose(BF_VERBOSE_DEBUG))                              \
             _bf_log_impl("debug", BF_COLOR_BLUE, fmt, ##__VA_ARGS__);          \
     })
 

--- a/src/core/opts.h
+++ b/src/core/opts.h
@@ -9,9 +9,16 @@
 
 #include "core/front.h"
 
+enum bf_verbose
+{
+    BF_VERBOSE_DEBUG,
+    BF_VERBOSE_BPF,
+    _BF_VERBOSE_MAX,
+};
+
 int bf_opts_init(int argc, char *argv[]);
 bool bf_opts_transient(void);
 unsigned int bf_opts_bpf_log_buf_len_pow(void);
 bool bf_opts_is_front_enabled(enum bf_front front);
-bool bf_opts_verbose(void);
-bool bf_opts_debug(void);
+bool bf_opts_is_verbose(enum bf_verbose opt);
+void bf_opts_set_verbose(enum bf_verbose opt);


### PR DESCRIPTION
Currently, 2 options are available to adjust the verbosity of bpfilter:
- `--verbose`: if set, log `bf_dbg()` messages
- `--debug`: if set, insert debug log message on kfunc failure in the BPF programs.

Those options are confusing (even I can't remember which option is which).

This change removes `--debug` and define flags for `--verbose` to specific which type of debug to be enabled. `--verbose $TYPE` can be used more than once to enable different types of debugging.