### PR TITLE
A few fixes to `libbpfilter`, `bpfilter`, and `bfcli`

### DIFF
--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -42,7 +42,7 @@ counter         { return COUNTER; }
     /* Hooks */
 BF_HOOK_[A-Z_]+ { BEGIN(STATE_HOOK_OPTS); yylval.sval = strdup(yytext); return HOOK; }
 <STATE_HOOK_OPTS>{
-    (\{|\}) /* Ignore */
+    (\{|\}|,) /* Ignore */
     [a-zA-Z0-9_]+=[a-zA-Z0-9_\-\.\/]+ {
         yylval.sval = strdup(yytext);
         return HOOK_OPT;

--- a/src/bpfilter/cgen/dump.c
+++ b/src/bpfilter/cgen/dump.c
@@ -112,6 +112,7 @@ void bf_program_dump_bytecode(const struct bf_program *program)
 
         if (double_insn) {
             double_insn = false;
+            ++bfdd.idx;
             continue;
         }
 

--- a/src/libbpfilter/generic.c
+++ b/src/libbpfilter/generic.c
@@ -35,11 +35,11 @@ int bf_send(const struct bf_request *request, struct bf_response **response)
 
     r = bf_send_request(fd, request);
     if (r < 0)
-        return bf_err(errno, "bpfilter: failed to send request to the daemon");
+        return bf_err(r, "bpfilter: failed to send request to the daemon");
 
     r = bf_recv_response(fd, response);
     if (r < 0) {
-        return bf_err(errno,
+        return bf_err(r,
                       "bpfilter: failed to receive response from the daemon");
     }
 


### PR DESCRIPTION
- Return the error code when `bf_send()` fails.
- Ignore commas in chain options list.
- Count double instructions as two instructions to ensure the counter is accurate.