### PR TITLE
Add support for ad-hoc benchmarks

### DIFF
--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -128,6 +128,10 @@ int main(int argc, char *argv[])
         r = _bf_cli_parse_file(_bf_opts.input_file, &ruleset);
     else
         r = _bf_cli_parse_str(_bf_opts.input_string, &ruleset);
+    if (r) {
+        bf_err_r(r, "failed to parse ruleset");
+        goto end_clean;
+    }
 
     // Set rules indexes
     bf_list_foreach (&ruleset.chains, chain_node) {
@@ -148,14 +152,14 @@ int main(int argc, char *argv[])
 
         r = bf_chain_marsh(chain, &marsh);
         if (r) {
-            bf_err_r(r, "failed to marsh chain, skipping");
-            continue;
+            bf_err_r(r, "failed to marsh chain");
+            goto end_clean;
         }
 
         r = bf_request_new(&request, marsh, bf_marsh_size(marsh));
         if (r) {
-            bf_err_r(r, "failed to create request for chain, skipping");
-            continue;
+            bf_err_r(r, "failed to create request for chain");
+            goto end_clean;
         }
 
         request->front = BF_FRONT_CLI;
@@ -163,13 +167,13 @@ int main(int argc, char *argv[])
 
         r = bf_send(request, &response);
         if (r) {
-            bf_err_r(r, "failed to send chain creation request, skipping");
-            continue;
+            bf_err_r(r, "failed to send chain creation request");
+            goto end_clean;
         }
 
         if (response->type == BF_RES_FAILURE) {
             bf_err_r(response->error, "chain creation request failed");
-            continue;
+            goto end_clean;
         }
     }
 

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -179,7 +179,7 @@ int setFdNonBlock(Fd &fd)
     ::std::string data;
 
     while ((len = read(fd.get(), buffer.data(), buffer.size())) >= 0)
-        data += ::std::string(::std::begin(buffer), ::std::end(buffer));
+        data += ::std::string(::std::begin(buffer), len);
 
     if (len < 0 && errno != EAGAIN)
         err("failed to read from file descriptor: {}", errStr(errno));
@@ -790,8 +790,8 @@ int Chain::apply()
     const ::std::vector<::std::string> args {"--str", chain};
 
     const auto [r, out, err] = run(bin_, args);
-    if (r < 0) {
-        err("failed to exec '{}': {}\nError logs: {}", bin_, errStr(r), err);
+    if (r != 0) {
+        abort("failed to exec '{}': {}\nError logs: {}", bin_, r, err);
         return r;
     }
 

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -80,6 +80,9 @@ public:
     ::std::string srcdir = ".";
     ::std::string outfile = "results.json";
     ::std::string gitrev = "<unknown>";
+    ::std::optional<::std::string> adhoc = "";
+    int adhocRepeat = 1;
+    const ::std::string adhocBenchName = "bf_adhoc";
     int64_t gitdate = 0;
 
     Config() noexcept = default;

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -78,5 +78,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    ::benchmark::Shutdown();
+
     return 0;
 }


### PR DESCRIPTION
Update the benchmark's command line options to support ad-hoc benchmark to be run. Ad-hoc benchmark allows users to define a filtering rule from the command line and benchmark the generated BPF program. The predefined benchmarks defined in `tests/benchmark/main.cpp` will be skipped.