### PR TITLE
Improvements to the benchmark

### DIFF
--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -99,6 +99,7 @@ enum
 {
     OPT_KEY_ADHOC,
     OPT_KEY_ADHOC_REPEAT,
+    OPT_KEY_NO_DAEMON,
 };
 
 const ::std::string help = "\v\
@@ -106,7 +107,7 @@ const ::std::string help = "\v\
 benchmarks will be skipped, and only the adhoc benchmark will be run. --adhoc \
 benchmarks won't create any output file.";
 
-constexpr std::array<struct argp_option, 7> options {{
+constexpr std::array<struct argp_option, 8> options {{
     {"cli", 'c', "CLI", 0,
      "Path to the bfcli binary. Defaults to 'bfcli' in $PATH.", 0},
     {"daemon", 'd', "DAEMON", 0,
@@ -121,6 +122,9 @@ constexpr std::array<struct argp_option, 7> options {{
      "Adhoc benchmark using RULE, skip all the predefined benchmarks.", 0},
     {"adhoc-repeat", OPT_KEY_ADHOC_REPEAT, "COUNT", 0,
      "Number of times to repeat the adhoc RULE in the chain. Defaults to 1.", 0},
+    {"no-daemon", OPT_KEY_NO_DAEMON, NULL, OPTION_ARG_OPTIONAL,
+     "If set, the benchmark will assume a daemon is already running and won't start one.",
+     0},
     {nullptr},
 }};
 
@@ -140,6 +144,9 @@ int optsParser(int key, char *arg, struct ::argp_state *state)
         break;
     case OPT_KEY_ADHOC_REPEAT:
         config->adhocRepeat = ::std::stoi(arg);
+        break;
+    case OPT_KEY_NO_DAEMON:
+        config->runDaemon = false;
         break;
     case 'c':
         config->bfcli = ::std::string(arg);
@@ -313,6 +320,7 @@ int setup(std::span<char *> args)
     ::benchmark::AddCustomContext("bfcli", config.bfcli);
     ::benchmark::AddCustomContext("bpfilter", config.bpfilter);
     ::benchmark::AddCustomContext("srcdir", config.srcdir);
+    ::benchmark::AddCustomContext("runDaemon", ::std::to_string(config.runDaemon));
 
     if (config.adhoc) {
         ::benchmark::AddCustomContext("adhoc", *config.adhoc);

--- a/tests/benchmark/benchmark.cpp
+++ b/tests/benchmark/benchmark.cpp
@@ -688,7 +688,7 @@ Program::~Program() noexcept(false)
 	if (r < 0)
 		return -EINVAL;
 
-    return prog_info.jited_prog_len;
+    return prog_info.xlated_prog_len / sizeof(struct bpf_insn);
 }
 
 int Program::run(int expect, const std::span<const uint8_t> &pkt) const

--- a/tests/benchmark/benchmark.hpp
+++ b/tests/benchmark/benchmark.hpp
@@ -84,6 +84,7 @@ public:
     int adhocRepeat = 1;
     const ::std::string adhocBenchName = "bf_adhoc";
     int64_t gitdate = 0;
+    bool runDaemon = true;
 
     Config() noexcept = default;
 };

--- a/tests/benchmark/main.cpp
+++ b/tests/benchmark/main.cpp
@@ -95,10 +95,14 @@ int main(int argc, char *argv[])
     }
 
     try {
-        auto daemon = bf::Daemon(
-            ::bf::config.bpfilter,
-            bf::Daemon::Options().transient().noIptables().noNftables());
-        ::benchmark::RunSpecifiedBenchmarks();
+        if (::bf::config.runDaemon) {
+            auto daemon = bf::Daemon(
+                ::bf::config.bpfilter,
+                bf::Daemon::Options().transient().noIptables().noNftables());
+            ::benchmark::RunSpecifiedBenchmarks();
+        } else {
+            ::benchmark::RunSpecifiedBenchmarks();
+        }
     } catch (const ::std::exception &e) {
         err("failed to run benchmark: {}", e.what());
         return -1;


### PR DESCRIPTION
Two changes to the benchmark:
- Add `--no-daemon` option so the benchmark doesn't start the `bpfilter` daemon itself (useful to control the daemon options easily and access the logs).
- Divide the program size fetched from the kernel by `sizeof(struct bpf_insn)` to have the current number of instructions. Use `xlated_prog_len` instead of `jited_prog_len`.