### PR TITLE
bfcli: allow a `raw_hook_opts` token to be `NULL`

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -132,17 +132,7 @@ chains          : chain
                 }
                 ;
 
-chain           : CHAIN hook POLICY verdict rules
-                {
-                    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
-                    _cleanup_bf_list_ bf_list *rules = $5;
-
-                    if (bf_chain_new(&chain, $2, $4, &ruleset->sets, rules) < 0)
-                        bf_parse_err("failed to create a new bf_chain\n");
-
-                    $$ = TAKE_PTR(chain);
-                }
-                | CHAIN hook raw_hook_opts POLICY verdict rules
+chain           : CHAIN hook raw_hook_opts POLICY verdict rules
                 {
                     _cleanup_bf_chain_ struct bf_chain *chain = NULL;
                     _cleanup_bf_list_ bf_list *raw_hook_opts = $3;
@@ -180,7 +170,8 @@ hook            : HOOK
                     $$ = hook;
                 }
 
-raw_hook_opts   : raw_hook_opts HOOK_OPT
+raw_hook_opts   : %empty { $$ = NULL; }
+                | raw_hook_opts HOOK_OPT
                 { 
                     _cleanup_bf_list_ bf_list *list = $1;
 


### PR DESCRIPTION
Factorize the chain creation by defining only one production in which the `raw_hook_opts` token can be `NULL`.