### PR TITLE
ctx: fix invalid pointer access

### DIFF
--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -80,7 +80,7 @@ static struct bf_cgen *_bf_ctx_get_nf_cgen(const bf_list *list,
     bf_assert(list);
 
     node = bf_list_get_head(list);
-    return node ? bf_list_node_get_data(node->data) : NULL;
+    return node ? bf_list_node_get_data(node) : NULL;
 }
 
 static struct bf_cgen *_bf_ctx_get_cgroup_cgen(const bf_list *list,


### PR DESCRIPTION
Callback to get a `BPF_NETFILTER` cgen from the context should call `bf_list_node_get_data(node)`, not `bf_list_node_get_data(node->data)`.