### PR TITLE
Add CONTINUE verdict

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -56,7 +56,7 @@ With:
     - ``BF_HOOK_NF_POST_ROUTING``: similar to ``nftables`` and ``iptables`` postrouting hook.
     - ``BF_HOOK_TC_EGRESS``: egress TC hook.
 
-  - ``$POLICY``: action taken if no rule matches the packet, either ``ACCEPT`` forward the packet to the kernel, or ``DROP`` to discard it.
+  - ``$POLICY``: action taken if no rule matches the packet, either ``ACCEPT`` forward the packet to the kernel, or ``DROP`` to discard it. Note while ``CONTINUE`` is a valid verdict for rules, it is not supported for chain policy.
 
 ``$OPTIONS`` are hook-specific comma separated key value pairs:
 
@@ -101,9 +101,14 @@ Rules are defined such as:
 With:
   - ``$MATCHER``: zero or more matchers. Matchers are defined later.
   - ``counter``: optional literal. If set, the filter will counter the number of packets and bytes matched by the rule.
-  - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT`` or ``DROP``.
+  - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP`` or ``CONTINUE``.
+    - ``ACCEPT``: forward the packet to the kernel
+    - ``DROP``: discard the packet.
+    - ``CONTINUE``: continue processing subsequent rules.
 
-In a chain, as soon as a rule matches a packet, its verdict is applied, and the subsequent rules are not processed. Hence, the rules' order matters. If no rule matches the packet, the chain's policy is applied.
+In a chain, as soon as a rule matches a packet, its verdict is applied. If the verdict is ``ACCEPT`` or ``DROP``, the subsequent rules are not processed. Hence, the rules' order matters. If no rule matches the packet, the chain's policy is applied.
+
+Note ``CONTINUE`` means a packet can be counted more than once if multiple rules specify ``CONTINUE`` and ``counter``.
 
 
 Matchers

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -49,7 +49,7 @@ BF_HOOK_[A-Z_]+ { BEGIN(STATE_HOOK_OPTS); yylval.sval = strdup(yytext); return H
     }
 }
     /* Verdicts */
-(ACCEPT|DROP)   { yylval.sval = strdup(yytext); return VERDICT; }
+(ACCEPT|DROP|CONTINUE)   { yylval.sval = strdup(yytext); return VERDICT; }
 
     /* Matcher types */
 meta\.ifindex  { BEGIN(STATE_MATCHER_META_IFINDEX); yylval.sval = strdup(yytext); return MATCHER_TYPE; }

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -139,6 +139,9 @@ chain           : CHAIN hook raw_hook_opts POLICY verdict rules
                     _cleanup_bf_list_ bf_list *raw_hook_opts = $3;
                     _cleanup_bf_list_ bf_list *rules = $6;
 
+                    if ($5 >= _BF_TERMINAL_VERDICT_MAX)
+                        bf_parse_err("'%s' is not supported for chains\n", bf_verdict_to_str($5));
+
                     if (bf_chain_new(&chain, $2, $5, &ruleset->sets, rules) < 0)
                         bf_parse_err("failed to create a new bf_chain\n");
 
@@ -173,11 +176,11 @@ hook            : HOOK
 
 raw_hook_opts   : %empty { $$ = NULL; }
                 | raw_hook_opts HOOK_OPT
