### PR TITLE
Fix the benchmark

### DIFF
--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -158,7 +158,7 @@ end_clean:
     bf_list_clean(&ruleset.chains);
     bf_list_clean(&ruleset.sets);
 
-    return 0;
+    return r;
 }
 
 #define streq(str, expected) (str) && bf_streq(str, expected)

--- a/src/bpfilter/cgen/matcher/ip6.c
+++ b/src/bpfilter/cgen/matcher/ip6.c
@@ -23,7 +23,7 @@
 
 #include "external/filter.h"
 
-#define _bf_make32(a, b, c, d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
+#define _bf_make32(a, b, c, d) (((uint32_t)(a) << 24) | ((uint32_t)(b) << 16) | ((uint32_t)(c) << 8) | (uint32_t)(d))
 #define _BF_MASK_LAST_BYTE 15
 
 static int _bf_matcher_generate_ip6_addr(struct bf_program *program,

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -7,6 +7,7 @@
 #include <cerrno>
 #include <cstring>
 #include <exception>
+#include <format>
 #include <span>
 #include <unistd.h>
 
@@ -14,6 +15,7 @@
 
 namespace
 {
+
 void firstRuleDropCounter(::benchmark::State &state)
 {
     ::bf::Chain chain(::bf::config.bfcli);
@@ -35,7 +37,10 @@ BENCHMARK(firstRuleDropCounter);
 void dropAfterXRules(::benchmark::State &state)
 {
     ::bf::Chain chain(::bf::config.bfcli);
-    chain.repeat("rule meta.l3_proto ipv4 counter ACCEPT", state.range(0));
+
+    for (int i = 0; i < state.range(0); ++i)
+        chain << std::format("rule meta.dport {} counter ACCEPT", i + 1);
+
     chain.apply();
     auto prog = chain.getProgram();
 
@@ -87,7 +92,7 @@ int main(int argc, char *argv[])
     if (::bf::config.adhoc) {
         ::benchmark::RegisterBenchmark("bf_adhoc", adhocBenchmark,
                                        *::bf::config.adhoc);
-    } 
+    }
 
     try {
         auto daemon = bf::Daemon(


### PR DESCRIPTION
- Return the correct error values from `_bf_do_ruleset_set()`
- Generate unique rules for `dropAfterXRules` to prevent the verifier from removing unused instructions