### PR TITLE
Handle unsupported protocols

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,9 @@
 #   Handled by bugprone-reserved-identifier.AllowedIdentifiers.
 # - clang-analyzer-core.CallAndMessage
 #   Too many false positives with GCC statement expressions.
+# - clang-analyzer-deadcode.DeadStores
+#   False positives when a bf_jmpctx with cleanup attribute is defined (but
+#   not initialized) and initialized later on.
 # - clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
 #   Avoid usage of Annex K functions for portability reasons.
 # - clang-analyzer-unix.Malloc
@@ -41,6 +44,7 @@ Checks: >
     -cert-dcl51-cpp,
   clang-analyzer-*,
     -clang-analyzer-core.CallAndMessage,
+    -clang-analyzer-deadcode.DeadStores,
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     -clang-analyzer-unix.Malloc,
   misc-*,

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -116,37 +116,34 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
     if (r)
         return r;
 
-    /* BPF_PROG_TYPE_NETFILTER doesn't provide access the the Ethernet header,
+    /* BPF_PROG_TYPE_CGROUP_SKB doesn't provide access the the Ethernet header,
      * so we can't parse it. Fill the runtime context's l3_proto and l3_offset
-     * manually instead. */
+     * manually instead.
+     * The switch structure below stores the L3 protocol identifier in BF_REG_1,
+     * then we use a shared logic to copy the L3 protocol and offset to the
+     * runtime context. */
     EMIT(program,
          BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l3_proto)));
     {
         _cleanup_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BF_REG_1);
 
-        EMIT_SWICH_OPTION(
-            &swich, AF_INET, BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IP)),
-            BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)),
-            BPF_MOV64_IMM(BF_REG_1, 0),
-            BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
-                        BF_PROG_CTX_OFF(l3_offset)));
-        EMIT_SWICH_OPTION(
-            &swich, AF_INET6, BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IPV6)),
-            BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)),
-            BPF_MOV64_IMM(BF_REG_1, 0),
-            BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1,
-                        BF_PROG_CTX_OFF(l3_offset)));
-        EMIT_SWICH_DEFAULT(
-            &swich,
-            BPF_MOV64_IMM(BF_REG_RET,
-                          program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT)),
-            BPF_EXIT_INSN());
+        EMIT_SWICH_OPTION(&swich, AF_INET,
+                          BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IP)));
+        EMIT_SWICH_OPTION(&swich, AF_INET6,
+                          BPF_MOV64_IMM(BF_REG_1, htons(ETH_P_IPV6)));
+        EMIT_SWICH_DEFAULT(&swich, BPF_MOV64_IMM(BF_REG_1, 0));
 
         r = bf_swich_generate(&swich);
         if (r)
             return r;
     }
+
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_proto)));
+    EMIT(program, BPF_MOV64_IMM(BF_REG_1, 0));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_1, BF_PROG_CTX_OFF(l3_offset)));
 
     r = bf_stub_parse_l3_hdr(program);
     if (r)

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -853,6 +853,17 @@ static int _bf_program_generate_runtime_init(struct bf_program *program)
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_ARG_1, BF_PROG_CTX_OFF(arg)));
 
+    // Initialize the context's headers metadata
+    EMIT(program, BPF_MOV64_IMM(BF_REG_2, 0));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(l3_offset)));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(l4_offset)));
+    EMIT(program,
+         BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(l3_proto)));
+    EMIT(program,
+         BPF_STX_MEM(BPF_B, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(l4_proto)));
+
     return 0;
 }
 


### PR DESCRIPTION
`bpfilter` only supports specific protocols for each layer: IPv4 and IPv6 on L3, TCP/UDP/ICMP on L4. This means we need to decide how to handle packets using other protocols, especially during pre-processing. 

For now, not much decision has been made on this matter: during pre-processing, if an unsupported protocol is discovered, the packet is accepted. This is far from an acceptable behaviour. 

The solution implemented in this PR is to rely on the program runtime context's `l3_proto` and `l4_proto` fields:
- Initialize `l3_proto` and `l4_proto` with 0
- When the L3 header is preprocessed, read `l3_proto`:
  - If it is set, create the slice and process the layer (i.e. store `l4_proto` in the context)
  - If it is not set, the L3 pre-processing completely
- Repeat for L4 preprocessing

This way, supported protocols are processed properly, and unsupported protocols are ignored. Because matchers check if the required protocol is available before processing the packet, unsupported protocol won't be processed by any matcher and go all the way to the chain's policy.

It's important not to jump directly to the end of the chain if we encounter an unsupported protocol because if the L4 protocol is not supported we could still have L3 only matchers to process.
