### PR TITLE
cgen: hook: add new `attach` hook option

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -77,6 +77,9 @@ With:
    * - ``name=$CHAIN_NAME``
      - Allowed patern: ``[a-zA-Z0-9_]+``
      - Name of the chain, will be reused as the name of the BPF program. A same name can be reused for multiple chains. Must be at most ``BPF_OBJ_NAME_LEN - 1`` characters.
+   * - ``attach=$BOOL``
+     - ``yes`` or ``no``
+     - If ``no``, the chain will be generated and loaded to the kernel, but not attached. Useful if you want to attach it manually, or validate the generation process. Default to ``yes``.
 
 .. note::
 

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -171,21 +171,15 @@ static int _bf_cgroup_get_verdict(enum bf_verdict verdict)
 static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
                                   struct bf_program *old_prog)
 {
-    _cleanup_close_ int prog_fd = -1;
-    _cleanup_close_ int link_fd = -1;
     _cleanup_close_ int cgroup_fd = -1;
-    const char *name =
-        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
+    int prog_fd;
     const char *cgroup_path;
     int r;
 
     bf_assert(new_prog);
 
-    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
-                         new_prog->img, new_prog->img_size,
-                         bf_hook_to_attach_type(new_prog->hook), &prog_fd);
-    if (r)
-        return bf_err_r(r, "failed to load new bf_program");
+    prog_fd = new_prog->runtime.prog_fd;
+    cgroup_path = new_prog->runtime.chain->hook_opts.cgroup;
 
     if (old_prog) {
         r = bf_bpf_link_update(old_prog->runtime.prog_fd, prog_fd);
@@ -194,23 +188,23 @@ static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
                 r, "failed to updated existing link for cgroup bf_program");
         }
 
+        // Copy the existing link FD to the new program
         new_prog->runtime.prog_fd = TAKE_FD(old_prog->runtime.prog_fd);
     } else {
-        cgroup_path = new_prog->runtime.chain->hook_opts.cgroup;
         cgroup_fd = open(cgroup_path, O_DIRECTORY | O_RDONLY);
         if (cgroup_fd < 0)
             return bf_err_r(errno, "failed to open cgroup '%s'", cgroup_path);
 
         r = bf_bpf_cgroup_link_create(prog_fd, cgroup_fd,
                                       bf_hook_to_attach_type(new_prog->hook),
-                                      &link_fd);
+                                      &new_prog->runtime.prog_fd);
         if (r) {
             return bf_err_r(r,
                             "failed to create new link for cgroup bf_program");
         }
-
-        new_prog->runtime.prog_fd = TAKE_FD(link_fd);
     }
