### PR TITLE
tests: benchmark: write results to a JSON file

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -22,12 +22,27 @@ target_link_libraries(benchmark_bin
         benchmark::benchmark
 )
 
+add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/gitrev.txt
+    COMMAND
+        /bin/sh -c "echo -n $(git rev-parse --short HEAD) > ${CMAKE_BINARY_DIR}/gitrev.txt"
+    COMMAND
+        /bin/sh -c "if [[ $(git status --porcelain) ]]; then echo -n _dirty >> ${CMAKE_BINARY_DIR}/gitrev.txt; fi"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    VERBATIM
+)
+
 add_custom_target(benchmark
     COMMAND
         sudo
             $<TARGET_FILE:benchmark_bin>
                 --cli $<TARGET_FILE:bfcli>
                 --daemon $<TARGET_FILE:bpfilter>
-    DEPENDS benchmark_bin bfcli bpfilter
+                --output ${CMAKE_BINARY_DIR}/output/`cat gitrev.txt`.json
+    DEPENDS
+        benchmark_bin bfcli bpfilter
+        ${CMAKE_BINARY_DIR}/gitrev.txt
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    USES_TERMINAL
     COMMENT "Running benchmarks"
 )


### PR DESCRIPTION
Add support for `--output` option to the benchmark, so the results can be written in JSON to a file. The `make benchmark` target defined in CMake uses this option, so benchmark results can be compared from a commit to another.