### PR TITLE
cgen: add an error counter

### DIFF
--- a/src/bpfilter/cgen/cgen.h
+++ b/src/bpfilter/cgen/cgen.h
@@ -128,11 +128,21 @@ int bf_cgen_unload(struct bf_cgen *cgen);
 void bf_cgen_dump(const struct bf_cgen *cgen, prefix_t *prefix);
 
 /**
+ * @enum bf_counter_type
+ *
+ * Special counter types for @ref bf_cgen_get_counter .
+ */
+enum bf_counter_type
+{
+    BF_COUNTER_POLICY = -1,
+    BF_COUNTER_ERRORS = -2,
+};
+
+/**
  * Get packets and bytes counter at a specific index.
  *
- * Counters are referenced by their index in the counters map. There are 1 more
- * counter in the map than the number of rules. This last counter (the last in
- * the map) is dedicated to the policy.
+ * Counters are referenced by their index in the counters map or the enum
+ * values defined by @ref bf_counter_type .
  *
  * The counter from all the program generated from @p cgen are summarised
  * together.
@@ -142,7 +152,8 @@ void bf_cgen_dump(const struct bf_cgen *cgen, prefix_t *prefix);
  *        correspond to a valid index, -E2BIG is returned.
  * @param counter Counter structure to fill with the counter values. Can't be
  *        NULL.
- * @return 0 on success, or a negative errno  value on failure.
+ * @return 0 on success, or a negative errno value on failure.
  */
-int bf_cgen_get_counter(const struct bf_cgen *cgen, uint32_t counter_idx,
+int bf_cgen_get_counter(const struct bf_cgen *cgen,
+                        enum bf_counter_type counter_idx,
                         struct bf_counter *counter);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -891,6 +891,11 @@ int bf_program_generate(struct bf_program *program)
             bf_flavor_to_str(bf_hook_to_flavor(program->hook)),
             bf_front_to_str(program->front), bf_hook_to_str(program->hook));
 
+    /* Add 1 to the number of counters for the policy counter, and 1
+     * for the first reserved error slot. This must be done ahead of
+     * generation, as we will index into the error counters. */
+    program->num_counters = bf_list_size(&chain->rules) + 2;
+
     r = _bf_program_generate_runtime_init(program);
     if (r)
         return r;
@@ -935,9 +940,6 @@ int bf_program_generate(struct bf_program *program)
     r = _bf_program_fixup(program, BF_FIXUP_TYPE_FUNC_CALL);
     if (r)
         return bf_err_r(r, "failed to generate function call fixups");
-
-    // Add 1 to the number of counters for the policy counter.
-    program->num_counters = bf_list_size(&chain->rules) + 1;
 
     return 0;
 }

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -19,6 +19,7 @@
 #include <endian.h>
 #include <stddef.h>
 
+#include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/jmp.h"
 #include "bpfilter/cgen/printer.h"
 #include "bpfilter/cgen/program.h"
@@ -66,6 +67,15 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program,
     {
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_2, 0, 0));
+
+        // BF_ARG_1: index in counters map (last slot).
+        EMIT(program, BPF_MOV32_IMM(BF_ARG_1, program->num_counters - 1));
+
+        // BF_ARG_2: packet size, from the context.
+        EMIT(program, BPF_LDX_MEM(BPF_DW, BF_ARG_2, BF_REG_CTX,
+                                  BF_PROG_CTX_OFF(pkt_size)));
+
+        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create a new dynamic pointer");
@@ -116,6 +126,15 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
     {
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
+
+        // BF_ARG_1: index in counters map (last slot).
+        EMIT(program, BPF_MOV32_IMM(BF_ARG_1, program->num_counters - 1));
+
+        // BF_ARG_2: packet size, from the context.
+        EMIT(program, BPF_LDX_MEM(BPF_DW, BF_ARG_2, BF_REG_CTX,
+                                  BF_PROG_CTX_OFF(pkt_size)));
+
+        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L2 dynamic pointer slice");
@@ -191,6 +210,15 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
     {
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
+
+        // BF_ARG_1: index in counters map (last slot).
+        EMIT(program, BPF_MOV32_IMM(BF_ARG_1, program->num_counters - 1));
+
+        // BF_ARG_2: packet size, from the context.
+        EMIT(program, BPF_LDX_MEM(BPF_DW, BF_ARG_2, BF_REG_CTX,
+                                  BF_PROG_CTX_OFF(pkt_size)));
+
+        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L3 dynamic pointer slice");
@@ -295,6 +323,15 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
     {
         _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BF_REG_RET, 0, 0));
+
+        // BF_ARG_1: index in counters map (last slot).
+        EMIT(program, BPF_MOV32_IMM(BF_ARG_1, program->num_counters - 1));
+
+        // BF_ARG_2: packet size, from the context.
+        EMIT(program, BPF_LDX_MEM(BPF_DW, BF_ARG_2, BF_REG_CTX,
+                                  BF_PROG_CTX_OFF(pkt_size)));
+
+        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L4 dynamic pointer slice");


### PR DESCRIPTION
For kfunc call errors, add a dedicated counter that can be read by the daemon in the future. This counter is exposed implicitly as a named counter object ("errors") via `nft`.

Fixes #105