-                { 
+                {
                     _cleanup_bf_list_ bf_list *list = $1;
 
                     if (bf_list_add_tail(list, $2) < 0)
-                        bf_parse_err("failed to insert raw hook options '%s' in list", $2);                     
+                        bf_parse_err("failed to insert raw hook options '%s' in list", $2);
 
                     $$ = TAKE_PTR(list);
                 }

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -153,14 +153,14 @@ static int _bf_cgroup_gen_inline_epilogue(struct bf_program *program)
  */
 static int _bf_cgroup_get_verdict(enum bf_verdict verdict)
 {
-    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+    bf_assert(0 <= verdict && verdict < _BF_TERMINAL_VERDICT_MAX);
 
     static const int verdicts[] = {
         [BF_VERDICT_ACCEPT] = 1,
         [BF_VERDICT_DROP] = 0,
     };
 
-    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+    static_assert(ARRAY_SIZE(verdicts) == _BF_TERMINAL_VERDICT_MAX);
 
     return verdicts[verdict];
 }

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -171,14 +171,14 @@ static int _bf_nf_gen_inline_epilogue(struct bf_program *program)
  */
 static int _bf_nf_get_verdict(enum bf_verdict verdict)
 {
-    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+    bf_assert(0 <= verdict && verdict < _BF_TERMINAL_VERDICT_MAX);
 
     static const int verdicts[] = {
         [BF_VERDICT_ACCEPT] = NF_ACCEPT,
         [BF_VERDICT_DROP] = NF_DROP,
     };
 
-    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+    static_assert(ARRAY_SIZE(verdicts) == _BF_TERMINAL_VERDICT_MAX);
 
     return verdicts[verdict];
 }

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -592,9 +592,22 @@ static int _bf_program_generate_rule(struct bf_program *program,
         EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
     }
 
-    EMIT(program, BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
-                                                rule->verdict)));
-    EMIT(program, BPF_EXIT_INSN());
+    switch (rule->verdict) {
+        case BF_VERDICT_ACCEPT:
+        case BF_VERDICT_DROP:
+            EMIT(program, BPF_MOV64_IMM(BF_REG_RET, program->runtime.ops->get_verdict(
+                                                        rule->verdict)));
+            EMIT(program, BPF_EXIT_INSN());
+            break;
+        case BF_VERDICT_CONTINUE:
+            // Fall through to next rule or default chain policy.
+            break;
+        default:
+            bf_abort(
+                "unsupported verdict, this should not happen: %d",
+                rule->verdict);
+            break;
+    }
 
     r = _bf_program_fixup(program, BF_FIXUP_TYPE_JMP_NEXT_RULE);
     if (r)

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -109,14 +109,14 @@ static int _bf_tc_gen_inline_epilogue(struct bf_program *program)
  */
 static int _bf_tc_get_verdict(enum bf_verdict verdict)
 {
-    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+    bf_assert(0 <= verdict && verdict < _BF_TERMINAL_VERDICT_MAX);
 
     static const int verdicts[] = {
         [BF_VERDICT_ACCEPT] = TC_ACT_OK,
         [BF_VERDICT_DROP] = TC_ACT_SHOT,
     };
 
-    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+    static_assert(ARRAY_SIZE(verdicts) == _BF_TERMINAL_VERDICT_MAX);
 
     return verdicts[verdict];
 }

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -105,14 +105,14 @@ static int _bf_xdp_gen_inline_epilogue(struct bf_program *program)
 
 static int _bf_xdp_get_verdict(enum bf_verdict verdict)
 {
-    bf_assert(0 <= verdict && verdict < _BF_VERDICT_MAX);
+    bf_assert(0 <= verdict && verdict < _BF_TERMINAL_VERDICT_MAX);
 
     static const int verdicts[] = {
         [BF_VERDICT_ACCEPT] = XDP_PASS,
         [BF_VERDICT_DROP] = XDP_DROP,
     };
 
-    static_assert(ARRAY_SIZE(verdicts) == _BF_VERDICT_MAX);
+    static_assert(ARRAY_SIZE(verdicts) == _BF_TERMINAL_VERDICT_MAX);
 
     return verdicts[verdict];
 }

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -26,6 +26,7 @@ int bf_chain_new(struct bf_chain **chain, enum bf_hook hook,
     int r;
 
     bf_assert(chain);
+    bf_assert(0 <= policy && policy < _BF_TERMINAL_VERDICT_MAX);
 
     _chain = malloc(sizeof(*_chain));
     if (!_chain)

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -83,6 +83,14 @@ struct bf_flavor_ops
     int (*gen_inline_prologue)(struct bf_program *program);
 
     int (*gen_inline_epilogue)(struct bf_program *program);
+
+    /**
+     * Generates a flavor-specific return code corresponding to the verdict.
+     *
+     * Note this function only needs to handle terminal verdicts - verdicts that
+     * stop further packet processing. Non-terminal verdicts do not need return
+     * codes and therefore do not need to be handled by get_verdict().
+     */
     int (*get_verdict)(enum bf_verdict verdict);
 
     /**

--- a/src/core/verdict.c
+++ b/src/core/verdict.c
@@ -12,6 +12,7 @@
 static const char *_bf_verdict_strs[] = {
     [BF_VERDICT_ACCEPT] = "ACCEPT",
     [BF_VERDICT_DROP] = "DROP",
+    [BF_VERDICT_CONTINUE] = "CONTINUE",
 };
 
 static_assert(ARRAY_SIZE(_bf_verdict_strs) == _BF_VERDICT_MAX,

--- a/src/core/verdict.h
+++ b/src/core/verdict.h
@@ -7,14 +7,20 @@
 
 /**
  * Verdict to apply for a rule or chain.
+ * Chains can only use terminal verdicts, rules can use all verdicts.
  */
 enum bf_verdict
 {
+    /** Terminal verdicts that stop further packet processing. */
     /** Accept the packet. */
     BF_VERDICT_ACCEPT,
     /** Drop the packet. */
     BF_VERDICT_DROP,
+    /** Non-terminal verdicts that allow further packet processing. */
+    /** Continue processing the next rule. */
+    BF_VERDICT_CONTINUE,
     _BF_VERDICT_MAX,
+    _BF_TERMINAL_VERDICT_MAX = BF_VERDICT_CONTINUE,
 };
 
 /**

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -3,6 +3,10 @@ chain BF_HOOK_XDP{attach=no,ifindex=2,name=my_xdp_program} policy ACCEPT
     rule
         meta.ifindex 1
         counter
+        CONTINUE
+    rule
+        meta.ifindex 1
+        counter
         ACCEPT
     rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
@@ -65,6 +69,10 @@ chain BF_HOOK_TC_INGRESS{attach=yes,ifindex=2} policy ACCEPT
     rule
         meta.ifindex 1
         counter
+        CONTINUE
+    rule
+        meta.ifindex 1
+        counter
         ACCEPT
     rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
@@ -115,6 +123,10 @@ chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
     rule
         meta.ifindex 1
         counter
+        CONTINUE
+    rule
+        meta.ifindex 1
+        counter
         ACCEPT
     rule
         ip4.saddr in {192.168.1.131,192.168.1.132}
@@ -162,6 +174,10 @@ chain BF_HOOK_NF_LOCAL_IN policy ACCEPT
 
 # Create a cgroup chain
 chain BF_HOOK_CGROUP_INGRESS{cgroup=/sys/fs/cgroup/user.slice} policy ACCEPT
+    rule
+        meta.ifindex 1
+        counter
+        CONTINUE
     rule
         meta.ifindex 1
         counter

--- a/tests/unit/src/bpfilter/cgen/cgen.c
+++ b/tests/unit/src/bpfilter/cgen/cgen.c
@@ -15,7 +15,7 @@ Test(cgen, create_delete_assert)
 
     expect_assert_failure(bf_cgen_new(NULL, BF_FRONT_CLI, NOT_NULL));
     expect_assert_failure(bf_cgen_new(NOT_NULL, BF_FRONT_CLI, NULL));
-    expect_assert_failure(bf_cgen_new(NOT_NULL, BF_FRONT_CLI, &no_chain));  
+    expect_assert_failure(bf_cgen_new(NOT_NULL, BF_FRONT_CLI, &no_chain));
     expect_assert_failure(bf_cgen_free(NULL));
 }
 
@@ -55,7 +55,7 @@ Test(cgen, create_delete)
 
 Test(cgen, create_delete_no_malloc)
 {
-    _cleanup_bf_mock_ bf_mock mock; 
+    _cleanup_bf_mock_ bf_mock mock;
     struct bf_cgen *cgen;
     _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
 
@@ -69,7 +69,7 @@ Test(cgen, marsh_unmarsh_assert)
     expect_assert_failure(bf_cgen_new_from_marsh(NOT_NULL, NULL));
     expect_assert_failure(bf_cgen_marsh(NULL, NOT_NULL));
     expect_assert_failure(bf_cgen_marsh(NOT_NULL, NULL));
-} 
+}
 
 Test(cgen, marsh_unmarsh)
 {
@@ -79,10 +79,15 @@ Test(cgen, marsh_unmarsh)
 
     /* Create a codegen without any program, other bf_program_unmarsh()
      * will try to open the pinned BPF objects.
-     */ 
+     */
     cgen0 = bf_test_cgen(BF_FRONT_CLI, BF_HOOK_XDP, BF_VERDICT_ACCEPT);
 
     assert_success(bf_cgen_marsh(cgen0, &marsh));
     assert_success(bf_cgen_new_from_marsh(&cgen1, marsh));
     assert_non_null(cgen1);
+}
+
+Test(cgen, invalid_chain_policy)
+{
+    expect_assert_failure(bf_test_chain(BF_HOOK_XDP, BF_VERDICT_CONTINUE));
 }


### PR DESCRIPTION
This PR adds a CONTINUE verdict for rules s.t. a rule can match and continue processing. This allows multiple rules to match and count a packet.

Note CONTINUE is not supported for chains as there is no nesting of chains and one cannot jump between BPF programs.