### PR TITLE
core: matcher: add range matcher for TCP and UDP ports

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -124,6 +124,7 @@ With:
     - ``any``: match the packet against a set of data defined as the payload. If any of the member of the payload set is found in the packet, the matcher is positive. For example, if you want to match all the ``icmp`` and ``udp`` packets: ``ip4.proto any icmp,udp``.
     - ``all``: match the packet against a set of data defined as the payload. If all the member of the payload set are found in the packet, the matcher is positive, even if the packet contains more than only the members defined in the payload. For example, to match all the packets containing *at least* the ``ACK`` TCP flag: ``tcp.flags all ACK``.
     - ``in``: matches the packet against a hashed set of reference values. Using the ``in`` operator is useful when the packet's data needs to be compared against a large set of different values. Let's say you want to filter 1000 different IPv4 addresses, you can either define 1000 ``ip4.saddr eq $IP`` matcher, in which case ``bpfilter`` will compare the packet against every IP one after the other. Or you can use ``ip4.saddr in {$IP0,IP1,...}`` in which case ``bpfilter`` will compare the packet's data against the hashed set as a whole in 1 operation.
+    - ``range``: matches in a range of values. Formatted as ``$START-$END``. Both ``$START`` and ``$END`` are included in the range.
 
   - ``$PAYLOAD``: payload to compare to the processed network packet. The exact payload format depends on ``$TYPE``.
 
@@ -229,17 +230,24 @@ With:
       - Operator
       - Payload
       - Notes
-    * - :rspan:`1` Source port
-      - :rspan:`1` ``tcp.sport``
+    * - :rspan:`2` Source port
+      - :rspan:`2` ``tcp.sport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`3` ``$PORT`` is a valid port value, as a decimal integer.
+      - :rspan:`1` ``$PORT`` is a valid port value, as a decimal integer.
     * - ``not``
-    * - :rspan:`1` Destination port
-      - :rspan:`1` ``tcp.dport``
+    * - ``range``
+      - ``$START-$END``
+      - ``$START`` and ``$END`` are valid port values, as decimal integers.
+    * - :rspan:`2` Destination port
+      - :rspan:`2` ``tcp.dport``
       - ``eq``
       - :rspan:`1` ``$PORT``
+      - :rspan:`1` ``$PORT`` is a valid port value, as a decimal integer.
     * - ``not``
+    * - ``range``
+      - ``$START-$END``
+      - ``$START`` and ``$END`` are valid port values, as decimal integers.
     * - :rspan:`3` Flags
       - :rspan:`3` ``tcp.flags``
       - ``eq``
@@ -262,14 +270,21 @@ With:
       - Operator
       - Payload
       - Notes
-    * - :rspan:`1` Source port
-      - :rspan:`1` ``udp.sport``
+    * - :rspan:`2` Source port
+      - :rspan:`2` ``udp.sport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`3` ``$PORT`` is a valid port value, as a decimal integer.
+      - :rspan:`1` ``$PORT`` is a valid port value, as a decimal integer.
     * - ``not``
-    * - :rspan:`1` Destination port
-      - :rspan:`1` ``udp.dport``
+    * - ``range``
+      - ``$START-$END``
+      - ``$START`` and ``$END`` are valid port values, as decimal integers.
+    * - :rspan:`2` Destination port
+      - :rspan:`2` ``udp.dport``
       - ``eq``
       - :rspan:`1` ``$PORT``
+      - :rspan:`1` ``$PORT`` is a valid port value, as a decimal integer.
     * - ``not``
+    * - ``range``
+      - ``$START-$END``
+      - ``$START`` and ``$END`` are valid port values, as decimal integers.

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -117,10 +117,14 @@ ip6\.(s|d)addr      { BEGIN(STATE_MATCHER_IP6_ADDR); yylval.sval = strdup(yytext
 tcp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_PORT>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|not|range) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     (\!)?[0-9]+ {
         yylval.sval = strdup(yytext);
         return MATCHER_PORT;
+    }
+    [0-9]+-[0-9]+ {
+        yylval.sval = strdup(yytext);
+        return MATCHER_PORT_RANGE;
     }
 }
 

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -80,9 +80,10 @@
 %token COUNTER
 %token <sval> HOOK_OPT
 %token <sval> MATCHER_META_IFINDEX  MATCHER_META_L3_PROTO MATCHER_META_L4_PROTO
-%token <sval> MATCHER_IP_PROTO MATCHER_IPADDR MATCHER_PORT
+%token <sval> MATCHER_IP_PROTO MATCHER_IPADDR
 %token <sval> MATCHER_IP_ADDR_SET
 %token <sval> MATCHER_IP6_ADDR
+%token <sval> MATCHER_PORT MATCHER_PORT_RANGE
 %token <sval> STRING
 %token <sval> HOOK VERDICT MATCHER_TYPE MATCHER_OP MATCHER_TCP_FLAGS
 
@@ -490,6 +491,34 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                     free($3);
 
                     if (bf_matcher_new(&matcher, $1, $2, &port, sizeof(port)))
