### PR TITLE
build: document the `-DWITH_BENCHMARK` option to enable benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(bpfilter
 
 include(GNUInstallDirs)
 
+option(WITH_BENCHMARK "Build and run the benchmarks" off)
+
 find_package(Doxygen REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(FLEX REQUIRED)

--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -1,7 +1,7 @@
 Build from sources
 ==================
 
-This document describes the process to build ``bpfilter`` from sources. While `bpfilter` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon. ``bpfilter`` officially supports Fedora 39+, and Ubuntu 24.04 LTS.
+This document describes the process to build ``bpfilter`` from sources. While ``bpfilter`` can be built on most systems, a recent (6.4+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon. ``bpfilter`` officially supports Fedora 39+, and Ubuntu 24.04 LTS.
 
 Required dependencies on Fedora and Ubuntu:
 
@@ -19,7 +19,7 @@ You can then use CMake to generate the build system:
 
     cmake -S $BPFILTER_SOURCE -B $BUILD_DIRECTORY
 
-There is no ``bpfilter``-specific CMake option, but you can use the CMake-provided ones (e.g. ``CMAKE_BUILD_TYPE``, ``CMAKE_INSTALL_PREFIX``, ...), including ``-G`` to override the default build system generator (``ninja`` and ``make`` are supported).
+Apart from the usual CMake options (e.g. ``CMAKE_BUILD_TYPE``, ``CMAKE_INSTALL_PREFIX``, ...), subparts of the projects can be enabled or disabled during the configuration step using ``-DWITH_XXX``. More detail below.
 
 Once CMake completes, you can build ``bpfilter``. The following Make targets are available:
 
@@ -38,6 +38,21 @@ Once CMake completes, you can build ``bpfilter``. The following Make targets are
 * ``coverage``: generate an HTML coverage report in ``$BUILD_DIRECTORY/doc/coverage``. This target will fail if ``make test`` hasn't been called before.
 
 The build artefacts are located in ``$BUILD_DIRECTORY/output``.
+
+
+**Benchmark**
+
+The benchmarks require the following dependencies:
+
+.. code-block:: shell
+
+    # Fedora
+    sudo dnf install -y google-benchmark-devel libgit2-devel
+
+    # Ubuntu
+    sudo apt-get install -y libbenchmark-dev libgit2-dev
+
+Use ``-DWITH_BENCHMARK=on`` to enable the benchmark, build and run it using ``make benchmark``. See :ref:`tests-benchmark-label` for more information.
 
 
 Building ``nftables`` and ``iptables``

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -98,6 +98,8 @@ The example below will create an empty chain with a default ``ACCEPT`` policy. W
     }
 
 
+.. _tests-benchmark-label:
+
 Benchmarking
 ------------
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,11 @@
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
 add_subdirectory(harness)
-add_subdirectory(benchmark)
+
+if (WITH_BENCHMARK)
+    add_subdirectory(benchmark)
+endif ()
+
 add_subdirectory(e2e)
 add_subdirectory(unit)
 add_subdirectory(integration)

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,12 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
-option(ENABLE_BENCHMARK "Enable benchmark" off)
-
-if (NOT ENABLE_BENCHMARK)
-    return()
-endif ()
-
 find_package(benchmark REQUIRED)
 pkg_check_modules(git2 REQUIRED IMPORTED_TARGET libgit2)
 


### PR DESCRIPTION
`-DWITH_BENCHMARK=on` will ensure CMake generates a build configuration with the benchmarks enabled.