### PR TITLE
Refactor testing harness

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -36,8 +36,8 @@
 #]]
 
 file(GLOB_RECURSE bf_srcs
-	${CMAKE_SOURCE_DIR}/src/*.c
-	${CMAKE_SOURCE_DIR}/src/*.h
+	${CMAKE_SOURCE_DIR}/src/*.h 			${CMAKE_SOURCE_DIR}/src/*.c
+	${CMAKE_SOURCE_DIR}/tests/harness/*.h	${CMAKE_SOURCE_DIR}/tests/harness/*.c
 )
 
 # Remove src/external/.* files from the list of sources
@@ -54,6 +54,7 @@ set(doc_srcs
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/generation.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/packets_processing.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/style.rst
+	${CMAKE_CURRENT_SOURCE_DIR}/developers/tests.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/bpfilter.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/fronts/index.rst

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2,8 +2,8 @@
 PROJECT_NAME            = "@PROJECT_NAME@"
 PROJECT_BRIEF           = An eBPF-based packet filtering framework
 OUTPUT_DIRECTORY        = "@CMAKE_CURRENT_BINARY_DIR@"
-STRIP_FROM_PATH         = "@CMAKE_SOURCE_DIR@/src"
-STRIP_FROM_INC_PATH     = "@CMAKE_SOURCE_DIR@/src"
+STRIP_FROM_PATH         = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests"
+STRIP_FROM_INC_PATH     = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests"
 OPTIMIZE_OUTPUT_FOR_C   = YES
 AUTOLINK_SUPPORT        = YES
 IDL_PROPERTY_SUPPORT    = NO
@@ -28,7 +28,7 @@ WARN_AS_ERROR           = FAIL_ON_WARNINGS_PRINT
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                   = "@CMAKE_SOURCE_DIR@/src"
+INPUT                   = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests/harness"
 EXCLUDE                 = "@CMAKE_SOURCE_DIR@/src/external"
 FILE_PATTERNS           = *.c \
                           *.h
@@ -54,7 +54,7 @@ GENERATE_PERLMOD        = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
-INCLUDE_PATH            = "@CMAKE_SOURCE_DIR@/src"
+INCLUDE_PATH            = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests"
 
 #---------------------------------------------------------------------------
 # Configuration options related to diagram generator tools

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -14,6 +14,10 @@ Daemon
 ~~~~~~~
 .. doxygenfile:: daemon.h
 
+Filters
+~~~~~~~
+.. doxygenfile:: filters.h
+
 
 Unit tests
 ----------

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -1,0 +1,35 @@
+Tests
+=====
+
+Test harness
+------------
+
+The test harness is a set of convenience functions used to ease testing of ``bpfilter``.
+
+Process
+~~~~~~~
+.. doxygenfile:: process.h
+
+
+Unit tests
+----------
+
+.. warning::
+
+    In progress.
+
+
+End-to-end tests
+----------------
+
+.. warning::
+
+    In progress.
+
+
+Benchmarking
+------------
+
+.. warning::
+
+    In progress.

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -10,6 +10,10 @@ Process
 ~~~~~~~
 .. doxygenfile:: process.h
 
+Daemon
+~~~~~~~
+.. doxygenfile:: daemon.h
+
 
 Unit tests
 ----------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,6 +16,7 @@
 
    developers/build
    developers/style
+   developers/tests
    developers/packets_processing
    developers/generation
    developers/modules/index

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
+add_subdirectory(harness)
 add_subdirectory(benchmark)
 add_subdirectory(unit)
 add_subdirectory(integration)
@@ -13,6 +14,7 @@ file(GLOB_RECURSE bf_srcs
     ${CMAKE_SOURCE_DIR}/src/bpfilter/*.h        ${CMAKE_SOURCE_DIR}/src/bpfilter/*.c
     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
     ${CMAKE_SOURCE_DIR}/src/bfcli/*.h           ${CMAKE_SOURCE_DIR}/src/bfcli/*.c
+    ${CMAKE_SOURCE_DIR}/tests/harness/*.h       ${CMAKE_SOURCE_DIR}/tests/harness/*.c
 )
 
 add_custom_command(

--- a/tests/harness/CMakeLists.txt
+++ b/tests/harness/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 add_library(harness
     OBJECT
+        ${CMAKE_CURRENT_SOURCE_DIR}/daemon.h    ${CMAKE_CURRENT_SOURCE_DIR}/daemon.c
         ${CMAKE_CURRENT_SOURCE_DIR}/process.h   ${CMAKE_CURRENT_SOURCE_DIR}/process.c
 )
 

--- a/tests/harness/CMakeLists.txt
+++ b/tests/harness/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+
+add_library(harness
+    OBJECT
+        ${CMAKE_CURRENT_SOURCE_DIR}/process.h   ${CMAKE_CURRENT_SOURCE_DIR}/process.c
+)
+
+target_include_directories(harness
+    PUBLIC
+        ${CMAKE_SOURCE_DIR}/tests
+)
+
+target_link_libraries(harness
+    PUBLIC
+        bf_global_flags
+        core
+)

--- a/tests/harness/CMakeLists.txt
+++ b/tests/harness/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_library(harness
     OBJECT
         ${CMAKE_CURRENT_SOURCE_DIR}/daemon.h    ${CMAKE_CURRENT_SOURCE_DIR}/daemon.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/filters.h    ${CMAKE_CURRENT_SOURCE_DIR}/filters.c
         ${CMAKE_CURRENT_SOURCE_DIR}/process.h   ${CMAKE_CURRENT_SOURCE_DIR}/process.c
 )
 

--- a/tests/harness/daemon.c
+++ b/tests/harness/daemon.c
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "harness/daemon.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "core/helper.h"
+#include "core/logger.h"
+#include "harness/process.h"
+
+#define _BF_DAEMON_START_TIMEOUT 5
+#define _BF_DAEMON_START_SLEEP 100000
+
+int bf_test_daemon_init(struct bf_test_daemon *daemon, const char *path,
+                        uint32_t options)
+{
+    char *args[__builtin_ctz(_BF_TEST_DAEMON_LAST) + 1] = {};
+    size_t nargs = 0;
+
+    bf_assert(daemon);
+
+    if (options & BF_TEST_DAEMON_TRANSIENT)
+        args[nargs++] = "--transient";
+    if (options & BF_TEST_DAEMON_NO_CLI)
+        args[nargs++] = "--no-cli";
+    if (options & BF_TEST_DAEMON_NO_IPTABLES)
+        args[nargs++] = "--no-iptables";
+    if (options & BF_TEST_DAEMON_NO_NFTABLES)
+        args[nargs++] = "--no-nftables";
+
+    return bf_test_process_init(&daemon->process, path, args, nargs);
+}
+
+void bf_test_daemon_clean(struct bf_test_daemon *daemon)
+{
+    bf_assert(daemon);
+
+    bf_test_process_clean(&daemon->process);
+}
+
+int bf_test_daemon_start(struct bf_test_daemon *daemon)
+{
+    clock_t begin;
+    int r;
+
+    bf_assert(daemon);
+
+    r = bf_test_process_start(&daemon->process);
+    if (r < 0)
+        return bf_err_r(r, "failed to start bpfilter daemon");
+
+    begin = clock();
+    while (true) {
+        _cleanup_free_ const char *err_buf = NULL;
+        int status;
+
+        r = waitpid(daemon->process.pid, &status, WNOHANG);
+        if (r < 0)
+            return bf_err_r(r, "waitpid() failed on bpfilter process");
+        if (r != 0) {
+            err_buf = bf_test_process_stderr(&daemon->process);
+            return bf_err_r(-ENOENT, "bpfilter process seems to be dead:\n%s\n",
+                            err_buf);
+        }
+
+        err_buf = bf_test_process_stderr(&daemon->process);
+        if (err_buf && strstr(err_buf, "waiting for requests..."))
+            break;
+
+        if ((clock() - begin) / CLOCKS_PER_SEC > _BF_DAEMON_START_TIMEOUT) {
+            kill(daemon->process.pid, SIGKILL);
+            return bf_err_r(
+                -EIO, "daemon is not showing up after %d seconds, aborting",
+                _BF_DAEMON_START_TIMEOUT);
+        }
+
+        // Wait a bit for the daemon to be ready
+        usleep(_BF_DAEMON_START_SLEEP);
+    }
+
+    return 0;
+}
+
+int bf_test_daemon_stop(struct bf_test_daemon *daemon)
+{
+    int r;
+
+    bf_assert(daemon);
+
+    r = bf_test_process_stop(&daemon->process);
+    if (r < 0)
+        return bf_err_r(r, "failed to stop bpfilter daemon");
+
+    return r;
+}

--- a/tests/harness/daemon.h
+++ b/tests/harness/daemon.h
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "harness/process.h"
+
+/**
+ * @file daemon.h
+ *
+ * bf_test_daemon represents a handle to manage the `bpfilter` daemon. Based
+ * on the primitives defined in `harness/process.h`.
+ */
+
+struct bf_test_daemon
+{
+    struct bf_test_process process;
+};
+
+/**
+ * Options to configure the daemon.
+ *
+ * Not all the options defined for `bpfilter` need to be defined below.
+ */
+enum bf_test_daemon_option
+{
+    BF_TEST_DAEMON_TRANSIENT = 1 << 0,
+    BF_TEST_DAEMON_NO_CLI = 1 << 1,
+    BF_TEST_DAEMON_NO_IPTABLES = 1 << 2,
+    BF_TEST_DAEMON_NO_NFTABLES = 1 << 3,
+    _BF_TEST_DAEMON_LAST = BF_TEST_DAEMON_NO_NFTABLES,
+};
+
+#define _cleanup_bf_test_daemon_                                               \
+    __attribute__((__cleanup__(bf_test_daemon_clean)))
+
+/**
+ * Initialize a new daemon object.
+ *
+ * @note `bf_test_daemon_init()` assumes none of the options defined in
+ * `bf_test_daemon_option` require an argument. If this assumption is erroneous,
+ * the logic used to parse the options need to be modified!
+ *
+ * @param daemon The daemon object to initialize. Can't be `NULL`.
+ * @param path Path to the `bpfilter` binary. If `NULL`, the first `bpfilter`
+ *        binary found in `$PATH` will be used.
+ * @param options Command line options to start the daemon with. See
+ *        `bf_test_daemon_option` for the list of available options.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_test_daemon_init(struct bf_test_daemon *daemon, const char *path,
+                        uint32_t options);
+
+/**
+ * Cleanup a daemon object.
+ *
+ * @param daemon Daemon object to cleanup. Can't be `NULL`.
+ */
+void bf_test_daemon_clean(struct bf_test_daemon *daemon);
+
+/**
+ * Start a daemon process.
+ *
+ * Once the process is started, this function will wait for a specific log
+ * from the daemon to validate the process is up and running (and didn't exit).
+ *
+ * @param daemon Daemon object to start the daemon process for. Can't be `NULL`.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_test_daemon_start(struct bf_test_daemon *daemon);
+
+/**
+ * Stop a daemon process.
+ *
+ * @param daemon Daemon object to stop the daemon process for. Can't be `NULL`.
+ * @return The return code of the daemon process as an integer >= 0 on success,
+ *         or a negative errno value on error.
+ */
+int bf_test_daemon_stop(struct bf_test_daemon *daemon);

--- a/tests/harness/filters.c
+++ b/tests/harness/filters.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "harness/filters.h"
+
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "core/chain.h"
+#include "core/helper.h"
+#include "core/hook.h"
+#include "core/list.h"
+#include "core/logger.h"
+#include "core/matcher.h"
+#include "core/rule.h"
+#include "core/set.h"
+#include "core/verdict.h"
+
+#define _clean_bf_list_ __attribute__((__cleanup__(bf_list_clean)))
+
+struct bf_matcher *bf_matcher_get(enum bf_matcher_type type,
+                                  enum bf_matcher_op op, const void *payload,
+                                  size_t payload_len)
+{
+    struct bf_matcher *matcher = NULL;
+    int r;
+
+    r = bf_matcher_new(&matcher, type, op, payload, payload_len);
+    if (r < 0) {
+        bf_err_r(r, "failed to create a new matcher");
+        return NULL;
+    }
+
+    return matcher;
+}
+
+struct bf_rule *bf_rule_get(bool counters, enum bf_verdict verdict,
+                            struct bf_matcher **matchers)
+{
+    _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+    int r;
+
+    r = bf_rule_new(&rule);
+    if (r < 0) {
+        bf_err_r(r, "failed to create a new rule");
+        goto err_free_matchers;
+    }
+
+    rule->counters = counters;
+    rule->verdict = verdict;
+
+    while (*matchers) {
+        r = bf_list_add_tail(&rule->matchers, *matchers);
+        if (r < 0) {
+            bf_err_r(r, "failed to add matcher to rule");
+            goto err_free_matchers;
+        }
+
+        ++matchers;
+    }
+
+    return TAKE_PTR(rule);
+
+err_free_matchers:
+    while (*matchers)
+        bf_matcher_free(matchers++);
+
+    return NULL;
+}
+
+struct bf_chain *bf_chain_get(enum bf_hook hook, struct bf_hook_opts hook_opts,
+                              enum bf_verdict policy, struct bf_set **sets,
+                              struct bf_rule **rules)
+{
+    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _clean_bf_list_ bf_list sets_list = bf_set_list();
+    _clean_bf_list_ bf_list rules_list = bf_rule_list();
+    int r;
+
+    while (sets && *sets) {
+        r = bf_list_add_tail(&sets_list, *sets);
+        if (r < 0) {
+            bf_err_r(r, "failed to add set to list");
+            goto err_free_arrays;
+        }
+
+        ++sets;
+    }
+
+    while (rules && *rules) {
+        r = bf_list_add_tail(&rules_list, *rules);
+        if (r < 0) {
+            bf_err_r(r, "failed to add rule to list");
+            goto err_free_arrays;
+        }
+
+        ++rules;
+    }
+
+    r = bf_chain_new(&chain, hook, policy, &sets_list, &rules_list);
+    if (r < 0) {
+        bf_err_r(r, "failed to create a new chain");
+        return NULL;
+    }
+
+    chain->hook_opts = hook_opts;
+
+    return TAKE_PTR(chain);
+
+err_free_arrays:
+    while (sets && *sets)
+        bf_set_free(sets++);
+    while (rules && *rules)
+        bf_rule_free(rules++);
+
+    return NULL;
+}

--- a/tests/harness/filters.h
+++ b/tests/harness/filters.h
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+#include "core/chain.h"
+#include "core/hook.h"
+#include "core/matcher.h"
+#include "core/rule.h"
+#include "core/set.h"
+#include "core/verdict.h"
+
+/**
+ * @file filters.h
+ *
+ * Convenience functions to easily create matchers, rules, and chains in order
+ * to test `bpfilter`. Those functions are wrapper around the actual API (i.e.
+ * `bf_matcher_new()`, `bf_rule_new()`, `bf_chain_new()`) which cut corners when
+ * it comes to error handling (e.g. you can't retrieve the actual error code).
+ *
+ * Some wrappers expect `NULL`-terminated array of pointers, they will take
+ * ownership of the pointers and free them if an error occurs during the object
+ * creation. Valid pointers in the array located after a `NULL` entry won't be
+ * processed nor freed, and `asan` will raise an error. See `bf_rule_get()` and
+ * `bf_chain_get()`.
+ */
+
+/**
+ * Create a new matcher.
+ *
+ * See `bf_matcher_new()` for details of the arguments.
+ *
+ * @return 0 on success, or a negative errno value on error.
+ */
+struct bf_matcher *bf_matcher_get(enum bf_matcher_type type,
+                                  enum bf_matcher_op op, const void *payload,
+                                  size_t payload_len);
+
+/**
+ * Create a new rule.
+ *
+ * See `bf_rule_new()` for details of the arguments.
+ *
+ * @return 0 on success, or a negative errno value on error.
+ */
+struct bf_rule *bf_rule_get(bool counters, enum bf_verdict verdict,
+                            struct bf_matcher **matchers);
+
+/**
+ * Create a new chain.
+ *
+ * See `bf_chain_get()` for details of the arguments.
+ *
+ * @return 0 on success, or a negative errno value on error.
+ */
+struct bf_chain *bf_chain_get(enum bf_hook hook, struct bf_hook_opts hook_opts,
+                              enum bf_verdict policy, struct bf_set **sets,
+                              struct bf_rule **rules);

--- a/tests/harness/process.c
+++ b/tests/harness/process.c
@@ -1,0 +1,265 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "harness/process.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "core/helper.h"
+#include "core/logger.h"
+
+int bf_test_process_init(struct bf_test_process *process, const char *cmd,
+                         char **args, size_t nargs)
+{
+    size_t i = 0;
+    int r;
+
+    /* execvp() requires args (its second argument) to contain the binary to
+     * run at index 0, and must end with a NULL pointer. Hence, process->args
+     * contains the command to run, the arguments, and a NULL pointer. */
+    process->nargs = nargs + 2;
+    process->args = (char **)malloc(process->nargs * sizeof(char *));
+    if (!process->args)
+        return bf_err_r(errno, "failed to allocate memory for bf_process.args");
+
+    process->args[0] = strdup(cmd);
+    if (!process->args[0]) {
+        r = bf_err_r(errno, "failed to copy cmd to bf_process.args[0]");
+        goto err_free_args;
+    }
+
+    process->cmd = process->args[0];
+
+    for (i = 1; i < process->nargs - 1; ++i) {
+        process->args[i] = strdup(args[i - 1]);
+        if (!process->args[i]) {
+            r = bf_err_r(errno, "failed to copy process args[%ld]", i);
+            goto err_free_args;
+        }
+    }
+
+    process->args[process->nargs - 1] = NULL;
+
+    process->pid = 0;
+    process->out_fd = -1;
+    process->err_fd = -1;
+
+    return 0;
+
+err_free_args:
+    for (size_t j = 0; j < i; ++j)
+        freep((void *)&process->args[j]);
+    return r;
+}
+
+void bf_test_process_clean(struct bf_test_process *process)
+{
+    if (process->args) {
+        for (size_t i = 0; i < process->nargs; ++i)
+            freep((void *)&process->args[i]);
+    }
+
+    freep((void *)&process->args);
+
+    closep(&process->out_fd);
+    closep(&process->err_fd);
+}
+
+static int _bf_test_process_exec(struct bf_test_process *process)
+{
+    int stdout_pipe[2] = {-1, -1};
+    int stderr_pipe[2] = {-1, -1};
+    pid_t pid;
+    int r;
+
+    r = pipe(stdout_pipe);
+    if (r)
+        return bf_err_r(errno, "failed to create stdout pipes pair");
+
+    r = pipe(stderr_pipe);
+    if (r)
+        return bf_err_r(errno, "failed to create stderr pipes pair");
+
+    pid = fork();
+    if (pid < 0)
+        return bf_err_r(errno, "failed to fork child");
+
+    if (pid == 0) {
+        // We're in the child process
+
+        r = dup2(stdout_pipe[1], STDOUT_FILENO);
+        if (r < 0)
+            return bf_err_r(errno, "failed to duplicae the child's stdout");
+
+        r = dup2(stderr_pipe[1], STDERR_FILENO);
+        if (r < 0)
+            return bf_err_r(errno, "failed to duplicae the child's stderr");
+
+        close(stdout_pipe[0]);
+        close(stderr_pipe[0]);
+
+        (void)execvp(process->cmd, process->args);
+
+        bf_abort("failed to execvp() %s: %s", process->cmd, strerror(errno));
+    }
+
+    process->out_fd = stdout_pipe[0];
+    process->err_fd = stderr_pipe[0];
+    process->pid = pid;
+
+    return 0;
+}
+
+static int _bf_fd_set_flag(int fd, int flag)
+{
+    int r;
+
+    r = fcntl(fd, F_GETFL, 0);
+    if (r < 0)
+        return bf_err_r(errno, "failed to get flags for FD %d", fd);
+
+    r = fcntl(fd, F_SETFL, r | flag);
+    if (r < 0)
+        return bf_err_r(errno, "failed to set flags for FD %d", fd);
+
+    return 0;
+}
+
+int bf_test_process_start(struct bf_test_process *process)
+{
+    int r;
+
+    r = _bf_test_process_exec(process);
+    if (r < 0)
+        return r;
+
+    r = _bf_fd_set_flag(process->out_fd, O_NONBLOCK);
+    if (r < 0) {
+        bf_err_r(r, "failed to set O_NONBLOCK flag to stdout FD");
+        goto err_fcntl;
+    }
+
+    r = _bf_fd_set_flag(process->err_fd, O_NONBLOCK);
+    if (r < 0) {
+        bf_err_r(r, "failed to set O_NONBLOCK flag to stderr FD");
+        goto err_fcntl;
+    }
+
+    return 0;
+
+err_fcntl:
+    kill(process->pid, SIGKILL);
+    return r;
+}
+
+int bf_test_process_wait(struct bf_test_process *process)
+{
+    int status;
+    int r;
+
+    r = waitpid(process->pid, &status, 0);
+    if (r < 0)
+        return bf_err_r(errno, "waitpid() on child process failed");
+
+    return WEXITSTATUS(status);
+}
+
+int bf_test_process_kill(struct bf_test_process *process)
+{
+    int r;
+
+    r = kill(process->pid, SIGTERM);
+    if (r < 0)
+        return bf_err_r(errno, "failed to send SIGTERM to the process");
+
+    return 0;
+}
+
+int bf_test_process_stop(struct bf_test_process *process)
+{
+    int r;
+
+    r = bf_test_process_kill(process);
+    if (r < 0)
+        return 0;
+
+    return bf_test_process_wait(process);
+}
+
+int bf_run(const char *cmd, char **args, size_t nargs)
+{
+    _cleanup_bf_test_process_ struct bf_test_process process;
+    int r;
+
+    r = bf_test_process_init(&process, cmd, args, nargs);
+    if (r < 0)
+        return r;
+
+    r = bf_test_process_start(&process);
+    if (r < 0)
+        return r;
+
+    r = bf_test_process_wait(&process);
+    if (r < 0)
+        return r;
+
+    bf_test_process_clean(&process);
+
+    return r;
+}
+
+const char *_bf_fd_read(int fd)
+{
+    _cleanup_free_ char *data = NULL;
+    char buffer[1024];
+    size_t tot_len = 0;
+    ssize_t read_len;
+
+    do {
+        char *new_data;
+
+        read_len = read(fd, buffer, ARRAY_SIZE(buffer));
+        if (read_len == 0 || (read_len < 0 && errno == EAGAIN)) {
+            // EAGAIN is expected for non-blocking FDs. Ignore it
+            break;
+        }
+        if (read_len < 0) {
+            bf_err_r(errno, "failed to read from FD %d", fd);
+            freep((void *)&data);
+            return NULL;
+        }
+
+        new_data = realloc(data, tot_len + read_len + 1);
+        if (!new_data) {
+            bf_warn("failed to grow the FD read buffer, skipping data");
+            break;
+        }
+
+        strncpy(&new_data[tot_len], buffer, read_len);
+        tot_len += read_len;
+        data = new_data;
+        data[tot_len] = '\0';
+    } while (read_len == ARRAY_SIZE(buffer));
+
+    return TAKE_PTR(data);
+}
+
+const char *bf_test_process_stdout(struct bf_test_process *process)
+{
+    return _bf_fd_read(process->out_fd);
+}
+
+const char *bf_test_process_stderr(struct bf_test_process *process)
+{
+    return _bf_fd_read(process->err_fd);
+}

--- a/tests/harness/process.h
+++ b/tests/harness/process.h
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <sys/types.h>
+
+/**
+ * @file process.h
+ *
+ * The functions defined in this file are used to manage an external process.
+ * They are inspired by the Python `subprocess` module.
+ *
+ * `bf_test_process` represents the process to manipulate, it must
+ * be initialized using `bf_test_process_init()` with the correct command and
+ * arguments.
+ *
+ * `bf_test_process_start()` will fork the current process, and run the
+ * pre-defined command in the new thread. Two file descriptors will be available
+ * to read the forked process' `stdout` and `stderr` streams (use
+ * `bf_test_process_stdout()` and `bf_test_process_stderr()` to do so).
+ *
+ * The forked process can terminate by itself, in which case you need to wait
+ * for it anyway using `bf_test_process_wait()`. You can also kill the process
+ * manually by calling `bf_test_process_kill()` to send a `SIGTERM` signal,
+ * then calling `bf_test_process_wait()`. The last option is to call
+ * `bf_test_process_stop()` which will kill it and wait.
+ *
+ * Lastly, cleanup the resources allocated for the process with
+ * `bf_test_process_clean()`.
+ */
+
+struct bf_test_process
+{
+    /// Command to run in the process.
+    const char *cmd;
+    /// Array of arguments as `char` pointers.
+    char **args;
+    /// Number of arguments in `args`.
+    size_t nargs;
+    /// PID of the process, only valid while the process is alive.
+    pid_t pid;
+    /// File descriptor of the process' `stdout` stream.
+    int out_fd;
+    /// File descriptor of the process' `stderr` stream.
+    int err_fd;
+};
+
+#define _cleanup_bf_test_process_                                              \
+    __attribute__((__cleanup__(bf_test_process_clean)))
+
+int bf_test_process_init(struct bf_test_process *process, const char *cmd,
+                         char **args, size_t nargs);
+void bf_test_process_clean(struct bf_test_process *process);
+
+/**
+ * Start the process.
+ *
+ * Fork the current process to start the requested process. Open two file
+ * descriptor to communicate with the forked process (`stdout` and `stderr`).
+ * Once started, the process can be waited on, killed, or stopped. Use
+ * `bf_test_process_stdout()` and `bf_test_process_stderr()` to access it
+ * standard output and error buffers.
+ *
+ * If this function succeeds, `bf_test_process_wait()` or
+ * `bf_test_process_stop()` must called before cleaning the process.
+ *
+ * @param process The process to start. Can't be `NULL`.
+ * @return 0 on success, or a negative errno value on error.
+ */
+
+int bf_test_process_start(struct bf_test_process *process);
+
+/**
+ * Wait for the process to terminate.
+ *
+ * This function will hang until the process has completed.
+ *
+ * @param process The process to wait on. Can't be NULL.
+ * @return The return code of the process as a non-negative integer, or a
+ *         negative errno value on error.
+ */
+int bf_test_process_wait(struct bf_test_process *process);
+
+/**
+ * Kill the process by sending `SIGTERM`.
+ *
+ * @param process The process to kill. Can't be `NULL`.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_test_process_kill(struct bf_test_process *process);
+
+/**
+ * Force the process to stop and wait for it.
+ *
+ * This function is equivalent to calling `bf_test_process_kill()` then
+ * `bf_test_process_wait()`.
+ *
+ * @param process The process to stop. Can't be `NULL`.
+ * @return The return code of the process as a non-negative integer, or a
+ *         negative errno value on error.
+ */
+int bf_test_process_stop(struct bf_test_process *process);
+
+/**
+ * Run a command in a forked process.
+ *
+ * This function won't kill the process but only wait on it. If you call
+ * `bf_run()` with a command that doesn't return, this function will hang
+ * indefinitely.
+ *
+ * @param cmd Command to run in the process.
+ * @param args Array of arguments to provide to the process.
+ * @param nargs Number of arguments in @p args.
+ * @return The return code of the process as a non-negative integer, or a
+ *         negative errno value on error.
+ */
+int bf_run(const char *cmd, char **args, size_t nargs);
+
+/**
+ * Read the process' `stdout` stream.
+ *
+ * The buffer returned by `bf_test_process_stdout()` is dynamically allocated
+ * and is owned by the caller.
+ *
+ * @param process Process to read the `stdout` stream from.
+ * @return Buffer containing the process' `stdout` stream, or `NULL` on error.
+ */
+const char *bf_test_process_stdout(struct bf_test_process *process);
+
+/**
+ * Read the process' `stderr` stream.
+ *
+ * The buffer returned by `bf_test_process_stderr()` is dynamically allocated
+ * and is owned by the caller.
+ *
+ * @param process Process to read the `stderr` stream from.
+ * @return Buffer containing the process' `stderr` stream, or `NULL` on error.
+ */
+const char *bf_test_process_stderr(struct bf_test_process *process);


### PR DESCRIPTION
`make benchmark` uses a testing harness in C++ to run and communicate with the `bpfilter` daemon and `bfcli`. The harness needs to be written in C to perform end-to-end tests using CMocka (which is used for unit tests already).

This PR introduces `tests/harness` to centralize the testing harness for the unit tests, end-to-end tests, benchmark... The document has been updated with the detail of the API. More changes will come to introduce end-to-end testing, and move the benchmark away from the deprecated C++ harness.