### PR TITLE
Add support for `src IPv6, src port` and `src IPv6` sets

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -459,7 +459,9 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
 
                     for (int i = 0; i < mask / 8; ++i)
                         addr.mask[i] = (uint8_t)0xff;
-                    addr.mask[mask / 8] = (uint8_t)0xff << (8 - mask % 8);
+                    
+                    if (mask % 8)
+                        addr.mask[mask / 8] = (uint8_t)0xff << (8 - mask % 8);
 
                     // Convert the IPv6 from string to uint64_t[2].
                     r = inet_pton(AF_INET6, $3, addr.addr);

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.h               ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip4.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip4.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip6.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip6.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/set.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/set.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/tcp.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/tcp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/udp.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/udp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/meta.h      ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/meta.c

--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -21,6 +21,7 @@
 #include "core/list.h"
 #include "core/logger.h"
 #include "core/marsh.h"
+#include "core/opts.h"
 #include "core/rule.h"
 
 int bf_cgen_new(struct bf_cgen **cgen, enum bf_front front,

--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -212,7 +212,8 @@ int bf_cgen_up(struct bf_cgen *cgen)
 
     bf_assert(cgen);
 
-    bf_cgen_dump(cgen, EMPTY_PREFIX);
+    if (bf_opts_is_verbose(BF_VERBOSE_DEBUG))
+        bf_cgen_dump(cgen, EMPTY_PREFIX);
 
     r = bf_program_new(&prog, cgen->chain->hook, cgen->front, cgen->chain);
     if (r < 0)
@@ -239,6 +240,9 @@ int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain)
     int r;
 
     bf_assert(cgen && new_chain);
+
+    if (bf_opts_is_verbose(BF_VERBOSE_DEBUG))
+        bf_cgen_dump(cgen, EMPTY_PREFIX);
 
     r = bf_program_new(&new_prog, (*new_chain)->hook, cgen->front, *new_chain);
     if (r < 0)

--- a/src/bpfilter/cgen/matcher/set.c
+++ b/src/bpfilter/cgen/matcher/set.c
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bpfilter/cgen/matcher/set.h"
+
+#include <linux/bpf.h>
+#include <linux/bpf_common.h>
+#include <linux/if_ether.h>
+#include <linux/in.h> // NOLINT
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
+#include <linux/udp.h>
+
+#include <endian.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "bpfilter/cgen/program.h"
+#include "bpfilter/cgen/reg.h"
+#include "bpfilter/cgen/swich.h"
+#include "core/helper.h"
+#include "core/logger.h"
+#include "core/matcher.h"
+
+#include "external/filter.h"
+
+int _bf_matcher_generate_set_ip6port(struct bf_program *program,
+                                     const struct bf_matcher *matcher)
+{
+    _cleanup_bf_swich_ struct bf_swich swich;
+    uint32_t set_id;
+    int r;
+
+    bf_assert(program);
+    bf_assert(matcher);
+
+    set_id = *(uint32_t *)matcher->payload;
+
+    // Ensure IPv6
+    EMIT(program,
+         BPF_LDX_MEM(BPF_H, BF_REG_1, BF_REG_CTX, BF_PROG_CTX_OFF(l3_proto)));
+    EMIT_FIXUP_JMP_NEXT_RULE(
+        program, BPF_JMP_IMM(BPF_JNE, BF_REG_1, htobe16(ETH_P_IPV6), 0));
+
+    // Get the source port into r2. If l4_proto is not UDP or TCP, jump to the next rule
+    swich = bf_swich_get(program, BF_REG_2);
+    EMIT(program,
+         BPF_LDX_MEM(BPF_B, BF_REG_2, BF_REG_CTX, BF_PROG_CTX_OFF(l4_proto)));
+    EMIT_SWICH_OPTION(&swich, IPPROTO_TCP,
+                      BPF_LDX_MEM(BPF_H, BF_REG_3, BF_REG_L4,
+                                  offsetof(struct tcphdr, source)));
+    EMIT_SWICH_OPTION(&swich, IPPROTO_TCP,
+                      BPF_LDX_MEM(BPF_H, BF_REG_3, BF_REG_L4,
+                                  offsetof(struct udphdr, source)));
+    EMIT_SWICH_DEFAULT(&swich, BPF_MOV64_IMM(BF_REG_3, 0));
+    r = bf_swich_generate(&swich);
+    if (r)
+        return bf_err_r(r, "failed to generate swich for meta.(s|d)port");
+    EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_3, 0, 0));
+
+    // Copy the source IPv6 address into r1 and r2
+    EMIT(program, BPF_LDX_MEM(BPF_DW, BF_REG_1, BF_REG_L3,
+                              offsetof(struct ipv6hdr, saddr)));
+    EMIT(program, BPF_LDX_MEM(BPF_DW, BF_REG_2, BF_REG_L3,
+                              offsetof(struct ipv6hdr, saddr) + 8));
+
+    //  Prepare the key
+    EMIT(program, BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_1, -32));
+    EMIT(program, BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_2, -24));
+    EMIT(program, BPF_STX_MEM(BPF_H, BF_REG_CTX, BF_REG_3, -16));
+
+    // Call bpf_map_lookup_elem(r1=map_fd, r2=key_addr)
+    EMIT_LOAD_SET_FD_FIXUP(program, BF_ARG_1, set_id);
+    EMIT(program, BPF_MOV64_REG(BF_REG_2, BF_REG_CTX));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BF_REG_2, -32));
+    EMIT(program, BPF_EMIT_CALL(BPF_FUNC_map_lookup_elem));
+
+    // Key not found? Jump to the next rule
+    EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(BPF_JEQ, BF_REG_0, 0, 0));
+
+    return 0;
+}
+
+int bf_matcher_generate_set(struct bf_program *program,
+                            const struct bf_matcher *matcher)
+{
+    int r;
+
+    switch (matcher->type) {
+    case BF_MATCHER_SET_SRCIP6PORT:
+        r = _bf_matcher_generate_set_ip6port(program, matcher);
+        break;
+    default:
+        return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);
+    };
+
+    if (r)
+        return r;
+
+    return 0;
+}

