### PR TITLE
Improve BPF bytecode dump

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -76,7 +76,7 @@ CheckOptions:
     value: '_|i|fd|r|j[0-9]|op'
   # Allowed short parameter names
   - key: readability-identifier-length.IgnoredParameterNames
-    value: 'ip|fd|op'
+    value: 'ip|fd|op|id'
   # Allow for magic constants that are power of 2.
   - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
     value: true

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -40,6 +40,9 @@ file(GLOB_RECURSE bf_srcs
 	${CMAKE_SOURCE_DIR}/src/*.h
 )
 
+# Remove src/external/.* files from the list of sources
+list(FILTER bf_srcs EXCLUDE REGEX "${CMAKE_SOURCE_DIR}/src/external/.*")
+
 set(doc_srcs
 	${CMAKE_CURRENT_SOURCE_DIR}/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/usage/bfcli.rst

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -29,6 +29,7 @@ WARN_AS_ERROR           = FAIL_ON_WARNINGS_PRINT
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
 INPUT                   = "@CMAKE_SOURCE_DIR@/src"
+EXCLUDE                 = "@CMAKE_SOURCE_DIR@/src/external"
 FILE_PATTERNS           = *.c \
                           *.h
 RECURSIVE               = YES

--- a/doc/usage/daemon.rst
+++ b/doc/usage/daemon.rst
@@ -10,10 +10,11 @@ It is possible to customize the daemon's behavior using the following command-li
 - ``--no-nftables``: disable ``nftables`` support.
 - ``--no-iptables``: disable ``iptables`` support.
 - ``-b``, ``--buffer-len=BUF_LEN_POW``: size of the ``BPF_PROG_LOAD`` buffer as a power of 2. Only available if ``--verbose`` is used. ``BPF_PROG_LOAD`` system call can be provided a buffer for the BPF verifier to provide details in case the program can't be loaded. The required size for the buffer being hardly predictable, this option allows for the user to control it. The final buffer will have a size of ``1 << BUF_LEN_POWER``.
-- ``-v=VERBOSE_FLAG``, ``--verbose=VERBOSE_FLAG``: enable verbose logs for ``VERBOSE_FLAG``. Currently, 2 verbose flags are supported:
+- ``-v=VERBOSE_FLAG``, ``--verbose=VERBOSE_FLAG``: enable verbose logs for ``VERBOSE_FLAG``. Currently, 3 verbose flags are supported:
 
   - ``debug``: enable all the debug logs in the application.
   - ``bpf``: insert log messages into the BPF programs to log failed kernel function calls. Those messages can be printed with ``bpftool prog tracelog`` or ``cat /sys/kernel/debug/tracing/trace_pipe``.
+  - ``bytecode``: dump a program's bytecode before loading it.
 
 - ``--usage``: print a short usage message.
 - ``-?``, ``--help``: print the help message.

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/xlate/nft/nfgroup.h      ${CMAKE_CURRENT_SOURCE_DIR}/xlate/nft/nfgroup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/xlate/nft/nfmsg.h        ${CMAKE_CURRENT_SOURCE_DIR}/xlate/nft/nfmsg.c
     ${CMAKE_CURRENT_SOURCE_DIR}/xlate/nft/nft.c
+
+    ${CMAKE_SOURCE_DIR}/src/external/disasm.h            ${CMAKE_SOURCE_DIR}/src/external/disasm.c
 )
 
 target_include_directories(bpfilter

--- a/src/bpfilter/cgen/dump.c
+++ b/src/bpfilter/cgen/dump.c
@@ -3,394 +3,124 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
-// NOLINTBEGIN
-
 #include "bpfilter/cgen/dump.h"
 
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "bpfilter/cgen/program.h"
+#include "core/btf.h"
 #include "core/dump.h"
 #include "core/helper.h"
 #include "core/logger.h"
 
-#define BF_INSN_CLS(insn) ((insn)->code & 0b00000111)
-#define BF_INSN_CODE(insn) ((insn)->code & 0b11110000)
-#define BF_INSN_SRC(insn) ((insn)->code & 0b00001000)
-#define BF_INSN_MODE(insn) ((insn)->code & 0b11100000)
-#define BF_INSN_SIZE(insn) ((insn)->code & 0b00011000)
+#include "external/disasm.h"
 
-#define BF_IMM_BUF_LEN 16
+#define SYM_MAX_NAME 256
 
-static const char *_bpf_reg(unsigned char reg)
+struct bf_dump_data
 {
-    static const char *regs[] = {
-        [BPF_REG_0] = "BPF_REG_0",   [BPF_REG_1] = "BPF_REG_1",
-        [BPF_REG_2] = "BPF_REG_2",   [BPF_REG_3] = "BPF_REG_3",
-        [BPF_REG_4] = "BPF_REG_4",   [BPF_REG_5] = "BPF_REG_5",
-        [BPF_REG_6] = "BPF_REG_6",   [BPF_REG_7] = "BPF_REG_7",
-        [BPF_REG_8] = "BPF_REG_8",   [BPF_REG_9] = "BPF_REG_9",
-        [BPF_REG_10] = "BPF_REG_10",
-    };
+    prefix_t *prefix;
+    char scratch_buff[SYM_MAX_NAME + 8];
+    unsigned long address_call_base;
+    size_t idx;
+};
 
-    bf_assert(reg < __MAX_BPF_REG);
-    static_assert(ARRAY_SIZE(regs) == __MAX_BPF_REG);
+static void _bf_print_insn(void *private_data, const char *fmt, ...)
+{
+    va_list args;
+    struct bf_dump_data *bfdd = private_data;
 
-    return regs[reg];
+    va_start(args, fmt);
+    (void)fprintf(stderr, "%s%-7s%s: %s %4ld: ",
+                  bf_logger_get_color(BF_COLOR_BLUE, BF_STYLE_BOLD), "debug",
+                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),
+                  *(bfdd->prefix), bfdd->idx);
+    (void)vfprintf(stderr, fmt, args);
+    va_end(args);
 }
 
-static const char *_bf_op(const struct bpf_insn *insn)
+static const char *_bf_print_call(void *private_data,
+                                  const struct bpf_insn *insn)
 {
-    static const char *ops[] = {
-        [BPF_ADD >> 4] = "+",  [BPF_SUB >> 4] = "-", [BPF_MUL >> 4] = "*",
-        [BPF_OR >> 4] = "|",   [BPF_AND >> 4] = "&", [BPF_LSH >> 4] = "<<",
-        [BPF_RSH >> 4] = ">>", [BPF_XOR >> 4] = "^",
-    };
+    struct bf_dump_data *bfdd = private_data;
 
-    unsigned code = BF_INSN_CODE(insn) >> 4;
-
-    bf_assert(code < ARRAY_SIZE(ops));
-
-    return ops[code];
-}
-
-static const char *_bf_src(const struct bpf_insn *insn,
-                           char (*imm_buf)[BF_IMM_BUF_LEN])
-{
-    bf_assert(insn);
-    bf_assert(imm_buf);
-
-    if (BF_INSN_SRC(insn))
-        return _bpf_reg(insn->src_reg);
-
-    snprintf(*imm_buf, BF_IMM_BUF_LEN, "%d", insn->imm);
-
-    return *imm_buf;
-}
-
-static void _bf_program_dump_alu_insn(const struct bf_program *program,
-                                      const size_t *insn_idx, prefix_t *prefix)
-{
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-    char imm_buf[BF_IMM_BUF_LEN] = {};
-    const struct bpf_insn *insn = &program->img[*insn_idx];
-    const char *size = BF_INSN_CLS(insn) == BPF_ALU64 ? "" : "(u32)";
-
-    switch (BF_INSN_CODE(insn)) {
-    case BPF_ADD:
-    case BPF_SUB:
-    case BPF_MUL:
-    case BPF_OR:
-    case BPF_AND:
-    case BPF_LSH:
-    case BPF_RSH:
-    case BPF_XOR:
-        DUMP(prefix, "%04lu %s = %s%s %s %s%s", *insn_idx,
-             _bpf_reg(insn->dst_reg), size, _bpf_reg(insn->dst_reg),
-             _bf_op(insn), size, _bf_src(insn, &imm_buf));
-        break;
-    case BPF_DIV:
-        DUMP(prefix, "%04lu BPF_DIV - Unsupported", *insn_idx);
-        break;
-    case BPF_MOD:
-        DUMP(prefix, "%04lu BPF_MOD - Unsupported", *insn_idx);
-        break;
-    case BPF_NEG:
-        DUMP(prefix, "%04lu %s = ~%s%s", *insn_idx, _bpf_reg(insn->dst_reg),
-             size, _bf_src(insn, &imm_buf));
-        break;
-    case BPF_MOV:
-        DUMP(prefix, "%04lu %s = %s%s", *insn_idx, _bpf_reg(insn->dst_reg),
-             size, _bf_src(insn, &imm_buf));
-        break;
-    case BPF_ARSH:
-        DUMP(prefix, "%04lu BPF_ARSH - Unsupported", *insn_idx);
-        break;
-    case BPF_END:
-        DUMP(prefix, "%04lu BPF_END - Unsupported", *insn_idx);
-        break;
-    };
-}
-
-static const char *_bf_jmp_op(const struct bpf_insn *insn)
-{
-    static const char *ops[] = {
-        [BPF_JEQ >> 4] = "==",   [BPF_JGT >> 4] = ">",
-        [BPF_JGE >> 4] = ">=",   [BPF_JSET >> 4] = "&",
-        [BPF_JNE >> 4] = "!=",   [BPF_JSGT >> 4] = "s>",
-        [BPF_JSGE >> 4] = "s>=", [BPF_JLT >> 4] = "<",
-        [BPF_JLE >> 4] = "<=",   [BPF_JSLT >> 4] = "s<",
-        [BPF_JSLE >> 4] = "s<=",
-    };
-
-    int code = BF_INSN_CODE(insn) >> 4;
-
-    bf_assert(0 <= code && code < (int)ARRAY_SIZE(ops));
-
-    return ops[code];
-}
-
-static const char *_bpf_helper(const struct bpf_insn *insn)
-{
-    static const char *funcs[] = {
-        [BPF_FUNC_map_lookup_elem] = "bpf_map_lookup_elem",
-        [BPF_FUNC_map_update_elem] = "bpf_map_update_elem",
-        [BPF_FUNC_trace_printk] = "bpf_trace_printk",
-    };
-
-    return funcs[insn->imm];
-}
-
-static void _bf_program_dump_jmp_insn(const struct bf_program *program,
-                                      const size_t *insn_idx, prefix_t *prefix)
-{
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-    char imm_buf[BF_IMM_BUF_LEN] = {};
-    const struct bpf_insn *insn = &program->img[*insn_idx];
-    const char *size = BF_INSN_CLS(insn) == BPF_ALU ? "" : "(u32)";
-
-    bf_assert(program);
-    bf_assert(insn_idx);
-
-    switch (BF_INSN_CODE(insn)) {
-    case BPF_JA:
-        if (insn->off == 0) {
-            DUMP(prefix, "%04lu noop", *insn_idx);
-        } else {
-            DUMP(prefix, "%04lu goto pc + %d", *insn_idx,
-                 program->img[*insn_idx].off);
-        }
-        break;
-    case BPF_JEQ:
-    case BPF_JGT:
-    case BPF_JGE:
-    case BPF_JSET:
-    case BPF_JNE:
-    case BPF_JLT:
-    case BPF_JLE:
-    case BPF_JSGT:
-    case BPF_JSGE:
-    case BPF_JSLT:
-    case BPF_JSLE:
-        DUMP(prefix, "%04lu if %s%s %s %s%s goto pc + %d", *insn_idx, size,
-             _bpf_reg(insn->dst_reg), _bf_jmp_op(insn), size,
-             _bf_src(insn, &imm_buf), insn->off);
-        break;
-    case BPF_CALL:
-        switch (insn->src_reg) {
-        case 0x00:
-            DUMP(prefix, "%04lu call %s", *insn_idx, _bpf_helper(insn));
-            break;
-        case 0x01:
-            DUMP(prefix, "%04lu call pc + %d", *insn_idx, insn->imm);
-            break;
-        case 0x02:
-            DUMP(prefix, "%04lu call helper function by BTF ID", *insn_idx);
-            break;
-        };
-        break;
-    case BPF_EXIT:
-        DUMP(prefix, "%04lu exit", *insn_idx);
-        break;
-    };
-}
-
-static const char *_bpf_ldst_size(const struct bpf_insn *insn)
-{
-    static const char *sizes[] = {
-        [BPF_W >> 3] = "u32",
-        [BPF_H >> 3] = "u16",
-        [BPF_B >> 3] = "u8",
-        [BPF_DW >> 3] = "u64",
-    };
-
-    unsigned char size = BF_INSN_SIZE(insn) >> 3;
-
-    bf_assert(size < (int)ARRAY_SIZE(sizes));
-
-    return sizes[size];
-}
-
-static void _bf_program_dump_imm64_insn(const struct bf_program *program,
-                                        size_t *insn_idx, prefix_t *prefix)
-{
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-    const struct bpf_insn *insn = &program->img[*insn_idx];
-    const struct bpf_insn *next_insn;
-
-    bf_assert(program);
-    bf_assert(insn_idx);
-    bf_assert(prefix);
-
-    bf_assert((*insn_idx + 1) < program->img_size);
-
-    next_insn = &program->img[*insn_idx + 1];
-
-    // Skip the next one as this is a 64 bits immediate value instruction.
-    (*insn_idx)++;
-
-    bf_assert(insn->code == (BPF_IMM | BPF_DW | BPF_LD));
-
-    switch (insn->src_reg) {
-    case 0x00:
-        DUMP(prefix, "%04lu %s = %llu", *insn_idx, _bpf_reg(insn->dst_reg),
-             ((unsigned long long)insn->imm << 32) | next_insn->imm);
-        break;
-    case 0x01:
-        DUMP(prefix, "%04lu %s = map_by_fd(%d)", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm);
-        break;
-    case 0x02:
-        DUMP(prefix, "%04lu %s = map_val(map_by_fd(%d)) + %d", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm, next_insn->imm);
-        break;
-    case 0x03:
-        DUMP(prefix, "%04lu %s = val_addr(%d)", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm);
-        break;
-    case 0x04:
-        DUMP(prefix, "%04lu %s = code_addr(%d)", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm);
-        break;
-    case 0x05:
-        DUMP(prefix, "%04lu %s = map_by_idx(%d)", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm);
-        break;
-    case 0x06:
-        DUMP(prefix, "%04lu %s = map_val(map_by_idx(%d)) + %d", *insn_idx,
-             _bpf_reg(insn->dst_reg), insn->imm, next_insn->imm);
-        break;
+    if (insn->src_reg == BPF_PSEUDO_CALL) {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff), "%+d",
+                       insn->imm);
+    } else {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff), "%s",
+                       bf_btf_get_name(insn->imm));
     }
+
+    return bfdd->scratch_buff;
 }
 
-static void _bf_program_dump_ldst_insn(const struct bf_program *program,
-                                       size_t *insn_idx, prefix_t *prefix)
+static const char *_bf_print_imm(void *private_data,
+                                 const struct bpf_insn *insn, uint64_t full_imm)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-    const struct bpf_insn *insn = &program->img[*insn_idx];
+    struct bf_dump_data *bfdd = private_data;
 
-    switch (BF_INSN_MODE(insn)) {
-    case BPF_IMM:
-        _bf_program_dump_imm64_insn(program, insn_idx, prefix);
-        break;
-    case BPF_ABS:
-    case BPF_IND:
-        DUMP(prefix, "%04lu legacy BPF instructions are not supported",
-             *insn_idx);
-        break;
-    case BPF_MEM:
-        switch (BF_INSN_CLS(insn)) {
-        case BPF_LDX:
-            DUMP(prefix, "%04lu %s = *(%s *)(%s + %d)", *insn_idx,
-                 _bpf_reg(insn->dst_reg), _bpf_ldst_size(insn),
-                 _bpf_reg(insn->src_reg), insn->off);
-            break;
-        case BPF_ST:
-            DUMP(prefix, "%04lu *(%s *)(%s + %d) = %d", *insn_idx,
-                 _bpf_ldst_size(insn), _bpf_reg(insn->dst_reg), insn->off,
-                 insn->imm);
-            break;
-        case BPF_STX:
-            DUMP(prefix, "%04lu *(%s *)(%s + %d) = %s", *insn_idx,
-                 _bpf_ldst_size(insn), _bpf_reg(insn->dst_reg), insn->off,
-                 _bpf_reg(insn->src_reg));
-            break;
-        };
-        break;
-    case BPF_ATOMIC:
-        DUMP(prefix, "%04lu BPF_ATOMIC - Unsupported", *insn_idx);
-        break;
+    if (insn->src_reg == BPF_PSEUDO_MAP_FD) {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff),
+                       "map[id:%u]", insn->imm);
+    } else if (insn->src_reg == BPF_PSEUDO_MAP_VALUE) {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff),
+                       "map[id:%u][0]+%u", insn->imm, (insn + 1)->imm);
+    } else if (insn->src_reg == BPF_PSEUDO_MAP_IDX_VALUE) {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff),
+                       "map[idx:%u]+%u", insn->imm, (insn + 1)->imm);
+    } else if (insn->src_reg == BPF_PSEUDO_FUNC) {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff),
+                       "subprog[%+d]", insn->imm);
+    } else {
+        (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff), "0x%llx",
+                       (unsigned long long)full_imm);
     }
+
+    return bfdd->scratch_buff;
 }
 
-static void _bf_program_dump_insn(const struct bf_program *program,
-                                  size_t *insn_idx, prefix_t *prefix)
+void bf_program_dump_bytecode(const struct bf_program *program)
 {
-    prefix_t _prefix = {};
-    prefix = prefix ?: &_prefix;
-    const struct bpf_insn *insn = &program->img[*insn_idx];
-
-    switch (BF_INSN_CLS(insn)) {
-    case BPF_LD:
-    case BPF_LDX:
-    case BPF_ST:
-    case BPF_STX:
-        _bf_program_dump_ldst_insn(program, insn_idx, prefix);
-        break;
-    case BPF_ALU:
-    case BPF_ALU64:
-        _bf_program_dump_alu_insn(program, insn_idx, prefix);
-        break;
-    case BPF_JMP:
-    case BPF_JMP32:
-        _bf_program_dump_jmp_insn(program, insn_idx, prefix);
-        break;
-    default:
-        DUMP(prefix, "%04lu Unknown insn code: 0x%02x", *insn_idx,
-             program->img[*insn_idx].code);
-        break;
-    };
-}
-
-static void _bf_program_dump_raw(const struct bf_program *program,
-                                 const size_t *insn_idx, prefix_t *prefix)
-{
-    const struct bpf_insn *insn = &program->img[*insn_idx];
-
-    switch (BF_INSN_CLS(&program->img[*insn_idx])) {
-    case BPF_LD:
-    case BPF_LDX:
-    case BPF_STX:
-    case BPF_ST:
-        DUMP(prefix,
-             "mode=0x%02x, size=0x%02x, cls=0x%02x, dst=%s, src=%s, imm=%d",
-             BF_INSN_MODE(insn), BF_INSN_SIZE(insn), BF_INSN_CLS(insn),
-             _bpf_reg(insn->dst_reg), _bpf_reg(insn->src_reg), insn->imm);
-        break;
-    case BPF_ALU:
-    case BPF_ALU64:
-    case BPF_JMP:
-    case BPF_JMP32:
-        DUMP(prefix,
-             "code=0x%02x, src=0x%02x, cls=0x%02x, dst=%s, src=%s, imm=%d",
-             BF_INSN_CODE(insn), BF_INSN_SRC(insn), BF_INSN_CLS(insn),
-             _bpf_reg(insn->dst_reg), _bpf_reg(insn->src_reg), insn->imm);
-        break;
-    };
-}
-
-void bf_program_dump_bytecode(const struct bf_program *program, bool with_raw)
-{
-    size_t i;
     prefix_t prefix = {};
+    struct bf_dump_data bfdd = {
+        .prefix = &prefix,
+    };
+    struct bpf_insn_cbs callbacks = {
+        .cb_print = _bf_print_insn,
+        .cb_call = _bf_print_call,
+        .cb_imm = _bf_print_imm,
+        .private_data = &bfdd,
+    };
+    bool double_insn = false;
+
+    bf_assert(program);
 
     bf_dump_prefix_push(&prefix);
 
     bf_dbg("Bytecode for program at %p, %lu insn:", program, program->img_size);
 
-    for (i = 0; i < program->img_size; ++i) {
+    for (size_t i = 0; i < program->img_size; ++i) {
         if (i == program->img_size - 1)
             bf_dump_prefix_last(&prefix);
 
-        _bf_program_dump_insn(program, &i, &prefix);
-
-        if (with_raw) {
-            bf_dump_prefix_push(&prefix);
-            bf_dump_prefix_last(&prefix);
-            _bf_program_dump_raw(program, &i, &prefix);
-            bf_dump_prefix_pop(&prefix);
+        if (double_insn) {
+            double_insn = false;
+            continue;
         }
+
+        print_bpf_insn(&callbacks, &program->img[i], true);
+        ++bfdd.idx;
+
+        double_insn = program->img[i].code == (BPF_LD | BPF_IMM | BPF_DW);
     }
 
     // Force flush, otherwise output on stderr might appear.
-    fflush(stdout);
+    (void)fflush(stdout);
 }
-
-// NOLINTEND

--- a/src/bpfilter/cgen/dump.h
+++ b/src/bpfilter/cgen/dump.h
@@ -5,8 +5,15 @@
 
 #pragma once
 
-#include <stdbool.h>
+/**
+ * @file dump.h
+ *
+ * @ref bf_program_dump_bytecode is defined to pretty-print the BPF bytecode
+ * from a @ref bf_program structure. The logic used here is inspired by
+ * bpftool's dumper (https://github.com/libbpf/bpftool) with all the heavy
+ * lifting performed by Linux @c kernel/bpf/disasm.c .
+ */
 
 struct bf_program;
 
-void bf_program_dump_bytecode(const struct bf_program *program, bool with_raw);
+void bf_program_dump_bytecode(const struct bf_program *program);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include "bpfilter/cgen/cgroup.h"
+#include "bpfilter/cgen/dump.h"
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/jmp.h"
 #include "bpfilter/cgen/matcher/ip4.h"
@@ -1086,6 +1087,9 @@ int bf_program_load(struct bf_program *new_prog, struct bf_program *old_prog)
     r = _bf_program_load_printer_map(new_prog);
     if (r)
         return r;
+
+    if (bf_opts_is_verbose(BF_VERBOSE_BYTECODE))
+        bf_program_dump_bytecode(new_prog, false);
 
     r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -1089,7 +1089,7 @@ int bf_program_load(struct bf_program *new_prog, struct bf_program *old_prog)
         return r;
 
     if (bf_opts_is_verbose(BF_VERBOSE_BYTECODE))
-        bf_program_dump_bytecode(new_prog, false);
+        bf_program_dump_bytecode(new_prog);
 
     r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
                          new_prog->img, new_prog->img_size,

--- a/src/core/btf.c
+++ b/src/core/btf.c
@@ -46,6 +46,19 @@ int bf_btf_get_id(const char *name)
     return id;
 }
 
