### PR TITLE
A few minor fixes to the tests

### DIFF
--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -787,7 +787,7 @@ int Chain::apply()
     for (const auto &rule: rules_)
         chain += rule + " ";
 
-    const ::std::vector<::std::string> args {"--str", chain};
+    const ::std::vector<::std::string> args {"ruleset", "set", "--str", chain};
 
     const auto [r, out, err] = run(bin_, args);
     if (r != 0) {

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -35,6 +35,9 @@ target_link_libraries(e2e_bin
         libbpfilter_a
 )
 
+# The unit tests executable needs PIC disabled for test auto-discovery to work.
+set_property(TARGET e2e_bin PROPERTY POSITION_INDEPENDENT_CODE FALSE)
+
 add_custom_target(e2e
     COMMAND
         sudo

--- a/tests/harness/prog.c
+++ b/tests/harness/prog.c
@@ -30,7 +30,8 @@ struct bf_test_prog *bf_test_prog_get(const struct bf_chain *chain)
         return NULL;
     }
 
-    if (bf_cli_set_chain(chain) < 0) {
+    r = bf_cli_set_chain(chain);
+    if (r < 0) {
         bf_err_r(r, "failed to create a new chain");
         return NULL;
     }


### PR DESCRIPTION
- Properly process `bf_cli_set_chain()` error in `bf_test_prog_get()`
- Disable PIC for integration tests, similarly to unit tests
- Use the new `bfcli` command format in the benchmark