### PR TITLE
tests: benchmark: ensure `gitrev.txt` is always up-to-date

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -23,7 +23,9 @@ target_link_libraries(benchmark_bin
 )
 
 add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/gitrev.txt
+    OUTPUT
+        ${CMAKE_BINARY_DIR}/_fake_dep.txt
+        ${CMAKE_BINARY_DIR}/gitrev.txt
     COMMAND
         /bin/sh -c "echo -n $(git rev-parse --short HEAD) > ${CMAKE_BINARY_DIR}/gitrev.txt"
     COMMAND


### PR DESCRIPTION
Define a fake dependency to the custom command used to get Git infos. As CMake run the custom commands when a dependency is missing, not creating this fake file will ensure the command is always run and gitrev.txt is always up-to-date.