### PR TITLE
Use `sudo` for `make benchmark` if current user is not root

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           file: .github/${{ matrix.distribution.name }}-${{ matrix.distribution.version }}.Dockerfile
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           tags: ghcr.io/facebook/bpfilter:${{ matrix.distribution.name }}-${{ matrix.distribution.version }}-${{ matrix.host.arch}}
           cache-from: type=gha,scope=${{ matrix.distribution.name }}-${{ matrix.distribution.version }}-${{ matrix.host.arch}}
           cache-to: type=gha,mode=max,scope=${{ matrix.distribution.name }}-${{ matrix.distribution.version }}-${{ matrix.host.arch}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           - { name: ubuntu, version: "24.10" }
           - { name: ubuntu, version: "24.04" }
     runs-on: [ "${{ matrix.host.name }}" ]
-    name: "Build container: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})"
+    name: "Image: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})"
     steps:
       - name: Checkout bpfilter
         uses: actions/checkout@v2

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -32,11 +32,12 @@ add_custom_target(benchmark
             -E make_directory
             ${CMAKE_BINARY_DIR}/output/benchmarks
     COMMAND
-        $<TARGET_FILE:benchmark_bin>
-            --cli $<TARGET_FILE:bfcli>
-            --daemon $<TARGET_FILE:bpfilter>
-            --srcdir ${CMAKE_SOURCE_DIR}
-            --outfile ${CMAKE_BINARY_DIR}/output/benchmarks/{gitrev}.json
+        ${CMAKE_CURRENT_SOURCE_DIR}/asroot
+            $<TARGET_FILE:benchmark_bin>
+                --cli $<TARGET_FILE:bfcli>
+                --daemon $<TARGET_FILE:bpfilter>
+                --srcdir ${CMAKE_SOURCE_DIR}
+                --outfile ${CMAKE_BINARY_DIR}/output/benchmarks/{gitrev}.json
     DEPENDS benchmark_bin bfcli bpfilter
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     USES_TERMINAL

--- a/tests/benchmark/asroot
+++ b/tests/benchmark/asroot
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# Run a command as root: if the current user is root, run the command directly,
+# otherwise prefix it with sudo.
+
+SUDO=''
+if [ "$(id -u)" -ne 0 ]
+then
+    SUDO='sudo'
+fi
+
+$SUDO "$@"


### PR DESCRIPTION
Use `sudo` for the benchmark run if the current user is not root, otherwise run as-is. This is expected to solve the CI build failure as the container waits for a password to be provided with sudo.