### PR TITLE
tests: benchmark: do not initialize the adhoc rule

### DIFF
--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -80,7 +80,7 @@ public:
     ::std::string srcdir = ".";
     ::std::string outfile = "results.json";
     ::std::string gitrev = "<unknown>";
-    ::std::optional<::std::string> adhoc = "";
+    ::std::optional<::std::string> adhoc;
     int adhocRepeat = 1;
     const ::std::string adhocBenchName = "bf_adhoc";
     int64_t gitdate = 0;


### PR DESCRIPTION
Initializing the `std::optional<std::string>` adhoc rule variable to `""` will... insert a value into the optional! Removing the point of using an optional and running the adhoc benchmark **every time**. Do not initialize the optional.