### PR TITLE
Fix bugs introduced by #143 (Handle unsupported protocols)

### DIFF
--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -253,7 +253,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
     /* Parse the L4 protocol and handle unuspported protocol, similarly to
      * bf_stub_parse_l3_hdr() above. */
     EMIT(program,
-         BPF_LDX_MEM(BPF_H, BF_ARG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+         BPF_LDX_MEM(BPF_B, BF_ARG_4, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
     {
         _cleanup_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BF_ARG_4);

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -164,7 +164,9 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
                           BPF_MOV64_IMM(BF_ARG_4, sizeof(struct iphdr)));
         EMIT_SWICH_OPTION(&swich, htobe16(ETH_P_IPV6),
                           BPF_MOV64_IMM(BF_ARG_4, sizeof(struct ipv6hdr)));
-        EMIT_SWICH_DEFAULT(&swich, BPF_MOV64_IMM(BF_ARG_4, 0));
+        EMIT_SWICH_DEFAULT(&swich, BPF_MOV64_IMM(BF_ARG_4, 0),
+                           BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_ARG_4,
+                                       BF_PROG_CTX_OFF(l3_proto)));
 
         r = bf_swich_generate(&swich);
         if (r)
@@ -266,8 +268,9 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
                           BPF_MOV64_IMM(BF_REG_4, sizeof(struct udphdr)));
         EMIT_SWICH_OPTION(&swich, IPPROTO_ICMPV6,
                           BPF_MOV64_IMM(BF_REG_4, sizeof(struct icmp6hdr)));
-        EMIT_SWICH_DEFAULT(&swich, 
-                          BPF_MOV64_IMM(BF_REG_4, 0));
+        EMIT_SWICH_DEFAULT(&swich, BPF_MOV64_IMM(BF_REG_4, 0),
+                           BPF_STX_MEM(BPF_B, BF_REG_CTX, BF_REG_4,
+                                       BF_PROG_CTX_OFF(l4_proto)));
 
         r = bf_swich_generate(&swich);
         if (r)


### PR DESCRIPTION
PR #143 introduced two bugs making the program rejected by the BPF verifier:
- The stub function to parse the L4 header reads `l4_proto` as `uint16_t` while it is a `uint8_t`.
- Explicitly write 0 to `l3_proto` and `l4_proto` if the protocol is unknown (or unsupported).