### PR TITLE
doc: rename hook option column

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -66,7 +66,7 @@ With:
    :fill-cells:
 
    * - Option
-     - Supported hooks
+     - Supported values
      - Notes
    * - ``ifindex=$IFINDEX``
      - ``BF_HOOK_XDP``, ``BF_HOOK_TC_INGRESS``, ``BF_HOOK_TC_EGRESS``


### PR DESCRIPTION
The column contains the hook options' values is named "Supported hooks", while it should be "Supported values".