### PR TITLE
core: matcher: fix `matcher.len` deserialization size

### DIFF
--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -60,7 +60,7 @@ int bf_matcher_new_from_marsh(struct bf_matcher **matcher,
 
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
-    memcpy(&payload_len, child->data, sizeof(op));
+    memcpy(&payload_len, child->data, sizeof(payload_len));
     payload_len -= sizeof(struct bf_matcher);
 
     if (!(child = bf_marsh_next_child(marsh, child)))


### PR DESCRIPTION
`matcher.len` was deserialized by reading the size of `matcher.op`, which would lead to erroneous values.