### PR TITLE
core: hook: add option to set the chain's name

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -74,6 +74,13 @@ With:
    * - ``cgroup=$CGROUP_PATH``
      - ``BF_HOOK_CGROUP_INGRESS``, ``BF_HOOK_CGROUP_EGRESS``
      - Path to the cgroup to attach to.
+   * - ``name=$CHAIN_NAME``
+     - Allowed patern: ``[a-zA-Z0-9_]+``
+     - Name of the chain, will be reused as the name of the BPF program. A same name can be reused for multiple chains. Must be at most ``BPF_OBJ_NAME_LEN - 1`` characters.
+
+.. note::
+
+    ``name=$CHAIN_NAME`` will only change the name of the BPF program loaded into the kernel. It won't affect the map names, not the pin path. Defining multiple programs with the same name is possible, but a name clash could prevent the program from being pinned.
 
 
 Rules

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -174,13 +174,14 @@ static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
     _cleanup_close_ int prog_fd = -1;
     _cleanup_close_ int link_fd = -1;
     _cleanup_close_ int cgroup_fd = -1;
+    const char *name =
+        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
     const char *cgroup_path;
     int r;
 
     bf_assert(new_prog);
 
-    r = bf_bpf_prog_load(new_prog->prog_name,
-                         bf_hook_to_bpf_prog_type(new_prog->hook),
+    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -192,10 +192,11 @@ static int _bf_nf_attach_prog(struct bf_program *new_prog,
     _cleanup_close_ int prog_fd = -1;
     _cleanup_close_ int link_fd = -1;
     _cleanup_close_ int tmp_fd = -1;
+    const char *name =
+        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
     int r;
 
-    r = bf_bpf_prog_load(new_prog->prog_name,
-                         bf_hook_to_bpf_prog_type(new_prog->hook),
+    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -126,12 +126,13 @@ static int _bf_tc_attach_prog(struct bf_program *new_prog,
 {
     _cleanup_close_ int prog_fd = -1;
     _cleanup_close_ int link_fd = -1;
+    const char *name =
+        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
     int r;
 
     bf_assert(new_prog);
 
-    r = bf_bpf_prog_load(new_prog->prog_name,
-                         bf_hook_to_bpf_prog_type(new_prog->hook),
+    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -122,12 +122,13 @@ static int _bf_xdp_attach_prog(struct bf_program *new_prog,
 {
     _cleanup_close_ int prog_fd = -1;
     _cleanup_close_ int link_fd = -1;
+    const char *name =
+        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
     int r;
 
     bf_assert(new_prog);
 
-    r = bf_bpf_prog_load(new_prog->prog_name,
-                         bf_hook_to_bpf_prog_type(new_prog->hook),
+    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,
                          bf_hook_to_attach_type(new_prog->hook), &prog_fd);
     if (r)

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -39,6 +39,7 @@ enum bf_hook_opt
 {
     BF_HOOK_OPT_IFINDEX,
     BF_HOOK_OPT_CGROUP,
+    BF_HOOK_OPT_NAME,
     _BF_HOOK_OPT_MAX,
 };
 
@@ -49,6 +50,7 @@ struct bf_hook_opts
     // Options
     uint32_t ifindex;
     const char *cgroup;
+    const char *name;
 };
 
 /**

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -1,5 +1,5 @@
 # Create an XDP chain
-chain BF_HOOK_XDP{ifindex=2} policy ACCEPT
+chain BF_HOOK_XDP{ifindex=2,name=my_xdp_program} policy ACCEPT
     rule
         meta.ifindex 1
         counter


### PR DESCRIPTION
The custom chain name will be used as the name of the BPF program, making the program easier to find, especially in `--transient` configuration.

For now, only the program name is modified:
- Map names: the chain name is at most `BPF_OBJ_NAME_LEN` characters, if the full length is used there is no room to use a custom prefix for each map, making them indistinguishable.
- Pin path: a chain name can be reused multiple time, but a pin path must be unique.