+
+    closep(&prog_fd);
 
     return 0;
 }

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -179,7 +179,7 @@ static int _bf_cgroup_attach_prog(struct bf_program *new_prog,
 
     cgroup_path = new_prog->runtime.chain->hook_opts.cgroup;
 
-    if (old_prog) {
+    if (old_prog && old_prog->runtime.link_fd != -1) {
         r = bf_bpf_link_update(old_prog->runtime.link_fd,
                                new_prog->runtime.prog_fd);
         if (r) {

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -192,7 +192,7 @@ static int _bf_nf_attach_prog(struct bf_program *new_prog,
     _cleanup_close_ int tmp_fd = -1;
     int r;
 
-    if (old_prog) {
+    if (old_prog && old_prog->runtime.link_fd != -1) {
         r = bf_bpf_nf_link_create(new_prog->runtime.prog_fd, new_prog->hook, 2,
                                   &tmp_fd);
         if (r)

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -196,9 +196,11 @@ struct bf_program
     enum bf_hook hook;
     enum bf_front front;
     char prog_name[BPF_OBJ_NAME_LEN];
+    char link_name[BPF_OBJ_NAME_LEN];
     /// Printer map name.
     char pmap_name[BPF_OBJ_NAME_LEN];
     char prog_pin_path[PIN_PATH_LEN];
+    char link_pin_path[PIN_PATH_LEN];
     /// Pinter map pinning path.
     char pmap_pin_path[PIN_PATH_LEN];
 
@@ -229,6 +231,8 @@ struct bf_program
     {
         /** File descriptor of the program. */
         int prog_fd;
+        /** File descriptor of the program's link. */
+        int link_fd;
         /** File descriptor of the printer map. */
         int pmap_fd;
         /** Hook-specific ops to use to generate the program. */

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -124,19 +124,12 @@ static int _bf_tc_get_verdict(enum bf_verdict verdict)
 static int _bf_tc_attach_prog(struct bf_program *new_prog,
                               struct bf_program *old_prog)
 {
-    _cleanup_close_ int prog_fd = -1;
-    _cleanup_close_ int link_fd = -1;
-    const char *name =
-        new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
+    int prog_fd;
     int r;
 
     bf_assert(new_prog);
 
-    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
-                         new_prog->img, new_prog->img_size,
-                         bf_hook_to_attach_type(new_prog->hook), &prog_fd);
-    if (r)
-        return bf_err_r(r, "failed to load new bf_program");
+    prog_fd = new_prog->runtime.prog_fd;
 
     if (old_prog) {
         r = bf_bpf_link_update(old_prog->runtime.prog_fd, prog_fd);
@@ -149,13 +142,12 @@ static int _bf_tc_attach_prog(struct bf_program *new_prog,
     } else {
         r = bf_bpf_tc_link_create(
             prog_fd, new_prog->runtime.chain->hook_opts.ifindex,
-            bf_hook_to_attach_type(new_prog->hook), &link_fd);
-        if (r) {
+            bf_hook_to_attach_type(new_prog->hook), &new_prog->runtime.prog_fd);
+        if (r)
             return bf_err_r(r, "failed to create new link for TC bf_program");
-        }
-
-        new_prog->runtime.prog_fd = TAKE_FD(link_fd);
     }
+
+    closep(&prog_fd);
 
     return 0;
 }

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -128,7 +128,7 @@ static int _bf_tc_attach_prog(struct bf_program *new_prog,
 
     bf_assert(new_prog);
 
-    if (old_prog) {
+    if (old_prog && old_prog->runtime.link_fd != -1) {
         r = bf_bpf_link_update(old_prog->runtime.link_fd,
                                new_prog->runtime.prog_fd);
         if (r) {

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -120,30 +120,26 @@ static int _bf_xdp_get_verdict(enum bf_verdict verdict)
 static int _bf_xdp_attach_prog(struct bf_program *new_prog,
                                struct bf_program *old_prog)
 {
-    int prog_fd;
     int r;
 
     bf_assert(new_prog);
 
-    prog_fd = new_prog->runtime.prog_fd;
-
     if (old_prog) {
-        r = bf_bpf_xdp_link_update(old_prog->runtime.prog_fd, prog_fd);
+        r = bf_bpf_xdp_link_update(old_prog->runtime.link_fd,
+                                   new_prog->runtime.prog_fd);
         if (r) {
             return bf_err_r(
                 r, "failed to update existing link for XDP bf_program");
         }
 
-        new_prog->runtime.prog_fd = TAKE_FD(old_prog->runtime.prog_fd);
+        new_prog->runtime.link_fd = TAKE_FD(old_prog->runtime.link_fd);
     } else {
-        r = bf_bpf_xdp_link_create(prog_fd,
+        r = bf_bpf_xdp_link_create(new_prog->runtime.prog_fd,
                                    new_prog->runtime.chain->hook_opts.ifindex,
-                                   &new_prog->runtime.prog_fd, BF_XDP_MODE_SKB);
+                                   &new_prog->runtime.link_fd, BF_XDP_MODE_SKB);
         if (r)
             return bf_err_r(r, "failed to create new link for XDP bf_program");
     }
-
-    closep(&prog_fd);
 
     return 0;
 }

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -124,7 +124,7 @@ static int _bf_xdp_attach_prog(struct bf_program *new_prog,
 
     bf_assert(new_prog);
 
-    if (old_prog) {
+    if (old_prog && old_prog->runtime.link_fd != -1) {
         r = bf_bpf_xdp_link_update(old_prog->runtime.link_fd,
                                    new_prog->runtime.prog_fd);
         if (r) {

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -113,6 +113,11 @@ int bf_chain_new_from_marsh(struct bf_chain **chain,
                 return -ENOMEM;
         }
 
+        if (!(list_elem = bf_marsh_next_child(chain_elem, list_elem)))
+            return -EINVAL;
+        memcpy(&_chain->hook_opts.attach, list_elem->data,
+               sizeof(_chain->hook_opts.attach));
+
         if (bf_marsh_next_child(chain_elem, list_elem)) {
             return bf_err_r(-E2BIG,
                             "too many serialized fields for bf_hook_opts");
@@ -225,6 +230,11 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
         // Similar to cg_path
         r = bf_marsh_add_child_raw(&child, name, name ? strlen(name) + 1 : 0);
         if (r)
+            return r;
+
+        r = bf_marsh_add_child_raw(&child, &chain->hook_opts.attach,
+                                   sizeof(chain->hook_opts.attach));
+        if (r < 0)
             return r;
 
         r = bf_marsh_add_child_obj(&_marsh, child);

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -7,6 +7,7 @@
 
 #include <linux/bpf.h>
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "core/dump.h"
@@ -40,6 +41,7 @@ enum bf_hook_opt
     BF_HOOK_OPT_IFINDEX,
     BF_HOOK_OPT_CGROUP,
     BF_HOOK_OPT_NAME,
+    BF_HOOK_OPT_ATTACH,
     _BF_HOOK_OPT_MAX,
 };
 
@@ -51,6 +53,7 @@ struct bf_hook_opts
     uint32_t ifindex;
     const char *cgroup;
     const char *name;
+    bool attach;
 };
 
 /**

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -1,5 +1,5 @@
 # Create an XDP chain
-chain BF_HOOK_XDP{ifindex=2,name=my_xdp_program} policy ACCEPT
+chain BF_HOOK_XDP{attach=no,ifindex=2,name=my_xdp_program} policy ACCEPT
     rule
         meta.ifindex 1
         counter
@@ -54,7 +54,7 @@ chain BF_HOOK_XDP{ifindex=2,name=my_xdp_program} policy ACCEPT
         ACCEPT
 
 # Create a TC chain
-chain BF_HOOK_TC_INGRESS{ifindex=2} policy ACCEPT
+chain BF_HOOK_TC_INGRESS{attach=yes,ifindex=2} policy ACCEPT
     rule
         meta.ifindex 1
         counter


### PR DESCRIPTION
By default, the chain is loaded and attached to the kernel, but eventually the user don't want the chain to be attached. Hence, by setting the chain option `attach=no`, bpfilter will generate the BPF program, load it (and all the required maps), then stop there. The user is free to open an FD to the program and manipulate it.