+const char *bf_btf_get_name(int id)
+{
+    const struct btf_type *type;
+
+    type = btf__type_by_id(_bf_btf, id);
+    if (!type) {
+        bf_warn("can't find BTF type ID %d", id);
+        return NULL;
+    }
+
+    return btf__name_by_offset(_bf_btf, type->name_off);
+}
+
 int bf_btf_get_field_off(const char *struct_name, const char *field_name)
 {
     int offset = -1;

--- a/src/core/btf.h
+++ b/src/core/btf.h
@@ -32,6 +32,18 @@ void bf_btf_teardown(void);
 int bf_btf_get_id(const char *name);
 
 /**
+ * Get a type name from a BTF ID from the kernel BTF data.
+ *
+ * Linux BTF data must be loaded with @ref bf_btf_setup before calling this
+ * function. If @c id is invalid, or not part of the kernel's BTF data, @c NULL
+ * is returned.
+ *
+ * @param id Type ID to look for.
+ * @return Name of the type represented by @c id or @c NULL .
+ */
+const char *bf_btf_get_name(int id);
+
+/**
  * Get the offset of a field in a kernel structure.
  *
  * Use Linux' BTF data to find the offset of a specific field in a structure.

--- a/src/core/opts.c
+++ b/src/core/opts.c
@@ -27,6 +27,7 @@ enum
 static const char *_bf_verbose_strs[] = {
     [BF_VERBOSE_DEBUG] = "debug",
     [BF_VERBOSE_BPF] = "bpf",
+    [BF_VERBOSE_BYTECODE] = "bytecode",
 };
 
 static_assert(ARRAY_SIZE(_bf_verbose_strs) == _BF_VERBOSE_MAX,

--- a/src/core/opts.h
+++ b/src/core/opts.h
@@ -13,6 +13,7 @@ enum bf_verbose
 {
     BF_VERBOSE_DEBUG,
     BF_VERBOSE_BPF,
+    BF_VERBOSE_BYTECODE,
     _BF_VERBOSE_MAX,
 };
 

--- a/src/external/disasm.c
+++ b/src/external/disasm.c
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright (c) 2011-2014 PLUMgrid, http://plumgrid.com
+ * Copyright (c) 2016 Facebook
+ */
+
+#include <linux/bpf.h>
+
+#include "external/disasm.h"
+
+/*******************************************************************************
+ * Missing types and definitions
+ ******************************************************************************/
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef uint64_t u64;
+typedef int64_t s64;
+typedef uint32_t u32;
+typedef int32_t s32;
+typedef uint16_t u16;
+typedef int16_t s16;
+typedef uint8_t u8;
+typedef int8_t s8;
+
+/*******************************************************************************
+ * #include <linux/bpf.h>
+ ******************************************************************************/
+#define BPF_ADDR_SPACE_CAST 1
+#define BPF_MAY_GOTO        0
+#define BPF_JCOND	    0xe0
+
+/*******************************************************************************
+ * #include <linux/bpf/disasm.h>
+ ******************************************************************************/
+extern const char *const bpf_alu_string[16];
+extern const char *const bpf_class_string[8];
+
+const char *func_id_name(int id);
+
+/*******************************************************************************
+ * #include <linux/stringify.h>
+ ******************************************************************************/
+/* Indirect stringification.  Doing two levels allows the parameter to be a
+ * macro itself.  For example, compile with -DFOO=bar, __stringify(FOO)
+ * converts to "bar".
+ */
+
+#define __stringify_1(x...)	#x
+#define __stringify(x...)	__stringify_1(x)
+
+#define FILE_LINE	__FILE__ ":" __stringify(__LINE__)
+
+/*******************************************************************************
+ * #include <linux/compiler_types.h>
+ ******************************************************************************/
+#define __compiletime_assert(condition, msg, prefix, suffix) do { } while (0)
+
+#define _compiletime_assert(condition, msg, prefix, suffix) \
+	__compiletime_assert(condition, msg, prefix, suffix)
+
+/**
+ * compiletime_assert - break build and emit msg if condition is false
+ * @condition: a compile-time constant condition to check
+ * @msg:       a message to emit if condition is false
+ *
+ * In tradition of POSIX assert, this macro will break the build if the
+ * supplied condition is *false*, emitting the supplied error message if the
+ * compiler has support to do so.
+ */
+#define compiletime_assert(condition, msg) \
+	_compiletime_assert(condition, msg, __compiletime_assert_, __COUNTER__)
+
+/*******************************************************************************
+ * #include <linux/build_bug.h>
+ ******************************************************************************/
+#ifdef __CHECKER__
+#define BUILD_BUG_ON_ZERO(e) (0)
+#else /* __CHECKER__ */
+/*
+ * Force a compilation error if condition is true, but also produce a
+ * result (of value 0 and type int), so the expression can be used
+ * e.g. in a structure initializer (or where-ever else comma expressions
+ * aren't permitted).
+ */
+#define BUILD_BUG_ON_ZERO(e) ((int)(sizeof(struct { int:(-!!(e)); })))
+#endif /* __CHECKER__ */
+
+/* Force a compilation error if a constant expression is not a power of 2 */
+#define __BUILD_BUG_ON_NOT_POWER_OF_2(n)	\
+	BUILD_BUG_ON(((n) & ((n) - 1)) != 0)
+#define BUILD_BUG_ON_NOT_POWER_OF_2(n)			\
+	BUILD_BUG_ON((n) == 0 || (((n) & ((n) - 1)) != 0))
+
+/*
+ * BUILD_BUG_ON_INVALID() permits the compiler to check the validity of the
+ * expression but avoids the generation of any code, even if that expression
+ * has side-effects.
+ */
+#define BUILD_BUG_ON_INVALID(e) ((void)(sizeof((__force long)(e))))
+
+/**
+ * BUILD_BUG_ON_MSG - break compile if a condition is true & emit supplied
+ *		      error message.
+ * @condition: the condition which the compiler should know is false.
+ *
+ * See BUILD_BUG_ON for description.
+ */
+#define BUILD_BUG_ON_MSG(cond, msg) compiletime_assert(!(cond), msg)
+
+/**
+ * BUILD_BUG_ON - break compile if a condition is true.
+ * @condition: the condition which the compiler should know is false.
+ *
+ * If you have some code which relies on certain constants being equal, or
+ * some other compile-time-evaluated condition, you should use BUILD_BUG_ON to
+ * detect if someone changes it.
+ */
+#define BUILD_BUG_ON(condition) \
+	BUILD_BUG_ON_MSG(condition, "BUILD_BUG_ON failed: " #condition)
+
+
+/*******************************************************************************
+ * Content of linux/bpf/disasm.c
+ ******************************************************************************/
+#define __BPF_FUNC_STR_FN(x) [BPF_FUNC_ ## x] = __stringify(bpf_ ## x)
+static const char * const func_id_str[] = {
+	__BPF_FUNC_MAPPER(__BPF_FUNC_STR_FN)
+};
+#undef __BPF_FUNC_STR_FN
+
+static const char *__func_get_name(const struct bpf_insn_cbs *cbs,
+				   const struct bpf_insn *insn,
+				   char *buff, size_t len)
+{
+	BUILD_BUG_ON(ARRAY_SIZE(func_id_str) != __BPF_FUNC_MAX_ID);
+
+	if (!insn->src_reg &&
+	    insn->imm >= 0 && insn->imm < __BPF_FUNC_MAX_ID &&
+	    func_id_str[insn->imm])
+		return func_id_str[insn->imm];
+
+	if (cbs && cbs->cb_call) {
+		const char *res;
+
+		res = cbs->cb_call(cbs->private_data, insn);
+		if (res)
+			return res;
+	}
+
+	if (insn->src_reg == BPF_PSEUDO_CALL)
+		snprintf(buff, len, "%+d", insn->imm);
+	else if (insn->src_reg == BPF_PSEUDO_KFUNC_CALL)
+		snprintf(buff, len, "kernel-function");
+
+	return buff;
+}
+
+static const char *__func_imm_name(const struct bpf_insn_cbs *cbs,
+				   const struct bpf_insn *insn,
+				   u64 full_imm, char *buff, size_t len)
+{
+	if (cbs && cbs->cb_imm)
+		return cbs->cb_imm(cbs->private_data, insn, full_imm);
+
+	snprintf(buff, len, "0x%llx", (unsigned long long)full_imm);
+	return buff;
+}
+
+const char *func_id_name(int id)
+{
+	if (id >= 0 && id < __BPF_FUNC_MAX_ID && func_id_str[id])
+		return func_id_str[id];
+	else
+		return "unknown";
+}
+
+const char *const bpf_class_string[8] = {
+	[BPF_LD]    = "ld",
+	[BPF_LDX]   = "ldx",
+	[BPF_ST]    = "st",
+	[BPF_STX]   = "stx",
+	[BPF_ALU]   = "alu",
+	[BPF_JMP]   = "jmp",
+	[BPF_JMP32] = "jmp32",
+	[BPF_ALU64] = "alu64",
+};
+
+const char *const bpf_alu_string[16] = {
+	[BPF_ADD >> 4]  = "+=",
+	[BPF_SUB >> 4]  = "-=",
+	[BPF_MUL >> 4]  = "*=",
+	[BPF_DIV >> 4]  = "/=",
+	[BPF_OR  >> 4]  = "|=",
+	[BPF_AND >> 4]  = "&=",
+	[BPF_LSH >> 4]  = "<<=",
+	[BPF_RSH >> 4]  = ">>=",
+	[BPF_NEG >> 4]  = "neg",
+	[BPF_MOD >> 4]  = "%=",
+	[BPF_XOR >> 4]  = "^=",
+	[BPF_MOV >> 4]  = "=",
+	[BPF_ARSH >> 4] = "s>>=",
+	[BPF_END >> 4]  = "endian",
+};
+
+static const char *const bpf_alu_sign_string[16] = {
+	[BPF_DIV >> 4]  = "s/=",
+	[BPF_MOD >> 4]  = "s%=",
+};
+
+static const char *const bpf_movsx_string[4] = {
+	[0] = "(s8)",
+	[1] = "(s16)",
+	[3] = "(s32)",
+};
+
+static const char *const bpf_atomic_alu_string[16] = {
+	[BPF_ADD >> 4]  = "add",
+	[BPF_AND >> 4]  = "and",
+	[BPF_OR >> 4]  = "or",
+	[BPF_XOR >> 4]  = "xor",
+};
+
+static const char *const bpf_ldst_string[] = {
+	[BPF_W >> 3]  = "u32",
+	[BPF_H >> 3]  = "u16",
+	[BPF_B >> 3]  = "u8",
+	[BPF_DW >> 3] = "u64",
+};
+
+static const char *const bpf_ldsx_string[] = {
+	[BPF_W >> 3]  = "s32",
+	[BPF_H >> 3]  = "s16",
+	[BPF_B >> 3]  = "s8",
+};
+
+static const char *const bpf_jmp_string[16] = {
+	[BPF_JA >> 4]   = "jmp",
+	[BPF_JEQ >> 4]  = "==",
+	[BPF_JGT >> 4]  = ">",
+	[BPF_JLT >> 4]  = "<",
+	[BPF_JGE >> 4]  = ">=",
+	[BPF_JLE >> 4]  = "<=",
+	[BPF_JSET >> 4] = "&",
+	[BPF_JNE >> 4]  = "!=",
+	[BPF_JSGT >> 4] = "s>",
+	[BPF_JSLT >> 4] = "s<",
+	[BPF_JSGE >> 4] = "s>=",
+	[BPF_JSLE >> 4] = "s<=",
+	[BPF_CALL >> 4] = "call",
+	[BPF_EXIT >> 4] = "exit",
+};
+
+static void print_bpf_end_insn(bpf_insn_print_t verbose,
+			       void *private_data,
+			       const struct bpf_insn *insn)
+{
+	verbose(private_data, "(%02x) r%d = %s%d r%d\n",
+		insn->code, insn->dst_reg,
+		BPF_SRC(insn->code) == BPF_TO_BE ? "be" : "le",
+		insn->imm, insn->dst_reg);
+}
+
+static void print_bpf_bswap_insn(bpf_insn_print_t verbose,
+			       void *private_data,
+			       const struct bpf_insn *insn)
+{
+	verbose(private_data, "(%02x) r%d = bswap%d r%d\n",
+		insn->code, insn->dst_reg,
+		insn->imm, insn->dst_reg);
+}
+
+static bool is_sdiv_smod(const struct bpf_insn *insn)
+{
+	return (BPF_OP(insn->code)  == BPF_DIV || BPF_OP(insn->code) == BPF_MOD) &&
+	       insn->off == 1;
+}
+
+static bool is_movsx(const struct bpf_insn *insn)
+{
+	return BPF_OP(insn->code) == BPF_MOV &&
+	       (insn->off == 8 || insn->off == 16 || insn->off == 32);
+}
+
+static bool is_addr_space_cast(const struct bpf_insn *insn)
+{
+	return insn->code == (BPF_ALU64 | BPF_MOV | BPF_X) &&
+		insn->off == BPF_ADDR_SPACE_CAST;
+}
+
+/* Special (internal-only) form of mov, used to resolve per-CPU addrs:
+ * dst_reg = src_reg + <percpu_base_off>
+ * BPF_ADDR_PERCPU is used as a special insn->off value.
+ */
+#define BPF_ADDR_PERCPU	(-1)
+
+static inline bool is_mov_percpu_addr(const struct bpf_insn *insn)
+{
+	return insn->code == (BPF_ALU64 | BPF_MOV | BPF_X) && insn->off == BPF_ADDR_PERCPU;
+}
+
+void print_bpf_insn(const struct bpf_insn_cbs *cbs,
+		    const struct bpf_insn *insn,
+		    bool allow_ptr_leaks)
+{
+	const bpf_insn_print_t verbose = cbs->cb_print;
+	u8 class = BPF_CLASS(insn->code);
+
+	if (class == BPF_ALU || class == BPF_ALU64) {
+		if (BPF_OP(insn->code) == BPF_END) {
+			if (class == BPF_ALU64)
+				print_bpf_bswap_insn(verbose, cbs->private_data, insn);
+			else
+				print_bpf_end_insn(verbose, cbs->private_data, insn);
+		} else if (BPF_OP(insn->code) == BPF_NEG) {
+			verbose(cbs->private_data, "(%02x) %c%d = -%c%d\n",
+				insn->code, class == BPF_ALU ? 'w' : 'r',
+				insn->dst_reg, class == BPF_ALU ? 'w' : 'r',
+				insn->dst_reg);
+		} else if (is_addr_space_cast(insn)) {
+			verbose(cbs->private_data, "(%02x) r%d = addr_space_cast(r%d, %d, %d)\n",
+				insn->code, insn->dst_reg,
+				insn->src_reg, ((u32)insn->imm) >> 16, (u16)insn->imm);
+		} else if (is_mov_percpu_addr(insn)) {
+			verbose(cbs->private_data, "(%02x) r%d = &(void __percpu *)(r%d)\n",
+				insn->code, insn->dst_reg, insn->src_reg);
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			verbose(cbs->private_data, "(%02x) %c%d %s %s%c%d\n",
+				insn->code, class == BPF_ALU ? 'w' : 'r',
+				insn->dst_reg,
+				is_sdiv_smod(insn) ? bpf_alu_sign_string[BPF_OP(insn->code) >> 4]
+						   : bpf_alu_string[BPF_OP(insn->code) >> 4],
+				is_movsx(insn) ? bpf_movsx_string[(insn->off >> 3) - 1] : "",
+				class == BPF_ALU ? 'w' : 'r',
+				insn->src_reg);
+		} else {
+			verbose(cbs->private_data, "(%02x) %c%d %s %d\n",
+				insn->code, class == BPF_ALU ? 'w' : 'r',
+				insn->dst_reg,
+				is_sdiv_smod(insn) ? bpf_alu_sign_string[BPF_OP(insn->code) >> 4]
+						   : bpf_alu_string[BPF_OP(insn->code) >> 4],
+				insn->imm);
+		}
+	} else if (class == BPF_STX) {
+		if (BPF_MODE(insn->code) == BPF_MEM)
+			verbose(cbs->private_data, "(%02x) *(%s *)(r%d %+d) = r%d\n",
+				insn->code,
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg,
+				insn->off, insn->src_reg);
+		else if (BPF_MODE(insn->code) == BPF_ATOMIC &&
+			 (insn->imm == BPF_ADD || insn->imm == BPF_AND ||
+			  insn->imm == BPF_OR || insn->imm == BPF_XOR)) {
+			verbose(cbs->private_data, "(%02x) lock *(%s *)(r%d %+d) %s r%d\n",
+				insn->code,
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg, insn->off,
+				bpf_alu_string[BPF_OP(insn->imm) >> 4],
+				insn->src_reg);
+		} else if (BPF_MODE(insn->code) == BPF_ATOMIC &&
+			   (insn->imm == (BPF_ADD | BPF_FETCH) ||
+			    insn->imm == (BPF_AND | BPF_FETCH) ||
+			    insn->imm == (BPF_OR | BPF_FETCH) ||
+			    insn->imm == (BPF_XOR | BPF_FETCH))) {
+			verbose(cbs->private_data, "(%02x) r%d = atomic%s_fetch_%s((%s *)(r%d %+d), r%d)\n",
+				insn->code, insn->src_reg,
+				BPF_SIZE(insn->code) == BPF_DW ? "64" : "",
+				bpf_atomic_alu_string[BPF_OP(insn->imm) >> 4],
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg, insn->off, insn->src_reg);
+		} else if (BPF_MODE(insn->code) == BPF_ATOMIC &&
+			   insn->imm == BPF_CMPXCHG) {
+			verbose(cbs->private_data, "(%02x) r0 = atomic%s_cmpxchg((%s *)(r%d %+d), r0, r%d)\n",
+				insn->code,
+				BPF_SIZE(insn->code) == BPF_DW ? "64" : "",
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg, insn->off,
+				insn->src_reg);
+		} else if (BPF_MODE(insn->code) == BPF_ATOMIC &&
+			   insn->imm == BPF_XCHG) {
+			verbose(cbs->private_data, "(%02x) r%d = atomic%s_xchg((%s *)(r%d %+d), r%d)\n",
+				insn->code, insn->src_reg,
+				BPF_SIZE(insn->code) == BPF_DW ? "64" : "",
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg, insn->off, insn->src_reg);
+		} else {
+			verbose(cbs->private_data, "BUG_%02x\n", insn->code);
+		}
+	} else if (class == BPF_ST) {
+		if (BPF_MODE(insn->code) == BPF_MEM) {
+			verbose(cbs->private_data, "(%02x) *(%s *)(r%d %+d) = %d\n",
+				insn->code,
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->dst_reg,
+				insn->off, insn->imm);
+		} else if (BPF_MODE(insn->code) == 0xc0 /* BPF_NOSPEC, no UAPI */) {
+			verbose(cbs->private_data, "(%02x) nospec\n", insn->code);
+		} else {
+			verbose(cbs->private_data, "BUG_st_%02x\n", insn->code);
+		}
+	} else if (class == BPF_LDX) {
+		if (BPF_MODE(insn->code) != BPF_MEM && BPF_MODE(insn->code) != BPF_MEMSX) {
+			verbose(cbs->private_data, "BUG_ldx_%02x\n", insn->code);
+			return;
+		}
+		verbose(cbs->private_data, "(%02x) r%d = *(%s *)(r%d %+d)\n",
+			insn->code, insn->dst_reg,
+			BPF_MODE(insn->code) == BPF_MEM ?
+				 bpf_ldst_string[BPF_SIZE(insn->code) >> 3] :
+				 bpf_ldsx_string[BPF_SIZE(insn->code) >> 3],
+			insn->src_reg, insn->off);
+	} else if (class == BPF_LD) {
+		if (BPF_MODE(insn->code) == BPF_ABS) {
+			verbose(cbs->private_data, "(%02x) r0 = *(%s *)skb[%d]\n",
+				insn->code,
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->imm);
+		} else if (BPF_MODE(insn->code) == BPF_IND) {
+			verbose(cbs->private_data, "(%02x) r0 = *(%s *)skb[r%d + %d]\n",
+				insn->code,
+				bpf_ldst_string[BPF_SIZE(insn->code) >> 3],
+				insn->src_reg, insn->imm);
+		} else if (BPF_MODE(insn->code) == BPF_IMM &&
+			   BPF_SIZE(insn->code) == BPF_DW) {
+			/* At this point, we already made sure that the second
+			 * part of the ldimm64 insn is accessible.
+			 */
+			u64 imm = ((u64)(insn + 1)->imm << 32) | (u32)insn->imm;
+			bool is_ptr = insn->src_reg == BPF_PSEUDO_MAP_FD ||
+				      insn->src_reg == BPF_PSEUDO_MAP_VALUE;
+			char tmp[64];
+
+			if (is_ptr && !allow_ptr_leaks)
+				imm = 0;
+
+			verbose(cbs->private_data, "(%02x) r%d = %s\n",
+				insn->code, insn->dst_reg,
+				__func_imm_name(cbs, insn, imm,
+						tmp, sizeof(tmp)));
+		} else {
+			verbose(cbs->private_data, "BUG_ld_%02x\n", insn->code);
+			return;
+		}
+	} else if (class == BPF_JMP32 || class == BPF_JMP) {
+		u8 opcode = BPF_OP(insn->code);
+
+		if (opcode == BPF_CALL) {
+			char tmp[64];
+
+			if (insn->src_reg == BPF_PSEUDO_CALL) {
+				verbose(cbs->private_data, "(%02x) call pc%s\n",
+					insn->code,
+					__func_get_name(cbs, insn,
+							tmp, sizeof(tmp)));
+			} else {
+				strcpy(tmp, "unknown");
+				verbose(cbs->private_data, "(%02x) call %s#%d\n", insn->code,
+					__func_get_name(cbs, insn,
+							tmp, sizeof(tmp)),
+					insn->imm);
+			}
+		} else if (insn->code == (BPF_JMP | BPF_JA)) {
+			verbose(cbs->private_data, "(%02x) goto pc%+d\n",
+				insn->code, insn->off);
+		} else if (insn->code == (BPF_JMP | BPF_JCOND) &&
+			   insn->src_reg == BPF_MAY_GOTO) {
+			verbose(cbs->private_data, "(%02x) may_goto pc%+d\n",
+				insn->code, insn->off);
+		} else if (insn->code == (BPF_JMP32 | BPF_JA)) {
+			verbose(cbs->private_data, "(%02x) gotol pc%+d\n",
+				insn->code, insn->imm);
+		} else if (insn->code == (BPF_JMP | BPF_EXIT)) {
+			verbose(cbs->private_data, "(%02x) exit\n", insn->code);
+		} else if (BPF_SRC(insn->code) == BPF_X) {
+			verbose(cbs->private_data,
+				"(%02x) if %c%d %s %c%d goto pc%+d\n",
+				insn->code, class == BPF_JMP32 ? 'w' : 'r',
+				insn->dst_reg,
+				bpf_jmp_string[BPF_OP(insn->code) >> 4],
+				class == BPF_JMP32 ? 'w' : 'r',
+				insn->src_reg, insn->off);
+		} else {
+			verbose(cbs->private_data,
+				"(%02x) if %c%d %s 0x%x goto pc%+d\n",
+				insn->code, class == BPF_JMP32 ? 'w' : 'r',
+				insn->dst_reg,
+				bpf_jmp_string[BPF_OP(insn->code) >> 4],
+				insn->imm, insn->off);
+		}
+	} else {
+		verbose(cbs->private_data, "(%02x) %s\n",
+			insn->code, bpf_class_string[class]);
+	}
+}

--- a/src/external/disasm.h
+++ b/src/external/disasm.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright (c) 2011-2014 PLUMgrid, http://plumgrid.com
+ * Copyright (c) 2016 Facebook
+ */
+
+#ifndef __BPF_DISASM_H__
+#define __BPF_DISASM_H__
+
+#include <linux/bpf.h>
+#include <linux/kernel.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef void (*bpf_insn_print_t)(void *private_data,
+						const char *, ...);
+typedef const char *(*bpf_insn_revmap_call_t)(void *private_data,
+					      const struct bpf_insn *insn);
+typedef const char *(*bpf_insn_print_imm_t)(void *private_data,
+					    const struct bpf_insn *insn,
+					    uint64_t full_imm);
+
+struct bpf_insn_cbs {
+	bpf_insn_print_t	cb_print;
+	bpf_insn_revmap_call_t	cb_call;
+	bpf_insn_print_imm_t	cb_imm;
+	void			*private_data;
+};
+
+void print_bpf_insn(const struct bpf_insn_cbs *cbs,
+		    const struct bpf_insn *insn,
+		    bool allow_ptr_leaks);
+#endif


### PR DESCRIPTION
The current logic used to dump a program's BPF bytecode is unstable. Not all the instructions are supported, and some of them are erroneously printed. However, this logic is not used often (even if it's been proven very useful sometimes) and the amount of effort required to dump the bytecode properly might not be worth the results.

Instead, this PR completely refactor the bytecode dump logic by using [Linux's `disasm.c`](https://github.com/torvalds/linux/blob/master/kernel/bpf/disasm.c), similarly to [`bpftool`](https://github.com/libbpf/bpftool). This change is also inspired by `bpftool`'s dump logic.

A new verbose flag has been added to the daemon to dump a program's bytecode before it is loaded into the kernel.