### PR TITLE
Fix filtering ICMPv6 using `BF_HOOK_NF_LOCAL_IN`

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -303,7 +303,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                         proto = IPPROTO_TCP;
                     else if (bf_streq($3, "udp"))
                         proto = IPPROTO_UDP;
-                    else if (bf_streq($3, "icmp6"))
+                    else if (bf_streq($3, "icmpv6"))
                         proto = IPPROTO_ICMPV6;
                     else
                         bf_parse_err("unsupported L4 protocol to match '%s'\n", $3);

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -185,7 +185,7 @@ int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
 
     attr.link_create.prog_fd = prog_fd;
     attr.link_create.attach_type = BPF_NETFILTER;
-    attr.link_create.netfilter.pf = NFPROTO_IPV4;
+    attr.link_create.netfilter.pf = NFPROTO_INET;
     attr.link_create.netfilter.hooknum = bf_hook_to_nf_hook(hook);
     attr.link_create.netfilter.priority = priority;
 


### PR DESCRIPTION
- Fix typo in parser expecting ICMPv6 to be named `icmp6`: filtering on ICMPv6 is now `meta.l4_proto eq icmpv6` as documented.
- Attach Netfilter programs with packet family `NFPROTO_INET` instead of `NFPROTO_IPV4` to filter both IPv4 and IPv6 traffic.