### PR TITLE
tests: benchmark: extract benchmark boilerplate for easier reuse and add benchmark

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-AccessModifierOffset: 0
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments: None

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,8 @@
 #   Generates false positives.
 # - modernize-macro-to-enum
 #   No benefit.
+# - modernize-use-trailing-return-type
+#   No benefit.
 # - readability-function-cognitive-complexity
 #   Functions generating BPF bytecode will trigger this rule anytime, but they're
 #   not that complex due to heavy use of macros.
@@ -44,6 +46,7 @@ Checks: >
   misc-*,
   modernize-*,
     -modernize-macro-to-enum,
+    -modernize-use-trailing-return-type,
   performance-*,
   portability-*,
   readability-*,
@@ -63,6 +66,8 @@ CheckOptions:
   # warn about _cleanup_ identifiers.
   - key: bugprone-reserved-identifier.AllowedIdentifiers
     value: '^_(bf|BF|cleanup)_[a-zA-Z0-9_]+$'
+  - key: misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
+    value: true
   # Unless a *statement* takes 1 line, it should be in braces
   - key: readability-braces-around-statements.ShortStatementLines
     value: 6

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,10 +9,11 @@ add_subdirectory(bpf)
 # It's OK to use GLOB_RECURSE here, as it's not the main target for the source
 # files but a secondary one.
 file(GLOB_RECURSE bf_srcs
-    ${CMAKE_SOURCE_DIR}/src/core/*.h        ${CMAKE_SOURCE_DIR}/src/core/*.c
-    ${CMAKE_SOURCE_DIR}/src/bpfilter/*.h    ${CMAKE_SOURCE_DIR}/src/bpfilter/*.c
-    ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
-    ${CMAKE_SOURCE_DIR}/src/bfcli/*.h       ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
+    ${CMAKE_SOURCE_DIR}/src/core/*.h            ${CMAKE_SOURCE_DIR}/src/core/*.c
+    ${CMAKE_SOURCE_DIR}/src/bpfilter/*.h        ${CMAKE_SOURCE_DIR}/src/bpfilter/*.c
+    ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
+    ${CMAKE_SOURCE_DIR}/src/bfcli/*.h           ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
+    ${CMAKE_SOURCE_DIR}/tests/benchmark/*.hpp   ${CMAKE_SOURCE_DIR}/tests/benchmark/*.cpp
 )
 
 add_custom_command(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,7 +13,6 @@ file(GLOB_RECURSE bf_srcs
     ${CMAKE_SOURCE_DIR}/src/bpfilter/*.h        ${CMAKE_SOURCE_DIR}/src/bpfilter/*.c
     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
     ${CMAKE_SOURCE_DIR}/src/bfcli/*.h           ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
-    ${CMAKE_SOURCE_DIR}/tests/benchmark/*.hpp   ${CMAKE_SOURCE_DIR}/tests/benchmark/*.cpp
 )
 
 add_custom_command(

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -39,6 +39,7 @@ add_custom_target(benchmark
                 --cli $<TARGET_FILE:bfcli>
                 --daemon $<TARGET_FILE:bpfilter>
                 --srcdir ${CMAKE_SOURCE_DIR}
+                --outfile ${CMAKE_BINARY_DIR}/output/{gitrev}.json
     DEPENDS benchmark_bin bfcli bpfilter
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     USES_TERMINAL

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(benchmark
             $<TARGET_FILE:benchmark_bin>
                 --cli $<TARGET_FILE:bfcli>
                 --daemon $<TARGET_FILE:bpfilter>
-                --output ${CMAKE_BINARY_DIR}/output/`cat gitrev.txt`.json
+                --outfile ${CMAKE_BINARY_DIR}/output/`cat gitrev.txt`.json
     DEPENDS
         benchmark_bin bfcli bpfilter
         ${CMAKE_BINARY_DIR}/gitrev.txt

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NOT ENABLE_BENCHMARK)
 endif ()
 
 find_package(benchmark REQUIRED)
+pkg_check_modules(git2 REQUIRED IMPORTED_TARGET libgit2)
 
 add_executable(benchmark_bin
     main.cpp
@@ -27,19 +28,8 @@ target_compile_options(benchmark_bin
 target_link_libraries(benchmark_bin
     PRIVATE
         PkgConfig::bpf
+        PkgConfig::git2
         benchmark::benchmark
-)
-
-add_custom_command(
-    OUTPUT
-        ${CMAKE_BINARY_DIR}/_fake_dep.txt
-        ${CMAKE_BINARY_DIR}/gitrev.txt
-    COMMAND
-        /bin/sh -c "echo -n $(git rev-parse --short HEAD) > ${CMAKE_BINARY_DIR}/gitrev.txt"
-    COMMAND
-        /bin/sh -c "if [[ $(git status --porcelain) ]]; then echo -n _dirty >> ${CMAKE_BINARY_DIR}/gitrev.txt; fi"
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    VERBATIM
 )
 
 add_custom_target(benchmark
@@ -48,10 +38,8 @@ add_custom_target(benchmark
             $<TARGET_FILE:benchmark_bin>
                 --cli $<TARGET_FILE:bfcli>
                 --daemon $<TARGET_FILE:bpfilter>
-                --outfile ${CMAKE_BINARY_DIR}/output/`cat gitrev.txt`.json
-    DEPENDS
-        benchmark_bin bfcli bpfilter
-        ${CMAKE_BINARY_DIR}/gitrev.txt
+                --srcdir ${CMAKE_SOURCE_DIR}
+    DEPENDS benchmark_bin bfcli bpfilter
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     USES_TERMINAL
     COMMENT "Running benchmarks"

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -9,7 +9,15 @@ endif ()
 
 find_package(benchmark REQUIRED)
 
-add_executable(benchmark_bin benchmark.cpp)
+add_executable(benchmark_bin
+    main.cpp
+    benchmark.cpp benchmark.hpp
+)
+
+target_include_directories(benchmark_bin
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 target_compile_options(benchmark_bin
     PRIVATE

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -243,7 +243,7 @@ run(::std::string bin, const ::std::vector<::std::string> &args)
 }
 } // namespace
 
-int parseArgs(std::span<char *> args)
+int setup(std::span<char *> args)
 {
     const struct argp argp = {options.data(), optsParser};
 

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -78,7 +78,7 @@ constexpr std::array<uint8_t, 80> pkt_local_ip6_tcp {
 
 constexpr int progRunRepeat = 1000000;
 
-Args args = {};
+Config config = {};
 
 namespace
 {
@@ -102,18 +102,18 @@ inline char *errStr(int value)
 
 int optsParser(int key, char *arg, struct ::argp_state *state)
 {
-    auto *args = static_cast<Args *>(state->input);
+    auto *config = static_cast<Config *>(state->input);
     int r;
 
     switch (key) {
     case 'c':
-        args->bfcli = std::string(arg);
+        config->bfcli = std::string(arg);
         break;
     case 'd':
-        args->bpfilter = std::string(arg);
+        config->bpfilter = std::string(arg);
         break;
     case 'o':
-        args->output_file.emplace(arg);
+        config->output_file.emplace(arg);
         ::benchmark::FLAGS_benchmark_out = arg;
         ::benchmark::FLAGS_benchmark_out_format = "json";
         break;
@@ -248,7 +248,7 @@ int parseArgs(std::span<char *> args)
     const struct argp argp = {options.data(), optsParser};
 
     const int r = argp_parse(&argp, static_cast<int>(args.size()), args.data(),
-                             0, nullptr, &::bf::args);
+                             0, nullptr, &::bf::config);
     if (r != 0) {
         err("failed to parse command line arguments: {}", errStr(r));
         return r;

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -87,11 +87,9 @@ constexpr int waitForDaemonSleepMs = 10;
 
 constexpr std::array<struct argp_option, 4> options {{
     {"cli", 'c', "CLI", 0,
-     "Path to the bfcli binary. Default to 'bfcli' in $PATH.", 0},
+     "Path to the bfcli binary. Defaults to 'bfcli' in $PATH.", 0},
     {"daemon", 'd', "DAEMON", 0,
-     "Path to the bpfilter binary. Default to 'bpfilter' in $PATH.", 0},
-    {"output", 'o', "OUTPUT_FILE", 0,
-     "Path to the JSON file to write the results to.", 0},
+     "Path to the bpfilter binary. Defaults to 'bpfilter' in $PATH.", 0},
     {nullptr},
 }};
 

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -107,10 +107,10 @@ int optsParser(int key, char *arg, struct ::argp_state *state)
 
     switch (key) {
     case 'c':
-        config->bfcli = std::string(arg);
+        config->bfcli = ::std::string(arg);
         break;
     case 'd':
-        config->bpfilter = std::string(arg);
+        config->bpfilter = ::std::string(arg);
         break;
     case 'o':
         config->output_file.emplace(arg);

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -3,45 +3,36 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include "benchmark.hpp"
+
+#include <linux/bpf.h>
+
 #include <argp.h>
 #include <array>
-#include <benchmark/benchmark.h>
 #include <bpf/bpf.h>
+#include <bpf/libbpf_common.h>
 #include <cerrno>
 #include <chrono>
-#include <csignal>
+#include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <format>
 #include <initializer_list>
-#include <iostream>
-#include <memory>
+#include <iostream> // NOLINT
 #include <optional>
-#include <sstream>
-#include <stdexcept>
+#include <signal.h> // NOLINT: otherwise kill() is not found
+#include <span>
+#include <stdlib.h> // NOLINT
 #include <string>
-#include <sys/syscall.h> /* Definition of SYS_* constants */
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <thread>
 #include <tuple>
 #include <unistd.h>
+#include <utility>
 #include <vector>
-
-#define _log_impl(stream, prefix, fmt, ...)                                    \
-    do {                                                                       \
-        using ::std::cerr;                                                     \
-        using ::std::cout;                                                     \
-        stream << ::std::format("{}" fmt, prefix, ##__VA_ARGS__)               \
-               << ::std::endl;                                                 \
-    } while (0)
-
-#define abort(fmt, ...)                                                        \
-    throw ::std::runtime_error(::std::format(fmt, ##__VA_ARGS__))
-
-#define err(fmt, ...) _log_impl(cerr, "ERROR: ", fmt, ##__VA_ARGS__)
-#define info(fmt, ...) _log_impl(cout, "", fmt, ##__VA_ARGS__)
 
 namespace benchmark
 {
@@ -66,40 +57,52 @@ extern int FLAGS_v;
 
 namespace bf
 {
-
 using TimePoint = std::chrono::steady_clock::time_point;
 using time = std::chrono::steady_clock;
 using seconds = std::chrono::seconds;
 
-static const struct argp_option options[] = {
+constexpr int CGROUP_DROP = 0;
+constexpr int CGROUP_ACCEPT = 1;
+
+// Ether(src=0x01, dst=0x02)
+// IPv6(src='::1', dst='::2')
+// TCP(sport=31337, dport=31415, flags='S')
+constexpr std::array<uint8_t, 80> pkt_local_ip6_tcp {
+    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x86, 0xdd, 0x60, 0x00, 0x00, 0x00, 0x00, 0x14, 0x06, 0x40,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x7a,
+    0x69, 0x7a, 0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x50, 0x02, 0x20, 0x00, 0x9a, 0xbf, 0x00, 0x00};
+
+constexpr int progRunRepeat = 1000000;
+
+Args args = {};
+
+namespace
+{
+constexpr int waitForDaemonTimeoutS = 5;
+constexpr int waitForDaemonSleepMs = 10;
+
+constexpr std::array<struct argp_option, 4> options {{
     {"cli", 'c', "CLI", 0,
      "Path to the bfcli binary. Default to 'bfcli' in $PATH.", 0},
     {"daemon", 'd', "DAEMON", 0,
      "Path to the bpfilter binary. Default to 'bpfilter' in $PATH.", 0},
     {"output", 'o', "OUTPUT_FILE", 0,
      "Path to the JSON file to write the results to.", 0},
-    {0},
-};
+    {nullptr},
+}};
 
-struct Args
+inline char *errStr(int value)
 {
-    ::std::string bfcli = "bfcli";
-    ::std::string bpfilter = "bpfilter";
-    ::std::optional<::std::string> output_file;
-};
-
-Args args;
-
-constexpr int progRunRepeat = 1000000;
-
-char *errStr(int v)
-{
-    return ::std::strerror(v >= 0 ?: -v);
+    return ::std::strerror(::std::abs(value));
 }
 
-static error_t optsParser(int key, char *arg, struct argp_state *state)
+int optsParser(int key, char *arg, struct ::argp_state *state)
 {
-    struct Args *args = static_cast<struct Args *>(state->input);
+    auto *args = static_cast<Args *>(state->input);
     int r;
 
     switch (key) {
@@ -111,81 +114,19 @@ static error_t optsParser(int key, char *arg, struct argp_state *state)
         break;
     case 'o':
         args->output_file.emplace(arg);
+        ::benchmark::FLAGS_benchmark_out = arg;
+        ::benchmark::FLAGS_benchmark_out_format = "json";
         break;
     default:
-        // Ignore unknown arguments, as Google Benchmark has their own
-        return 0;
+        return ARGP_ERR_UNKNOWN;
     }
 
     return 0;
 }
 
-class Fd
-{
-    public:
-    Fd(int fd = -1):
-        fd_ {fd}
-    {}
-
-    Fd(Fd &other) = delete;
-
-    Fd(Fd &&other)
-    {
-        if (fd_ != -1)
-            abort("calling ::bf::Fd(Fd &&) on an open file descriptor!");
-
-        fd_ = other.fd_;
-        other.fd_ = -1;
-    }
-
-    Fd &operator=(Fd &other) = delete;
-
-    Fd &operator=(Fd &&other)
-    {
-        if (fd_ != -1)
-            abort(
-                "calling ::bf::Fd::operator=(Fd &&) on an open file descriptor!");
-
-        fd_ = other.fd_;
-        other.fd_ = -1;
-
-        return *this;
-    }
-
-    ~Fd() noexcept(false)
-    {
-        if (close() < 0)
-            abort("failed to close ::bf::Fd");
-    }
-
-    int get() const
-    {
-        return fd_;
-    }
-
-    int close()
-    {
-        if (fd_ == -1)
-            return 0;
-
-        int r = ::close(fd_);
-        if (r < 0) {
-            err("failed to close ::bf::Fd file descriptor: {}", errStr(errno));
-            return -errno;
-        }
-
-        fd_ = -1;
-
-        return 0;
-    }
-
-    private:
-    int fd_ = -1;
-};
-
 int setFdNonBlock(Fd &fd)
 {
-    int flags = fcntl(fd.get(), F_GETFL, 0);
+    const int flags = fcntl(fd.get(), F_GETFL, 0);
     if (flags < 0) {
         err("failed to get current flags for FD {}: {}", fd.get(),
             errStr(errno));
@@ -198,11 +139,11 @@ int setFdNonBlock(Fd &fd)
 ::std::optional<::std::string> readFd(Fd &fd)
 {
     ssize_t len;
-    char buffer[1024] = {};
+    std::array<char, 1024> buffer;
     ::std::string data;
 
-    while ((len = read(fd.get(), buffer, sizeof(buffer))) >= 0)
-        data += ::std::string(buffer, len);
+    while ((len = read(fd.get(), buffer.data(), buffer.size())) >= 0)
+        data += ::std::string(::std::begin(buffer), ::std::end(buffer));
 
     if (len < 0 && errno != EAGAIN)
         err("failed to read from file descriptor: {}", errStr(errno));
@@ -210,11 +151,11 @@ int setFdNonBlock(Fd &fd)
     return data;
 }
 
-int exec(::std::string bin, ::std::vector<::std::string> args, Fd &stdoutFd,
-         Fd &stderrFd)
+int exec(const ::std::string &bin, const ::std::vector<::std::string> &args,
+         Fd &stdoutFd, Fd &stderrFd)
 {
-    int stdout_pipe[2];
-    int stderr_pipe[2];
+    std::array<int, 2> stdout_pipe;
+    std::array<int, 2> stderr_pipe;
     pid_t pid;
 
     // Format the argv[] array properly
@@ -224,7 +165,7 @@ int exec(::std::string bin, ::std::vector<::std::string> args, Fd &stdoutFd,
         args_.push_back(arg.c_str());
     args_.push_back(nullptr);
 
-    if (pipe(stdout_pipe) != 0 || pipe(stderr_pipe) != 0) {
+    if (pipe(stdout_pipe.data()) != 0 || pipe(stderr_pipe.data()) != 0) {
         err("failed to create pipes for '{}'", bin);
         return -EINVAL;
     }
@@ -256,7 +197,7 @@ int exec(::std::string bin, ::std::vector<::std::string> args, Fd &stdoutFd,
         close(stdout_pipe[0]);
         close(stderr_pipe[0]);
 
-        r = execvp(bin.c_str(), (char * const *)(args_.data()));
+        (void)execvp(bin.c_str(), (char * const *)(args_.data()));
 
         // If execvp returns, an error occurred
         err("execvp() failed to '{}': {}", bin, errStr(errno));
@@ -271,7 +212,7 @@ int exec(::std::string bin, ::std::vector<::std::string> args, Fd &stdoutFd,
 }
 
 ::std::tuple<int, ::std::string, ::std::string>
-run(::std::string bin, ::std::vector<::std::string> args)
+run(::std::string bin, const ::std::vector<::std::string> &args)
 {
     Fd stdoutFd, stderrFd;
 
@@ -287,468 +228,417 @@ run(::std::string bin, ::std::vector<::std::string> args)
     }
 
     int status;
-    int r = waitpid(pid, &status, 0);
+    const int r = waitpid(pid, &status, 0);
     if (r < 0) {
         err("failed to wait for PID {}: {}", pid, errStr(errno));
         return {-errno, {}, {}};
     }
 
-    auto logOut = readFd(stdoutFd);
-    auto logErr = readFd(stderrFd);
-    ::std::string noLog;
+    const auto logOut = readFd(stdoutFd);
+    const auto logErr = readFd(stderrFd);
+    const ::std::string noLog;
 
     return {WEXITSTATUS(status), logOut ? *logOut : noLog,
             logErr ? *logErr : noLog};
 }
+} // namespace
 
-class Daemon
+int parseArgs(std::span<char *> args)
 {
-    public:
-    class Options
-    {
-        public:
-        Options &transient()
-        {
-            options_.push_back("--transient");
-            return *this;
-        }
-
-        Options &noCli()
-        {
-            options_.push_back("--no-cli");
-            return *this;
-        }
-
-        Options &noIptables()
-        {
-            options_.push_back("--no-iptables");
-            return *this;
-        }
-
-        Options &noNftables()
-        {
-            options_.push_back("--no-nftables");
-            return *this;
-        }
-
-        Options &bufferLen(::std::size_t len)
-        {
-            options_.push_back("--buffer-len");
-            options_.push_back(::std::to_string(len));
-            return *this;
-        }
-
-        Options &verbose(const ::std::string &component)
-        {
-            options_.push_back("--verbose");
-            options_.push_back(component);
-            return *this;
-        }
-
-        ::std::vector<::std::string> get() const
-        {
-            return options_;
-        }
-
-        private:
-        ::std::vector<::std::string> options_;
-    };
-
-    Daemon(const ::std::string &path = "bpfilter", Options options = Options()):
-        path_ {path},
-        options_ {options}
-    {
-        if (start() < 0)
-            abort("failed to start bpfilter");
-    }
-
-    Daemon(Daemon &other) = delete;
-
-    Daemon(Daemon &&other)
-    {
-        if (pid_)
-            abort("calling ::bf::Daemon(::bf::Daemon &&) on an active daemon!");
-
-        other.pid_.swap(pid_);
-        stdoutFd_ = ::std::move(other.stdoutFd_);
-        stderrFd_ = ::std::move(other.stderrFd_);
-    }
-
-    Daemon &operator=(Daemon &other) = delete;
-
-    Daemon &operator=(Daemon &&other)
-    {
-        if (pid_)
-            abort(
-                "calling ::bf::Daemon::operator=(::fd::Daemon &&) on an active daemon!");
-
-        other.pid_.swap(pid_);
-        stdoutFd_ = ::std::move(other.stdoutFd_);
-        stderrFd_ = ::std::move(other.stderrFd_);
-
-        return *this;
-    }
-
-    ~Daemon() noexcept(false)
-    {
-        if (stop() < 0)
-            abort("failed to stop bpfilter");
-    }
-
-    private:
-    ::std::string path_;
-    Options options_;
-    std::optional<pid_t> pid_;
-    Fd stdoutFd_;
-    Fd stderrFd_;
-
-    int start()
-    {
-        Fd stdoutFd, stderrFd;
-        int pid, r;
-
-        if (pid_)
-            abort("calling ::bf::Daemon::start() on an active daemon!");
-
-        pid = exec(path_, options_.get(), stdoutFd, stderrFd);
-        if (pid < 0) {
-            err("failed to start the daemon: {}", errStr(pid));
-            return pid;
-        }
-
-        if ((r = setFdNonBlock(stdoutFd)) < 0) {
-            err("failed to set non-blocking flag to the daemon's stdout FD: {}",
-                errStr(r));
-            return r;
-        }
-
-        if ((r = setFdNonBlock(stderrFd)) < 0) {
-            err("failed to set non-blocking flag to the daemon's stderr FD: {}",
-                errStr(r));
-            return r;
-        }
-
-        TimePoint begin = time::now();
-        int timeout = 5;
-
-        while (true) {
-            int status;
-
-            r = waitpid(pid, &status, WNOHANG);
-            if (r == -1) {
-                err("failed to wait on the deamon's PID {}: {}", pid,
-                    errStr(errno));
-                return -errno;
-            } else if (r != 0) {
-                auto errLogs = readFd(stderrFd);
-                err("daemon seems to be dead! Err logs:\n{}",
-                    errLogs ? *errLogs : "<no logs>");
-                return -ENOENT;
-            }
-
-            auto data = readFd(stderrFd);
-            if (data &&
-                data->find("waiting for requests...") != ::std::string::npos)
-                break;
-
-            if (std::chrono::duration_cast<seconds>(time::now() - begin)
-                    .count() > timeout) {
-                // Let's try to stop it just in case
-                kill(pid, SIGINT);
-                err("daemon is not showing up after {} seconds, aborting",
-                    timeout);
-                return -EIO;
-            }
-
-            // Wait a bit for the daemon to be ready
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
-
-        pid_ = std::optional<int>(pid);
-        stdoutFd_ = std::move(stdoutFd);
-        stderrFd_ = std::move(stderrFd);
-
-        return 0;
-    }
-
-    int stop()
-    {
-        if (!pid_)
-            return 0;
-
-        int r = kill(*pid_, SIGINT);
-        if (r < 0) {
-            err("failed to send SIGINT signal to the daemon: {}",
-                errStr(errno));
-            return -errno;
-        }
-
-        int status;
-        r = waitpid(*pid_, &status, 0);
-        if (r < 0) {
-            err("can't wait on the daemon: {}", errStr(errno));
-            return -errno;
-        }
-
-        return 0;
-    }
-};
-
-class Program
-{
-    public:
-    Program(std::string name):
-        name_ {name}
-    {
-        if (open() < 0)
-            abort("failed to open BPF program '{}'", name_);
-    }
-
-    Program(Program &other) = delete;
-
-    Program(Program &&other)
-    {
-        if (fd_ != -1)
-            abort(
-                "calling ::bf::Program(::bf::Program &&) on an open program!");
-
-        fd_ = other.fd_;
-        other.fd_ = -1;
-    }
-
-    Program &operator=(Program &other) = delete;
-
-    Program &operator=(Program &&other)
-    {
-        if (fd_ != -1)
-            abort(
-                "calling ::bf::Program::operator=(::bf::Program &&) on an open program!");
-
-        fd_ = other.fd_;
-        other.fd_ = -1;
-
-        return *this;
-    }
-
-    ~Program() noexcept(false)
-    {
-        if (close() < 0)
-            abort("failed to close ::bf::Program");
-    }
-
-    int run(int expect, const uint8_t *pkt, ::std::size_t pkt_len)
-    {
-        LIBBPF_OPTS(bpf_test_run_opts, opts, .data_in = (const void *)pkt,
-                    .data_size_in = (uint32_t)pkt_len, .repeat = progRunRepeat);
-
-        int r = bpf_prog_test_run_opts(fd_, &opts);
-        if (r < 0) {
-            err("BPF program test run failed: {}", errStr(r));
-            return r;
-        }
-
-        if (opts.retval != expect) {
-            err("unexpected test run return value: {}", opts.retval);
-            return -EINVAL;
-        }
-
-        return 0;
-    }
-
-    int close()
-    {
-        if (fd_ == -1)
-            return 0;
-
-        int r = ::close(fd_);
-        if (r < 0) {
-            err("failed to close ::bf::Program file descriptor: {}",
-                errStr(errno));
-            return -errno;
-        }
-
-        fd_ = -1;
-
-        return 0;
-    }
-
-    private:
-    ::std::string name_;
-    int fd_ = -1;
-
-    int open()
-    {
-        uint32_t id = 0;
-        int r;
-
-        while (true) {
-            r = bpf_prog_get_next_id(id, &id);
-            if (r < 0) {
-                err("call to bpf_prog_get_next_id() failed: {}", errStr(r));
-                return r;
-            }
-
-            int prog_fd = bpf_prog_get_fd_by_id(id);
-            if (prog_fd < 0) {
-                err("call to bpf_prog_get_fd_by_id() failed: {}",
-                    errStr(prog_fd));
-                return prog_fd;
-            }
-
-            struct bpf_prog_info info = {};
-            uint32_t len = sizeof(info);
-            r = bpf_prog_get_info_by_fd(prog_fd, &info, &len);
-            if (r < 0) {
-                ::close(prog_fd);
-                err("call to bpf_prog_get_info_by_fd() failed: {}", errStr(r));
-                return r;
-            }
-
-            if (::std::string(info.name) == name_) {
-                fd_ = prog_fd;
-                return 0;
-            }
-
-            ::close(prog_fd);
-        }
-
-        return -ENOENT;
-    }
-};
-
-class Chain
-{
-    public:
-    Chain(::std::string bin = "bfcli", ::std::string name = "bf_benchmark"):
-        bin_ {bin},
-        name_ {name}
-    {}
-
-    Chain(::std::initializer_list<::std::string> rules)
-    {
-        rules_.insert(rules_.begin(), rules.begin(), rules.end());
-    }
-
-    Chain &operator<<(const ::std::string &rule)
-    {
-        rules_.push_back(rule);
-        return *this;
-    }
-
-    Chain &repeat(const ::std::string &rule, ::std::size_t count)
-    {
-        for (::std::size_t i = 0; i < count; ++i)
-            rules_.push_back(rule);
-
-        return *this;
-    }
-
-    int apply()
-    {
-        ::std::string chain = "chain BF_HOOK_CGROUP_INGRESS{cgroup=" + name_ +
-                              ",name=" + name_ + ",attach=no} policy DROP ";
-
-        for (const auto &rule: rules_)
-            chain += rule + " ";
-
-        ::std::vector<::std::string> args {"--str", chain};
-
-        const auto [r, out, err] = run(bin_, args);
-        if (r < 0) {
-            err("failed to exec '{}': {}\nError logs: {}", bin_, errStr(r),
-                err);
-            return r;
-        }
-
-        return 0;
-    }
-
-    Program getProgram() const
-    {
-        Program p(name_);
-
-        return ::std::move(p);
-    }
-
-    private:
-    ::std::string bin_;
-    ::std::string name_;
-    ::std::vector<::std::string> rules_;
-};
-
-} // namespace bf
-
-// Ether(
-// src=0x01, dst=0x02
-// )/IPv6(
-// src='::1', dst='::2'
-// )/TCP(
-// sport=31337, dport=31415, flags='S')
-
-#define benchLoop(state) while (state.KeepRunningBatch(::bf::progRunRepeat))
-
-constexpr uint8_t pkt_local_ip6_tcp[] = {
-    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x86, 0xdd, 0x60, 0x00, 0x00, 0x00, 0x00, 0x14, 0x06, 0x40,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x7a,
-    0x69, 0x7a, 0xb7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x50, 0x02, 0x20, 0x00, 0x9a, 0xbf, 0x00, 0x0};
-
-#define CGROUP_DROP 0
-#define CGROUP_ACCEPT 1
-
-static void firstRuleDropCounter(benchmark::State &state)
-{
-    ::bf::Chain chain(::bf::args.bfcli);
-    chain << "rule meta.l3_proto ipv6 counter DROP";
-    chain.apply();
-    auto p = chain.getProgram();
-
-    benchLoop(state)
-    {
-        p.run(CGROUP_DROP, static_cast<const uint8_t *>(pkt_local_ip6_tcp),
-              sizeof(pkt_local_ip6_tcp));
-    }
-}
-
-BENCHMARK(firstRuleDropCounter);
-
-int main(int argc, char *argv[])
-{
-    struct argp argp = {::bf::options, ::bf::optsParser, nullptr, nullptr, 0,
-                        nullptr,       nullptr};
-    int r;
-
-    if (geteuid() != 0) {
-        err("the benchmark should be run as root");
-        return -1;
-    }
-
-    r = argp_parse(&argp, argc, argv, 0, 0, &::bf::args);
-    if (r < 0) {
-        err("failed to parse command line arguments");
-        return -1;
+    const struct argp argp = {options.data(), optsParser};
+
+    const int r = argp_parse(&argp, static_cast<int>(args.size()), args.data(),
+                             0, nullptr, &::bf::args);
+    if (r != 0) {
+        err("failed to parse command line arguments: {}", errStr(r));
+        return r;
     }
 
     info("Using:");
     info("  bfcli: {}", ::bf::args.bfcli);
     info("  bpfilter: {}", ::bf::args.bpfilter);
 
-    if (::bf::args.output_file) {
+    if (::bf::args.output_file)
         info("  output_file: {}", *::bf::args.output_file);
-        ::benchmark::FLAGS_benchmark_out = *::bf::args.output_file;
-        ::benchmark::FLAGS_benchmark_out_format = "json";
-    }
-
-    ::benchmark::Initialize(&argc, argv, nullptr);
-
-    auto d =
-        bf::Daemon(::bf::args.bpfilter,
-                   bf::Daemon::Options().transient().noIptables().noNftables());
-
-    ::benchmark::RunSpecifiedBenchmarks();
 
     return 0;
 }
+
+Fd::Fd(int fd):
+    fd_ {fd}
+{}
+
+Fd::Fd(Fd &&other) noexcept(false)
+{
+    if (fd_ != -1)
+        abort("calling ::bf::Fd(Fd &&) on an open file descriptor!");
+
+    fd_ = other.fd_;
+    other.fd_ = -1;
+}
+
+Fd &Fd::operator=(Fd &&other) noexcept(false)
+{
+    if (fd_ != -1)
+        abort("calling ::bf::Fd::operator=(Fd &&) on an open file descriptor!");
+
+    fd_ = other.fd_;
+    other.fd_ = -1;
+
+    return *this;
+}
+
+Fd::~Fd() noexcept(false)
+{
+    if (close() < 0)
+        abort("failed to close ::bf::Fd");
+}
+
+int Fd::get() const
+{
+    return fd_;
+}
+
+int Fd::close()
+{
+    if (fd_ == -1)
+        return 0;
+
+    if (::close(fd_) < 0) {
+        err("failed to close ::bf::Fd file descriptor: {}", errStr(errno));
+        return -errno;
+    }
+
+    fd_ = -1;
+
+    return 0;
+}
+
+Daemon::Options &Daemon::Options::transient()
+{
+    options_.emplace_back("--transient");
+    return *this;
+}
+
+Daemon::Options &Daemon::Options::noCli()
+{
+    options_.emplace_back("--no-cli");
+    return *this;
+}
+
+Daemon::Options &Daemon::Options::noIptables()
+{
+    options_.emplace_back("--no-iptables");
+    return *this;
+}
+
+Daemon::Options &Daemon::Options::noNftables()
+{
+    options_.emplace_back("--no-nftables");
+    return *this;
+}
+
+Daemon::Options &Daemon::Options::bufferLen(::std::size_t len)
+{
+    options_.emplace_back("--buffer-len");
+    options_.emplace_back(::std::to_string(len));
+    return *this;
+}
+
+Daemon::Options &Daemon::Options::verbose(const ::std::string &component)
+{
+    options_.emplace_back("--verbose");
+    options_.emplace_back(component);
+    return *this;
+}
+
+::std::vector<::std::string> Daemon::Options::get() const
+{
+    return options_;
+}
+
+Daemon::Daemon(::std::string path, Options options):
+    path_ {::std::move(path)},
+    options_ {::std::move(options)}
+{
+    if (start() < 0)
+        abort("failed to start bpfilter");
+}
+
+Daemon::Daemon(Daemon &&other) noexcept(false)
+{
+    if (pid_)
+        abort("calling ::bf::Daemon(::bf::Daemon &&) on an active daemon!");
+
+    other.pid_.swap(pid_);
+    stdoutFd_ = ::std::move(other.stdoutFd_);
+    stderrFd_ = ::std::move(other.stderrFd_);
+}
+
+Daemon &Daemon::operator=(Daemon &&other) noexcept(false)
+{
+    if (pid_)
+        abort(
+            "calling ::bf::Daemon::operator=(::fd::Daemon &&) on an active daemon!");
+
+    other.pid_.swap(pid_);
+    stdoutFd_ = ::std::move(other.stdoutFd_);
+    stderrFd_ = ::std::move(other.stderrFd_);
+
+    return *this;
+}
+
+Daemon::~Daemon() noexcept(false)
+{
+    if (stop() < 0)
+        abort("failed to stop bpfilter");
+}
+
+int Daemon::start()
+{
+    Fd stdoutFd, stderrFd;
+    int pid, r;
+
+    if (pid_)
+        abort("calling ::bf::Daemon::start() on an active daemon!");
+
+    pid = exec(path_, options_.get(), stdoutFd, stderrFd);
+    if (pid < 0) {
+        err("failed to start the daemon: {}", errStr(pid));
+        return pid;
+    }
+
+    if ((r = setFdNonBlock(stdoutFd)) < 0) {
+        err("failed to set non-blocking flag to the daemon's stdout FD: {}",
+            errStr(r));
+        return r;
+    }
+
+    if ((r = setFdNonBlock(stderrFd)) < 0) {
+        err("failed to set non-blocking flag to the daemon's stderr FD: {}",
+            errStr(r));
+        return r;
+    }
+
+    const TimePoint begin = time::now();
+
+    while (true) {
+        int status;
+
+        r = waitpid(pid, &status, WNOHANG);
+        if (r == -1) {
+            err("failed to wait on the deamon's PID {}: {}", pid,
+                errStr(errno));
+            return -errno;
+        }
+        if (r != 0) {
+            auto errLogs = readFd(stderrFd);
+            err("daemon seems to be dead! Err logs:\n{}",
+                errLogs ? *errLogs : "<no logs>");
+            return -ENOENT;
+        }
+
+        auto data = readFd(stderrFd);
+        if (data &&
+            data->find("waiting for requests...") != ::std::string::npos)
+            break;
+
+        if (std::chrono::duration_cast<seconds>(time::now() - begin).count() >
+            waitForDaemonTimeoutS) {
+            // Let's try to stop it just in case
+            kill(pid, SIGINT);
+            err("daemon is not showing up after {} seconds, aborting",
+                waitForDaemonTimeoutS);
+            return -EIO;
+        }
+
+        // Wait a bit for the daemon to be ready
+        ::std::this_thread::sleep_for(
+            std::chrono::milliseconds(waitForDaemonSleepMs));
+    }
+
+    pid_ = ::std::optional<int>(pid);
+    stdoutFd_ = std::move(stdoutFd);
+    stderrFd_ = std::move(stderrFd);
+
+    return 0;
+}
+
+int Daemon::stop()
+{
+    if (!pid_)
+        return 0;
+
+    int r = kill(*pid_, SIGINT);
+    if (r < 0) {
+        err("failed to send SIGINT signal to the daemon: {}", errStr(errno));
+        return -errno;
+    }
+
+    int status;
+    r = waitpid(*pid_, &status, 0);
+    if (r < 0) {
+        err("can't wait on the daemon: {}", errStr(errno));
+        return -errno;
+    }
+
+    return 0;
+}
+
+Program::Program(std::string name):
+    name_ {::std::move(name)}
+{
+    if (open() < 0)
+        abort("failed to open BPF program '{}'", name_);
+}
+
+Program::Program(Program &&other) noexcept(false)
+{
+    if (fd_ != -1) {
+        abort("calling ::bf::Program(::bf::Program &&) on an open program!");
+    }
+
+    fd_ = other.fd_;
+    other.fd_ = -1;
+}
+
+Program &Program::operator=(Program &&other) noexcept(false)
+{
+    if (fd_ != -1) {
+        abort(
+            "calling ::bf::Program::operator=(::bf::Program &&) on an open program!");
+    }
+
+    fd_ = other.fd_;
+    other.fd_ = -1;
+
+    return *this;
+}
+
+Program::~Program() noexcept(false)
+{
+    if (close() < 0)
+        abort("failed to close ::bf::Program");
+}
+
+int Program::run(int expect, const std::span<const uint8_t> &pkt) const
+{
+    LIBBPF_OPTS(bpf_test_run_opts, opts, .data_in = (const void *)pkt.data(),
+                .data_size_in = (uint32_t)pkt.size(), .repeat = progRunRepeat);
+
+    const int r = bpf_prog_test_run_opts(fd_, &opts);
+    if (r < 0) {
+        err("BPF program test run failed: {}", errStr(r));
+        return r;
+    }
+
+    if (opts.retval != expect) {
+        err("unexpected test run return value: {}", opts.retval);
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+int Program::close()
+{
+    if (fd_ == -1)
+        return 0;
+
+    if (::close(fd_) < 0) {
+        err("failed to close ::bf::Program file descriptor: {}", errStr(errno));
+        return -errno;
+    }
+
+    fd_ = -1;
+
+    return 0;
+}
+
+int Program::open()
+{
+    uint32_t id = 0;
+    int r;
+
+    while (true) {
+        r = bpf_prog_get_next_id(id, &id);
+        if (r < 0) {
+            err("call to bpf_prog_get_next_id() failed: {}", errStr(r));
+            return r;
+        }
+
+        const int prog_fd = bpf_prog_get_fd_by_id(id);
+        if (prog_fd < 0) {
+            err("call to bpf_prog_get_fd_by_id() failed: {}", errStr(prog_fd));
+            return prog_fd;
+        }
+
+        struct bpf_prog_info info = {};
+        uint32_t len = sizeof(info);
+        r = bpf_prog_get_info_by_fd(prog_fd, &info, &len);
+        if (r < 0) {
+            ::close(prog_fd);
+            err("call to bpf_prog_get_info_by_fd() failed: {}", errStr(r));
+            return r;
+        }
+
+        if (::std::string(info.name) == name_) {
+            fd_ = prog_fd;
+            return 0;
+        }
+
+        ::close(prog_fd);
+    }
+
+    return -ENOENT;
+}
+
+Chain::Chain(::std::string bin, ::std::string name):
+    bin_ {::std::move(bin)},
+    name_ {::std::move(name)}
+{}
+
+Chain::Chain(::std::initializer_list<::std::string> rules)
+{
+    rules_.insert(rules_.begin(), rules.begin(), rules.end());
+}
+
+Chain &Chain::operator<<(const ::std::string &rule)
+{
+    rules_.push_back(rule);
+    return *this;
+}
+
+Chain &Chain::repeat(const ::std::string &rule, ::std::size_t count)
+{
+    for (::std::size_t i = 0; i < count; ++i)
+        rules_.push_back(rule);
+
+    return *this;
+}
+
+int Chain::apply()
+{
+    ::std::string chain = "chain BF_HOOK_CGROUP_INGRESS{cgroup=" + name_ +
+                          ",name=" + name_ + ",attach=no} policy DROP ";
+
+    for (const auto &rule: rules_)
+        chain += rule + " ";
+
+    const ::std::vector<::std::string> args {"--str", chain};
+
+    const auto [r, out, err] = run(bin_, args);
+    if (r < 0) {
+        err("failed to exec '{}': {}\nError logs: {}", bin_, errStr(r), err);
+        return r;
+    }
+
+    return 0;
+}
+
+Program Chain::getProgram() const
+{
+    return {name_};
+}
+
+} // namespace bf

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -282,6 +282,11 @@ int setup(std::span<char *> args)
         config.gitdate = srcs.getLastCommitTime();
     }
 
+    const ::std::string pattern = "{gitrev}";
+    const auto pos = config.outfile.find(pattern);
+    if (pos != ::std::string::npos)
+        config.outfile.replace(pos, pattern.size(), config.gitrev);
+
     ::benchmark::AddCustomContext("gitrev", config.gitrev);
     ::benchmark::AddCustomContext("gitdate", ::std::to_string(config.gitdate));
     ::benchmark::AddCustomContext("bfcli", config.bfcli);

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -90,6 +90,9 @@ constexpr std::array<struct argp_option, 4> options {{
      "Path to the bfcli binary. Defaults to 'bfcli' in $PATH.", 0},
     {"daemon", 'd', "DAEMON", 0,
      "Path to the bpfilter binary. Defaults to 'bpfilter' in $PATH.", 0},
+    {"outfile", 'o', "OUTPUT_FILE", 0,
+     "Path to the JSON file to write the results to. Defaults to 'results.json'.",
+     0},
     {nullptr},
 }};
 
@@ -111,9 +114,7 @@ int optsParser(int key, char *arg, struct ::argp_state *state)
         config->bpfilter = ::std::string(arg);
         break;
     case 'o':
-        config->output_file.emplace(arg);
-        ::benchmark::FLAGS_benchmark_out = arg;
-        ::benchmark::FLAGS_benchmark_out_format = "json";
+        config->outfile = ::std::string(arg);
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -252,12 +253,13 @@ int setup(std::span<char *> args)
         return r;
     }
 
-    info("Using:");
-    info("  bfcli: {}", ::bf::args.bfcli);
-    info("  bpfilter: {}", ::bf::args.bpfilter);
+    ::benchmark::AddCustomContext("bfcli", config.bfcli);
+    ::benchmark::AddCustomContext("bpfilter", config.bpfilter);
+    ::benchmark::AddCustomContext("srcdir", config.srcdir);
+    ::benchmark::AddCustomContext("outfile", config.outfile);
 
-    if (::bf::args.output_file)
-        info("  output_file: {}", *::bf::args.output_file);
+    ::benchmark::FLAGS_benchmark_out = config.outfile;
+    ::benchmark::FLAGS_benchmark_out_format = "json";
 
     return 0;
 }

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -83,7 +83,7 @@ public:
 
 extern Config config;
 
-int parseArgs(std::span<char *> args);
+int setup(std::span<char *> args);
 
 class Fd
 {

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -76,7 +76,7 @@ struct Config
 public:
     ::std::string bfcli = "bfcli";
     ::std::string bpfilter = "bpfilter";
-    ::std::optional<::std::string> output_file;
+    ::std::string outfile = "results.json";
 
     Config() noexcept = default;
 };

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -71,17 +71,17 @@ extern const int progRunRepeat;
  */
 #define benchLoop(state) while ((state).KeepRunningBatch(::bf::progRunRepeat))
 
-struct Args
+struct Config
 {
 public:
     ::std::string bfcli = "bfcli";
     ::std::string bpfilter = "bpfilter";
     ::std::optional<::std::string> output_file;
 
-    Args() noexcept = default;
+    Config() noexcept = default;
 };
 
-extern Args args;
+extern Config config;
 
 int parseArgs(std::span<char *> args);
 

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <format> // NOLINT: used by the logging macros
+#include <git2/types.h>
 #include <initializer_list>
 #include <iostream> // NOLINT: used by the logging macros
 #include <optional>
@@ -76,7 +77,10 @@ struct Config
 public:
     ::std::string bfcli = "bfcli";
     ::std::string bpfilter = "bpfilter";
+    ::std::string srcdir = ".";
     ::std::string outfile = "results.json";
+    ::std::string gitrev = "<unknown>";
+    int64_t gitdate = 0;
 
     Config() noexcept = default;
 };
@@ -84,6 +88,26 @@ public:
 extern Config config;
 
 int setup(std::span<char *> args);
+
+class Sources
+{
+public:
+    Sources(::std::string path);
+    Sources(Sources &other) = delete;
+    Sources(Sources &&other) = delete;
+    ~Sources();
+
+    Sources &operator=(Sources &other) = delete;
+    Sources &operator=(Sources &&other) = delete;
+
+    [[nodiscard]] ::std::string getLastCommitHash() const;
+    [[nodiscard]] int64_t getLastCommitTime() const;
+    [[nodiscard]] bool isDirty() const;
+
+private:
+    ::std::string path_;
+    git_repository *repo_ = nullptr;
+};
 
 class Fd
 {

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -1,0 +1,182 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <format> // NOLINT: used by the logging macros
+#include <initializer_list>
+#include <iostream> // NOLINT: used by the logging macros
+#include <optional>
+#include <span>
+#include <string>
+#include <sys/types.h> // NOLINT: for pid_t
+#include <vector>
+
+#pragma once
+
+namespace bf
+{
+
+extern const int CGROUP_DROP;
+extern const int CGROUP_ACCEPT;
+
+/**
+ * Dummy network packet, created using Python's @c scapy and the following
+ * definition:
+ *
+ *  Ether(src=0x01, dst=0x02)/
+ *  IPv6(src='::1', dst='::2')/
+ *  TCP(sport=31337, dport=31415, flags='S')
+ *
+ * This packet defines an Ethernet, IPv6, and TCP header.
+ */
+extern const std::array<uint8_t, 80> pkt_local_ip6_tcp;
+
+/**
+ * Number of iterations to run the program for.
+ *
+ * Google Benchmark will run each benchmark for a specific duration, so the
+ * fastest functions will run for more iterations. This is problematic as
+ * @c BPF_PROG_TEST_RUN requires a number of iterations. To solve this, we use
+ * @c KeepRunningBatch in order to find out if we can run the benchmark for
+ * @c progRunRepeat more iterations.
+ *
+ * @c progRunRepeat is big enough to have meaningful benchmark results and
+ * reduce syscall overhead, while being small enough to avoid blocking the
+ * system too long with longer benchmarks.
+ */
+extern const int progRunRepeat;
+
+#define abort(fmt, ...)                                                        \
+    throw ::std::runtime_error(::std::format(fmt, ##__VA_ARGS__))
+
+#define err(fmt, ...)                                                          \
+    do {                                                                       \
+        ::std::cerr << ::std::format("ERROR: " fmt "\n", ##__VA_ARGS__);       \
+    } while (0)
+
+#define info(fmt, ...)                                                         \
+    do {                                                                       \
+        ::std::cout << ::std::format(fmt "\n", ##__VA_ARGS__);                 \
+    } while (0)
+
+/**
+ * Loop used to run the benchmark.
+ *
+ * Use this macro to loop over the state automatically.
+ */
+#define benchLoop(state) while ((state).KeepRunningBatch(::bf::progRunRepeat))
+
+struct Args
+{
+public:
+    ::std::string bfcli = "bfcli";
+    ::std::string bpfilter = "bpfilter";
+    ::std::optional<::std::string> output_file;
+
+    Args() noexcept = default;
+};
+
+extern Args args;
+
+int parseArgs(std::span<char *> args);
+
+class Fd
+{
+public:
+    Fd(int fd = -1);
+    Fd(Fd &other) = delete;
+    Fd(Fd &&other) noexcept(false);
+    ~Fd() noexcept(false);
+
+    Fd &operator=(Fd &other) = delete;
+    Fd &operator=(Fd &&other) noexcept(false);
+
+    [[nodiscard]] int get() const;
+    int close();
+
+private:
+    int fd_ = -1;
+};
+
+class Daemon
+{
+public:
+    class Options
+    {
+    public:
+        Options &transient();
+        Options &noCli();
+        Options &noIptables();
+        Options &noNftables();
+        Options &bufferLen(::std::size_t len);
+        Options &verbose(const ::std::string &component);
+        [[nodiscard]] ::std::vector<::std::string> get() const;
+
+    private:
+        ::std::vector<::std::string> options_;
+    };
+
+    Daemon(::std::string path = "bpfilter", Options options = Options());
+    Daemon(Daemon &other) = delete;
+    Daemon(Daemon &&other) noexcept(false);
+    ~Daemon() noexcept(false);
+
+    Daemon &operator=(Daemon &other) = delete;
+    Daemon &operator=(Daemon &&other) noexcept(false);
+
+private:
+    ::std::string path_;
+    Options options_;
+    std::optional<pid_t> pid_;
+    Fd stdoutFd_;
+    Fd stderrFd_;
+
+    [[nodiscard]] int start();
+    int stop();
+};
+
+class Program
+{
+public:
+    Program(std::string name);
+    Program(Program &other) = delete;
+    Program(Program &&other) noexcept(false);
+    ~Program() noexcept(false);
+
+    Program &operator=(Program &other) = delete;
+    Program &operator=(Program &&other) noexcept(false);
+
+    [[nodiscard]] int run(int expect,
+                          const std::span<const uint8_t> &pkt) const;
+    int close();
+
+private:
+    ::std::string name_;
+    int fd_ = -1;
+
+    int open();
+};
+
+class Chain
+{
+public:
+    Chain(::std::string bin = "bfcli", ::std::string name = "bf_benchmark");
+    Chain(::std::initializer_list<::std::string> rules);
+
+    Chain &operator<<(const ::std::string &rule);
+    Chain &repeat(const ::std::string &rule, ::std::size_t count);
+    int apply();
+    [[nodiscard]] Program getProgram() const;
+
+private:
+    ::std::string bin_;
+    ::std::string name_;
+    ::std::vector<::std::string> rules_;
+};
+
+} // namespace bf

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -16,7 +16,7 @@ namespace
 {
 void firstRuleDropCounter(::benchmark::State &state)
 {
-    ::bf::Chain chain(::bf::args.bfcli);
+    ::bf::Chain chain(::bf::config.bfcli);
     chain << "rule meta.l3_proto ipv6 counter DROP";
     chain.apply();
     auto prog = chain.getProgram();
@@ -32,7 +32,7 @@ BENCHMARK(firstRuleDropCounter);
 
 void dropAfterXRules(::benchmark::State &state)
 {
-    ::bf::Chain chain(::bf::args.bfcli);
+    ::bf::Chain chain(::bf::config.bfcli);
     chain.repeat("rule meta.l3_proto ipv4 counter ACCEPT", state.range(0));
     chain.apply();
     auto prog = chain.getProgram();
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 
     try {
         auto daemon = bf::Daemon(
-            ::bf::args.bpfilter,
+            ::bf::config.bpfilter,
             bf::Daemon::Options().transient().noIptables().noNftables());
         ::benchmark::RunSpecifiedBenchmarks();
     } catch (const ::std::exception &e) {

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <benchmark/benchmark.h>
+#include <cerrno>
+#include <cstring>
+#include <exception>
+#include <span>
+#include <unistd.h>
+
+#include "benchmark.hpp"
+
+namespace
+{
+void firstRuleDropCounter(::benchmark::State &state)
+{
+    ::bf::Chain chain(::bf::args.bfcli);
+    chain << "rule meta.l3_proto ipv6 counter DROP";
+    chain.apply();
+    auto prog = chain.getProgram();
+
+    benchLoop(state)
+    {
+        if (prog.run(::bf::CGROUP_DROP, ::bf::pkt_local_ip6_tcp) < 0)
+            state.SkipWithError("benchmark run failed");
+    }
+}
+
+BENCHMARK(firstRuleDropCounter);
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    if (geteuid() != 0) {
+        err("the benchmark should be run as root");
+        return -EPERM;
+    }
+
+    if (::bf::parseArgs(std::span<char *>(argv, argc)) < 0)
+        return -1;
+
+    ::benchmark::Initialize(&argc, argv, nullptr);
+
+    try {
+        auto daemon = bf::Daemon(
+            ::bf::args.bpfilter,
+            bf::Daemon::Options().transient().noIptables().noNftables());
+        ::benchmark::RunSpecifiedBenchmarks();
+    } catch (const ::std::exception &e) {
+        err("failed to run benchmark: {}", e.what());
+        return -1;
+    }
+
+    return 0;
+}

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
         return -EPERM;
     }
 
-    if (::bf::parseArgs(std::span<char *>(argv, argc)) < 0)
+    if (::bf::setup(std::span<char *>(argv, argc)) < 0)
         return -1;
 
     ::benchmark::Initialize(&argc, argv, nullptr);

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -29,6 +29,32 @@ void firstRuleDropCounter(::benchmark::State &state)
 }
 
 BENCHMARK(firstRuleDropCounter);
+
+void dropAfterXRules(::benchmark::State &state)
+{
+    ::bf::Chain chain(::bf::args.bfcli);
+    chain.repeat("rule meta.l3_proto ipv4 counter ACCEPT", state.range(0));
+    chain.apply();
+    auto prog = chain.getProgram();
+
+    benchLoop(state)
+    {
+        if (prog.run(::bf::CGROUP_DROP, ::bf::pkt_local_ip6_tcp) < 0)
+            state.SkipWithError("benchmark run failed");
+    }
+}
+
+BENCHMARK(dropAfterXRules)
+    ->Arg(0)
+    ->Arg(8)
+    ->Arg(16)
+    ->Arg(32)
+    ->Arg(64)
+    ->Arg(128)
+    ->Arg(256)
+    ->Arg(512)
+    ->Arg(1024)
+    ->Arg(2048);
 } // namespace
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Extract all the benchmark boilerplate from the main file to move it all into a dedicated source file and add a benchmark to match the packet after X non-matching rules.