### PR TITLE
Benchmark improvements

### DIFF
--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -643,6 +643,19 @@ Program::~Program() noexcept(false)
         abort("failed to close ::bf::Program");
 }
 
+::std::size_t Program::nInsn() const
+{
+    struct bpf_prog_info prog_info = {};
+	uint32_t prog_info_len = sizeof(prog_info);
+	int r;
+
+	r = bpf_prog_get_info_by_fd(fd_, &prog_info, &prog_info_len);
+	if (r < 0)
+		return -EINVAL;
+
+    return prog_info.jited_prog_len;
+}
+
 int Program::run(int expect, const std::span<const uint8_t> &pkt) const
 {
     LIBBPF_OPTS(bpf_test_run_opts, opts, .data_in = (const void *)pkt.data(),

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -175,6 +175,7 @@ public:
     Program &operator=(Program &other) = delete;
     Program &operator=(Program &&other) noexcept(false);
 
+    [[nodiscard]] ::std::size_t nInsn() const;
     [[nodiscard]] int run(int expect,
                           const std::span<const uint8_t> &pkt) const;
     int close();

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -49,15 +49,10 @@ void dropAfterXRules(::benchmark::State &state)
 }
 
 BENCHMARK(dropAfterXRules)
-    ->Arg(0)
     ->Arg(8)
-    ->Arg(16)
     ->Arg(32)
-    ->Arg(64)
     ->Arg(128)
-    ->Arg(256)
     ->Arg(512)
-    ->Arg(1024)
     ->Arg(2048);
 } // namespace
 

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -26,6 +26,8 @@ void firstRuleDropCounter(::benchmark::State &state)
         if (prog.run(::bf::CGROUP_DROP, ::bf::pkt_local_ip6_tcp) < 0)
             state.SkipWithError("benchmark run failed");
     }
+
+    state.counters["nInsn"] = prog.nInsn();
 }
 
 BENCHMARK(firstRuleDropCounter);
@@ -42,6 +44,8 @@ void dropAfterXRules(::benchmark::State &state)
         if (prog.run(::bf::CGROUP_DROP, ::bf::pkt_local_ip6_tcp) < 0)
             state.SkipWithError("benchmark run failed");
     }
+
+    state.counters["nInsn"] = prog.nInsn();
 }
 
 BENCHMARK(dropAfterXRules)


### PR DESCRIPTION
Two simple changes to the benchmarks:
- Reduce the number of `dropAfterXRules` tests
- Record the number of instructions for each generated program to validate size increase overtime