+                        bf_parse_err("failed to create new matcher\n");
+
+                    $$ = TAKE_PTR(matcher);
+                }
+                | matcher_type matcher_op MATCHER_PORT_RANGE
+                {
+                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    long raw_val;
+                    char *end_port_str;
+                    uint16_t ports[2];
+
+                    end_port_str = strchr($3, '-');
+                    *end_port_str = '\0';
+                    ++end_port_str;
+
+                    raw_val = atol($3);
+                    if (raw_val < 0 || USHRT_MAX < raw_val)
+                        bf_parse_err("invalid port value: %s\n", $3);
+                    ports[0] = (uint16_t)raw_val;
+
+                    raw_val = atol(end_port_str);
+                    if (raw_val < 0 || USHRT_MAX < raw_val)
+                        bf_parse_err("invalid port value: %s\n", end_port_str);
+                    ports[1] = (uint16_t)raw_val;
+
+                    free($3);
+
+                    if (bf_matcher_new(&matcher, $1, $2, ports, sizeof(ports)))
                         bf_parse_err("failed to create new matcher\n");
 
                     $$ = TAKE_PTR(matcher);

--- a/src/bpfilter/cgen/matcher/udp.c
+++ b/src/bpfilter/cgen/matcher/udp.c
@@ -25,15 +25,32 @@
 static int _bf_matcher_generate_udp_port(struct bf_program *program,
                                          const struct bf_matcher *matcher)
 {
-    uint16_t port = *(uint16_t *)&matcher->payload;
+    uint16_t *port = (uint16_t *)&matcher->payload;
     size_t offset = matcher->type == BF_MATCHER_UDP_SPORT ?
                         offsetof(struct udphdr, source) :
                         offsetof(struct udphdr, dest);
 
     EMIT(program, BPF_LDX_MEM(BPF_H, BF_REG_4, BF_REG_L4, offset));
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program, BPF_JMP_IMM(matcher->op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ,
-                             BF_REG_4, htobe16(port), 0));
+
+    switch (matcher->op) {
+    case BF_MATCHER_EQ:
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP_IMM(BPF_JNE, BF_REG_4, htobe16(*port), 0));
+        break;
+    case BF_MATCHER_NE:
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP_IMM(BPF_JEQ, BF_REG_4, htobe16(*port), 0));
+        break;
+    case BF_MATCHER_RANGE:
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP_IMM(BPF_JLT, BF_REG_4, htobe16(port[0]), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP_IMM(BPF_JGT, BF_REG_4, htobe16(port[1]), 0));
+        break;
+    default:
+        return bf_err_r(-EINVAL, "unknown matcher operator '%s' (%d)",
+                        bf_matcher_op_to_str(matcher->op), matcher->op);
+    }
 
     return 0;
 }

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -173,8 +173,9 @@ int bf_matcher_type_from_str(const char *str, enum bf_matcher_type *type)
 }
 
 static const char *_bf_matcher_ops_strs[] = {
-    [BF_MATCHER_EQ] = "eq",   [BF_MATCHER_NE] = "not", [BF_MATCHER_ANY] = "any",
-    [BF_MATCHER_ALL] = "all", [BF_MATCHER_IN] = "in",
+    [BF_MATCHER_EQ] = "eq",   [BF_MATCHER_NE] = "not",
+    [BF_MATCHER_ANY] = "any", [BF_MATCHER_ALL] = "all",
+    [BF_MATCHER_IN] = "in",   [BF_MATCHER_RANGE] = "range",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_ops_strs) == _BF_MATCHER_OP_MAX);

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -126,6 +126,8 @@ enum bf_matcher_op
     BF_MATCHER_ALL,
     /// Test if the value is in a set
     BF_MATCHER_IN,
+    /// Test if the value is in a range
+    BF_MATCHER_RANGE,
     _BF_MATCHER_OP_MAX,
 };
 

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -52,6 +52,13 @@ chain BF_HOOK_XDP{attach=no,ifindex=2,name=my_xdp_program} policy ACCEPT
         udp.dport 22
         counter
         ACCEPT
+    rule
+        tcp.sport 0-9
+        tcp.dport 10-19
+        udp.sport 20-29
+        udp.dport 30-39
+        counter
+        ACCEPT
 
 # Create a TC chain
 chain BF_HOOK_TC_INGRESS{attach=yes,ifindex=2} policy ACCEPT
@@ -95,6 +102,13 @@ chain BF_HOOK_TC_INGRESS{attach=yes,ifindex=2} policy ACCEPT
         udp.dport 22
         counter
         ACCEPT
+    rule
+        tcp.sport 0-9
+        tcp.dport 10-19
+        udp.sport 20-29
+        udp.dport 30-39
+        counter
+        ACCEPT
 
 # Create a BPF_NETFILTER chain
 chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
@@ -136,6 +150,13 @@ chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
         ACCEPT
     rule
         udp.dport 22
+        counter
+        ACCEPT
+    rule
+        tcp.sport 0-9
+        tcp.dport 10-19
+        udp.sport 20-29
+        udp.dport 30-39
         counter
         ACCEPT
 
@@ -191,5 +212,12 @@ chain BF_HOOK_CGROUP_INGRESS{cgroup=/sys/fs/cgroup/user.slice} policy ACCEPT
         ACCEPT
     rule
         udp.dport 22
+        counter
+        ACCEPT
+    rule
+        tcp.sport 0-9
+        tcp.dport 10-19
+        udp.sport 20-29
+        udp.dport 30-39
         counter
         ACCEPT


### PR DESCRIPTION
Add a new matcher operator for ranges used as `$START-$END` and add support for it for TCP and UDP port (source and destination).