--- a/src/bpfilter/cgen/matcher/set.h
+++ b/src/bpfilter/cgen/matcher/set.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+struct bf_matcher;
+struct bf_program;
+
+/**
+ * Generate the bytecode for the BF_MATCHER_SET_* matcher types.
+ *
+ * @param program Program to generate the bytecode into. Can't be NULL.
+ * @param matcher Matcher to generate the bytecode for. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_matcher_generate_set(struct bf_program *program,
+                            const struct bf_matcher *matcher);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -580,6 +580,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
                 return r;
             break;
         case BF_MATCHER_SET_SRCIP6PORT:
+        case BF_MATCHER_SET_SRCIP6:
             r = bf_matcher_generate_set(program, matcher);
             if (r)
                 return r;

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -24,6 +24,7 @@
 #include "bpfilter/cgen/matcher/ip4.h"
 #include "bpfilter/cgen/matcher/ip6.h"
 #include "bpfilter/cgen/matcher/meta.h"
+#include "bpfilter/cgen/matcher/set.h"
 #include "bpfilter/cgen/matcher/tcp.h"
 #include "bpfilter/cgen/matcher/udp.h"
 #include "bpfilter/cgen/printer.h"
@@ -575,6 +576,11 @@ static int _bf_program_generate_rule(struct bf_program *program,
         case BF_MATCHER_UDP_SPORT:
         case BF_MATCHER_UDP_DPORT:
             r = bf_matcher_generate_udp(program, matcher);
+            if (r)
+                return r;
+            break;
+        case BF_MATCHER_SET_SRCIP6PORT:
+            r = bf_matcher_generate_set(program, matcher);
             if (r)
                 return r;
             break;

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -12,7 +12,6 @@
 #include "bpfilter/cgen/reg.h"
 #include "bpfilter/cgen/stub.h"
 #include "core/bpf.h"
-#include "core/btf.h"
 #include "core/flavor.h"
 #include "core/helper.h"
 #include "core/hook.h"
@@ -71,7 +70,8 @@ static int _bf_xdp_gen_inline_prologue(struct bf_program *program)
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 
     // Copy the ingress ifindex into the runtime context
-    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, offsetof(struct xdp_md, ingress_ifindex)));
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1,
+                              offsetof(struct xdp_md, ingress_ifindex)));
     EMIT(program,
          BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(ifindex)));
 

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -71,9 +71,7 @@ static int _bf_xdp_gen_inline_prologue(struct bf_program *program)
          BPF_STX_MEM(BPF_DW, BF_REG_CTX, BF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 
     // Copy the ingress ifindex into the runtime context
-    if ((r = bf_btf_get_field_off("xdp_md", "ingress_ifindex")) < 0)
-        return r;
-    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, r));
+    EMIT(program, BPF_LDX_MEM(BPF_W, BF_REG_2, BF_REG_1, offsetof(struct xdp_md, ingress_ifindex)));
     EMIT(program,
          BPF_STX_MEM(BPF_W, BF_REG_CTX, BF_REG_2, BF_PROG_CTX_OFF(ifindex)));
 

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -147,6 +147,7 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_TCP_FLAGS] = "tcp.flags",
     [BF_MATCHER_UDP_SPORT] = "udp.sport",
     [BF_MATCHER_UDP_DPORT] = "udp.dport",
+    [BF_MATCHER_SET_SRCIP6PORT] = "set.srcip6port",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_type_strs) == _BF_MATCHER_TYPE_MAX,

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -148,6 +148,7 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_UDP_SPORT] = "udp.sport",
     [BF_MATCHER_UDP_DPORT] = "udp.dport",
     [BF_MATCHER_SET_SRCIP6PORT] = "set.srcip6port",
+    [BF_MATCHER_SET_SRCIP6] = "set.srcip6",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_type_strs) == _BF_MATCHER_TYPE_MAX,

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -73,6 +73,8 @@ enum bf_matcher_type
     BF_MATCHER_UDP_SPORT,
     /// Matches against the UDP destination port
     BF_MATCHER_UDP_DPORT,
+    /// Matches the source (IPv6, port) tuple against a set
+    BF_MATCHER_SET_SRCIP6PORT,
     _BF_MATCHER_TYPE_MAX,
 };
 

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -75,6 +75,8 @@ enum bf_matcher_type
     BF_MATCHER_UDP_DPORT,
     /// Matches the source (IPv6, port) tuple against a set
     BF_MATCHER_SET_SRCIP6PORT,
+    /// Matches the source IPv6 address against a set
+    BF_MATCHER_SET_SRCIP6,
     _BF_MATCHER_TYPE_MAX,
 };
 

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -18,6 +18,7 @@ size_t _bf_set_type_elem_size(enum bf_set_type type)
 {
     static const size_t sizes[_BF_SET_MAX] = {
         [BF_SET_IP4] = 4,
+        [BF_SET_SRCIP6PORT] = 18,
     };
 
     static_assert(ARRAY_SIZE(sizes) == _BF_SET_MAX,
@@ -172,6 +173,7 @@ int bf_set_add_elem(struct bf_set *set, void *elem)
 
 static const char *_bf_set_type_strs[] = {
     [BF_SET_IP4] = "BF_SET_IP4",
+    [BF_SET_SRCIP6PORT] = "BF_SET_SRCIP6PORT",
 };
 
 static_assert(ARRAY_SIZE(_bf_set_type_strs) == _BF_SET_MAX, "");

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -14,6 +14,7 @@
 #include "core/dump.h"
 #include "core/helper.h"
 #include "core/list.h"
+#include "core/logger.h"
 #include "core/marsh.h"
 
 size_t _bf_set_type_elem_size(enum bf_set_type type)
@@ -21,6 +22,7 @@ size_t _bf_set_type_elem_size(enum bf_set_type type)
     static const size_t sizes[_BF_SET_MAX] = {
         [BF_SET_IP4] = 4,
         [BF_SET_SRCIP6PORT] = 18,
+        [BF_SET_SRCIP6] = 16,
     };
 
     static_assert(ARRAY_SIZE(sizes) == _BF_SET_MAX,
@@ -118,8 +120,8 @@ int bf_set_marsh(const struct bf_set *set, struct bf_marsh **marsh)
         return bf_err_r(r, "failed to allocate memory for the set's content");
 
     bf_list_foreach (&set->elems, elem_node) {
-        memcpy(data + (elem_idx * set->elem_size), bf_list_node_get_data(elem_node),
-               set->elem_size);
+        memcpy(data + (elem_idx * set->elem_size),
+               bf_list_node_get_data(elem_node), set->elem_size);
         ++elem_idx;
     }
 
@@ -186,6 +188,7 @@ int bf_set_add_elem(struct bf_set *set, void *elem)
 static const char *_bf_set_type_strs[] = {
     [BF_SET_IP4] = "BF_SET_IP4",
     [BF_SET_SRCIP6PORT] = "BF_SET_SRCIP6PORT",
+    [BF_SET_SRCIP6] = "BF_SET_SRCIP6",
 };
 
 static_assert(ARRAY_SIZE(_bf_set_type_strs) == _BF_SET_MAX, "");

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -55,6 +55,8 @@ enum bf_set_type
     BF_SET_IP4,
     /// Keys are (source IPv6 address, source port) (18 bytes).
     BF_SET_SRCIP6PORT,
+    /// Keys are IPv6 addresses (16 bytes).
+    BF_SET_SRCIP6,
     _BF_SET_MAX,
 };
 

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -53,6 +53,8 @@ enum bf_set_type
 {
     /// Keys are IPv4 addresses (4 bytes).
     BF_SET_IP4,
+    /// Keys are (source IPv6 address, source port) (18 bytes).
+    BF_SET_SRCIP6PORT,
     _BF_SET_MAX,
 };
 

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
+find_package(Python3 COMPONENTS Interpreter)
+
 add_custom_command(
     COMMAND
         ${CMAKE_COMMAND}
             -E make_directory
             ${CMAKE_CURRENT_BINARY_DIR}/include
-	COMMAND
-		${CMAKE_CURRENT_SOURCE_DIR}/genpkts.py
+    COMMAND
+        Python3::Interpreter
+            ${CMAKE_CURRENT_SOURCE_DIR}/genpkts.py
             --output ${CMAKE_CURRENT_BINARY_DIR}/include/packets.h
     DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/genpkts.py

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import pathlib

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -590,6 +590,103 @@ Test(xdp, ip6port_200kset_nomatch)
     assert_success(bf_test_prog_run(prog, XDP_PASS, pkt_remote_ip6_tcp));
 }
 
+struct bf_set *make_ip6_set(size_t nelems, uint8_t *matching_elem)
+{
+    _cleanup_bf_set_ struct bf_set *set = NULL;
+    int r;
+
+    r = bf_set_new(&set, BF_SET_SRCIP6);
+    if (r < 0) {
+        bf_err_r(r, "failed to create a new set");
+        return NULL;
+    }
+
+    if (matching_elem) {
+        r = bf_set_add_elem(set, matching_elem);
+        if (r < 0) {
+            bf_err_r(r, "failed to add matching element to set");
+            return NULL;
+        }
+    }
+
+    for (size_t i = 0; i < nelems; i++) {
+        uint8_t elem[16] = {};
+
+        for (int j = 0; j < ARRAY_SIZE(elem); j++)
+            elem[j] = rand() % 256;
+
+        r = bf_set_add_elem(set, elem);
+        if (r < 0) {
+            bf_err_r(r, "failed to add key to set");
+            return NULL;
+        }
+    }
+
+    return TAKE_PTR(set);
+}
+
+Test(xdp, ip6_200kset_match)
+{
+    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        (struct bf_set *[]) {
+            make_ip6_set(200000, (uint8_t[]){0x54, 0x2c, 0x1a, 0x31, 0xf9, 0x64, 0x94, 0x6c, 0x5a, 0x24, 0xe7, 0x1e, 0x4d, 0x26, 0xb8, 0x7e}),
+            NULL,
+        },
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_SET_SRCIP6PORT, BF_MATCHER_IN,
+                        (uint32_t[]) {0}, 4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+
+    _free_bf_test_prog_ struct bf_test_prog *prog = bf_test_prog_get(chain);
+
+    assert_non_null(prog);
+
+    assert_success(bf_test_prog_run(prog, XDP_DROP, pkt_remote_ip6_tcp));
+}
+
+Test(xdp, ip6_200kset_nomatch)
+{
+    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        (struct bf_set *[]) {
+            make_ip6_set(200000, NULL),
+            NULL,
+        },
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_SET_SRCIP6PORT, BF_MATCHER_IN,
+                        (uint32_t[]) {0}, 4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+
+    _free_bf_test_prog_ struct bf_test_prog *prog = bf_test_prog_get(chain);
+
+    assert_non_null(prog);
+
+    assert_success(bf_test_prog_run(prog, XDP_PASS, pkt_remote_ip6_tcp));
+}
+
 int main(int argc, char *argv[])
 {
     _free_bf_test_suite_ bf_test_suite *suite = NULL;

--- a/tests/harness/CMakeLists.txt
+++ b/tests/harness/CMakeLists.txt
@@ -24,7 +24,7 @@ endforeach()
 endfunction()
 
 add_library(harness
-    OBJECT
+    STATIC
         ${CMAKE_CURRENT_SOURCE_DIR}/daemon.h    ${CMAKE_CURRENT_SOURCE_DIR}/daemon.c
         ${CMAKE_CURRENT_SOURCE_DIR}/filters.h   ${CMAKE_CURRENT_SOURCE_DIR}/filters.c
         ${CMAKE_CURRENT_SOURCE_DIR}/mock.h      ${CMAKE_CURRENT_SOURCE_DIR}/mock.c

--- a/tests/harness/filters.c
+++ b/tests/harness/filters.c
@@ -70,6 +70,29 @@ err_clean:
     return (struct bf_hook_opts) {};
 }
 
+struct bf_set *bf_test_set_get(enum bf_set_type type, uint8_t *data[])
+{
+    _cleanup_bf_set_ struct bf_set *set = NULL;
+    int r;
+
+    r = bf_set_new(&set, type);
+    if (r < 0) {
+        bf_err_r(r, "failed to create a new test set");
+        return NULL;
+    }
+
+    while (data && *data) {
+        r = bf_set_add_elem(set, *data);
+        if (r < 0) {
+            bf_err_r(r, "failed to add a new element to a test set");
+            return NULL;
+        }
+        ++data;
+    }
+
+    return TAKE_PTR(set);
+}
+
 struct bf_matcher *bf_matcher_get(enum bf_matcher_type type,
                                   enum bf_matcher_op op, const void *payload,
                                   size_t payload_len)

--- a/tests/harness/filters.h
+++ b/tests/harness/filters.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "core/chain.h"
 #include "core/hook.h"
@@ -50,6 +51,29 @@
  *         `bf_hook_opts` structure is filled with `0`.
  */
 struct bf_hook_opts bf_hook_opts_get(enum bf_hook_opt opt, ...);
+
+/**
+ * Create a new set.
+ *
+ * @code {.c}
+ *  bf_test_set_get(
+ *      BF_SET_IP4,
+ *      (uint8_t *[]) {
+ *          { 0x01, 0x02, 0x03, 0x04 },
+ *          NULL,
+ *      }
+ *  );
+ * @endcode
+ *
+ * The caller owns the set and is responsible for freeing it.
+ *
+ * @param type Set type. Defines the key size.
+ * @param data Array of elements to fill the set with. The elements are
+ *        expected to a size defined by their @p type. If `NULL`, the set
+ *        is empty
+ * @return A valid @ref bf_set on success, or NULL on failure.
+ */
+struct bf_set *bf_test_set_get(enum bf_set_type type, uint8_t *data[]);
 
 /**
  * Create a new matcher.


### PR DESCRIPTION
Those sets are required for benchmarking purpose until a better solution is available (generic sets). This change adds support for sets using `src IPv6, src port` and `src IPv6` as keys.