### PR TITLE
Allow a program to be attached to multiple hooks

### DIFF
--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/nf.h                ${CMAKE_CURRENT_SOURCE_DIR}/cgen/nf.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/printer.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/printer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.h         ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/map.h          ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/map.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/stub.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/stub.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/swich.h             ${CMAKE_CURRENT_SOURCE_DIR}/cgen/swich.c

--- a/src/bpfilter/cgen/prog/link.c
+++ b/src/bpfilter/cgen/prog/link.c
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bpfilter/cgen/prog/link.h"
+
+#include <linux/bpf.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "core/bpf.h"
+#include "core/dump.h"
+#include "core/helper.h"
+#include "core/hook.h"
+#include "core/logger.h"
+#include "core/marsh.h"
+#include "core/nf.h"
+
+int bf_link_new(struct bf_link **link, const char *name, enum bf_hook hook)
+{
+    _cleanup_bf_link_ struct bf_link *_link = NULL;
+
+    bf_assert(link && name);
+    bf_assert(name[0] != '\0');
+
+    _link = malloc(sizeof(*_link));
+    if (!_link)
+        return -ENOMEM;
+
+    // snprintf() will write the \0 as part of the BPF_OBJ_NAME_LEN bytes
+    (void)snprintf(_link->name, BPF_OBJ_NAME_LEN, name);
+
+    _link->fd = -1;
+    _link->hook = hook;
+
+    *link = TAKE_PTR(_link);
+
+    return 0;
+}
+
+int bf_link_new_from_marsh(struct bf_link **link, int dir_fd,
+                           const struct bf_marsh *marsh)
+{
+    _cleanup_bf_link_ struct bf_link *_link = NULL;
+    struct bf_marsh *elem = NULL;
+    int r;
+
+    bf_assert(link && marsh);
+
+    _link = malloc(sizeof(*_link));
+    if (!_link)
+        return -ENOMEM;
+
+    _link->fd = -1;
+
+    if (!(elem = bf_marsh_next_child(marsh, elem)))
+        return -EINVAL;
+    memcpy(&_link->name, elem->data, BPF_OBJ_NAME_LEN);
+
+    if (!(elem = bf_marsh_next_child(marsh, elem)))
+        return -EINVAL;
+    memcpy(&_link->hook, elem->data, sizeof(_link->hook));
+
+    if (bf_marsh_next_child(marsh, elem))
+        return bf_err_r(-E2BIG, "too many elements in bf_link marsh");
+
+    if (dir_fd != -1) {
+        r = bf_bpf_obj_get(_link->name, dir_fd, &_link->fd);
+        if (r) {
+            return bf_err_r(r, "failed to open pinned BPF link '%s'",
+                            _link->name);
+        }
+    }
+
+    *link = TAKE_PTR(_link);
+
+    return 0;
+}
+
+void bf_link_free(struct bf_link **link)
+{
+    bf_assert(link);
+
+    if (!*link)
+        return;
+
+    closep(&(*link)->fd);
+    freep((void *)link);
+}
+
+int bf_link_marsh(const struct bf_link *link, struct bf_marsh **marsh)
+{
+    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    int r;
+
+    bf_assert(link && marsh);
+
+    r = bf_marsh_new(&_marsh, NULL, 0);
+    if (r)
+        return r;
+
+    r = bf_marsh_add_child_raw(&_marsh, &link->name, BPF_OBJ_NAME_LEN);
+    if (r)
+        return r;
+
+    r = bf_marsh_add_child_raw(&_marsh, &link->hook, sizeof(link->hook));
+    if (r)
+        return r;
+
+    *marsh = TAKE_PTR(_marsh);
+
+    return 0;
+}
+
+void bf_link_dump(const struct bf_link *link, prefix_t *prefix)
+{
+    bf_assert(link && prefix);
+
+    DUMP(prefix, "struct bf_link at %p", link);
+
+    bf_dump_prefix_push(prefix);
+    DUMP(prefix, "name: %s", link->name);
+    DUMP(prefix, "fd: %d", link->fd);
+    DUMP(bf_dump_prefix_last(prefix), "hook: %s", bf_hook_to_str(link->hook));
+    bf_dump_prefix_pop(prefix);
+}
+
+int bf_link_attach_xdp(struct bf_link *link, int prog_fd, unsigned int ifindex,
+                       enum bf_xdp_attach_mode mode)
+{
+    union bpf_attr attr = {
+        .link_create =
+            {
+                .prog_fd = prog_fd,
+                .target_fd = ifindex,
+                .attach_type = BPF_XDP,
+                .flags = mode,
+            },
+    };
+    int r;
+
+    r = bf_bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    link->fd = r;
+
+    return 0;
+}
+
+int bf_link_attach_tc(struct bf_link *link, int prog_fd, unsigned int ifindex)
+{
+    union bpf_attr attr = {
+        .link_create =
+            {
+                .prog_fd = prog_fd,
+                .target_fd = ifindex,
+                .attach_type = bf_hook_to_attach_type(link->hook),
+            },
+    };
+    int r;
+
+    r = bf_bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    link->fd = r;
+
+    return 0;
+}
+
+int bf_link_attach_nf(struct bf_link *link, int prog_fd, unsigned int family,
+                      int priority)
+{
+    union bpf_attr attr = {
+        .link_create =
+            {
+                .prog_fd = prog_fd,
+                .attach_type = BPF_NETFILTER,
+                .netfilter =
+                    {
+                        .pf = family,
+                        .hooknum = bf_hook_to_nf_hook(link->hook),
+                        .priority = priority,
+                    },
+            },
+    };
+    int r;
+
+    r = bf_bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    link->fd = r;
+
+    return 0;
+}
+
+int bf_link_attach_cgroup(struct bf_link *link, int prog_fd,
+                          const char *cgroup_path)
+{
+    _cleanup_close_ int cgroup_fd = -1;
+    union bpf_attr attr = {
+        .link_create =
+            {
+                .prog_fd = prog_fd,
+                .attach_type = bf_hook_to_attach_type(link->hook),
+            },
+    };
+    int r;
+
+    cgroup_fd = open(cgroup_path, O_DIRECTORY | O_RDONLY);
+    if (cgroup_fd < 0)
+        return bf_err_r(errno, "failed to open cgroup '%s'", cgroup_path);
+
+    attr.link_create.target_fd = cgroup_fd;
+
+    r = bf_bpf(BPF_LINK_CREATE, &attr);
+    if (r < 0)
+        return r;
+
+    link->fd = r;
+
+    return 0;
+}
+
+int bf_link_update(struct bf_link *link, int new_prog_fd)
+{
+    union bpf_attr attr = {
+        .link_update.link_fd = link->fd,
+        .link_update.new_prog_fd = new_prog_fd,
+    };
+
+    return bf_bpf(BPF_LINK_UPDATE, &attr);
+}
+
+int bf_link_detach(struct bf_link *link)
+{
+    union bpf_attr attr = {
+        .link_detach.link_fd = link->fd,
+    };
+    int r;
+
+    r = bf_bpf(BPF_LINK_DETACH, &attr);
+    if (r)
+        return r;
+
+    closep(&link->fd);
+
+    return 0;
+}
+
+int bf_link_pin(struct bf_link *link, int dir_fd)
+{
+    int r;
+
+    bf_assert(link);
+    bf_assert(dir_fd > 0);
+
+    r = bf_bpf_obj_pin(link->name, link->fd, dir_fd);
+    if (r)
+        return bf_err_r(r, "failed to pin BPF link '%s'", link->name);
+
+    return 0;
+}
+
+void bf_link_unpin(struct bf_link *link, int dir_fd)
+{
+    int r;
+
+    bf_assert(link);
+    bf_assert(dir_fd > 0);
+
+    r = unlinkat(dir_fd, link->name, 0);
+    if (r < 0 && errno != ENOENT) {
+        // Do not warn on ENOENT, we want the file to be gone!
+        bf_warn_r(
+            errno,
+            "failed to unlink BPF link '%s', assuming the link is not pinned",
+            link->name);
+    }
+}
+
+int bf_link_get_info(struct bf_link *link, struct bpf_link_info *info)
+{
+    union bpf_attr attr = {};
+
+    bf_assert(link && info);
+
+    if (link->fd == -1)
+        return -ENOENT;
+
+    attr.info.bpf_fd = link->fd;
+    attr.info.info_len = sizeof(*info);
+    attr.info.info = bf_ptr_to_u64(info);
+
+    return bf_bpf(BPF_OBJ_GET_INFO_BY_FD, &attr);
+}

--- a/src/bpfilter/cgen/prog/link.h
+++ b/src/bpfilter/cgen/prog/link.h
@@ -1,0 +1,200 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2022 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/bpf.h"
+#include "core/dump.h"
+#include "core/hook.h"
+#include "core/list.h"
+#include "linux/bpf.h"
+
+/**
+ * BPF link object.
+ */
+struct bf_link
+{
+    /** Name of the link. From the kernel perspective, BPF link objects don't
+     * have a name the program does, but this name will be used to
+     * pin the link. */
+    char name[BPF_OBJ_NAME_LEN];
+    /** Hook to attach the link to, this field will impact the
+     * @c bpf_attach_type property of the link. */
+    enum bf_hook hook;
+    /** File descriptor of the link, only valide once the link object has been
+     * created. */
+    int fd;
+};
+
+struct bf_marsh;
+
+#define _cleanup_bf_link_ __attribute__((__cleanup__(bf_link_free)))
+
+/**
+ * Convenience macro to intialize a list of @ref bf_link .
+ *
+ * @return An initialized @ref bf_list that can contain @ref bf_link objects,
+ *         with its @ref bf_list_ops properly configured.
+ */
+#define bf_link_list()                                                         \
+    ((bf_list) {.ops = {.free = (bf_list_ops_free)bf_link_free,                \
+                        .marsh = (bf_list_ops_marsh)bf_link_marsh}})
+
+/**
+ * Allocate and initializes a new BPF link object.
+ *
+ * @note This function won't creae a new BPF link, but a bpfilter-specific
+ * object used to keep track of a BPF link on the system.
+ *
+ * @param link Link to allocate and initialize. Can't be NULL. On success,
+ *        @c *link points to a valid @ref bf_link . On failure, @c *link
+ *        remain unchanged.
+ * @param name Name of the link. See @ref bf_link for details.
+ * @param hook Hook to attach the link to. See @ref bf_link for details.
+ * @return 0 on success, or a negative errno value on success.
+ */
+int bf_link_new(struct bf_link **link, const char *name, enum bf_hook hook);
+
+/**
+ * Create a new BPF link object from serialized data.
+ *
+ * @param link BPF link object to allocated and initialize from the serialized
+ *        data. The caller will own the object. On success, @c *link points to
+ *        a valid BPF link object. On failure, @c *link is unchanged. Can't be
+ *        NULL.
+ * @param dir_fd File descriptor of the directory to open the pinned link from.
+ *        BPF link objects are always pinned relative to a directory, if
+ *        @p dir_fd is -1, @ref bf_link_new_from_marsh assumes the link hasn't
+ *        been pinned.
+ * @param marsh Serialized BPF link object data. Can't be NULL.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_link_new_from_marsh(struct bf_link **link, int dir_fd,
+                           const struct bf_marsh *marsh);
+
+/**
+ * Free a bf_link object.
+ *
+ * The BPF link's file descriptor contained in @c link is closed and set to
+ * @c -1 . To prevent the BPF link from being destroy (and the BPF program
+ * detached from its hook), pin it beforehand.
+ *
+ * @param link @ref bf_link object to free. On success, @c *link is set to NULL,
+ *        On failure, @c *link is unchanged.
+ */
+void bf_link_free(struct bf_link **link);
+
+/**
+ * Serializes a BPF link object.
+ *
+ * @param link BPF link object to serialize. The object itself won't be modified.
+ *        Can't be NULL.
+ * @param marsh Marsh object, will be allocated by this function and owned by
+ *        the caller. On success, @c *marsh will point to the BPF link's
+ *        serialized data. On failure, @c *marsh is unchanged. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_marsh(const struct bf_link *link, struct bf_marsh **marsh);
+
+/**
+ * Dump a @c bf_link object.
+ *
+ * @param link @c bf_link object to dump. Can't be NULL.
+ * @param prefix String to prefix each log with. If no prefix is needed, use
+ *               @ref EMPTY_PREFIX . Can't be NULL.
+ */
+void bf_link_dump(const struct bf_link *link, prefix_t *prefix);
+
+/**
+ * Attach a program to an XDP hook using the link.
+ *
+ * @param link Link to create on the system. Can't be NULL.
+ * @param prog_fd File descriptor of the program to attach. Must be a valid
+ *        file descriptor.
+ * @param ifindex Index of the interface to attach the program to.
+ * @param mode Attach mode, see @ref bf_xdp_attach_mode .
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_attach_xdp(struct bf_link *link, int prog_fd, unsigned int ifindex,
+                       enum bf_xdp_attach_mode mode);
+
+/**
+ * Attach a program to a TC hook using the link.
+ *
+ * @param link Link to create on the system. Can't be NULL.
+ * @param prog_fd File descriptor of the program to attach. Must be a valid
+ *        file descriptor.
+ * @param ifindex Index of the interface to attach the program to.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_attach_tc(struct bf_link *link, int prog_fd, unsigned int ifindex);
+
+/**
+ * Attach a program to a Netfilter hook using the link.
+ *
+ * @param link Link to create on the system. Can't be NULL.
+ * @param prog_fd File descriptor of the program to attach. Must be a valid
+ *        file descriptor.
+ * @param family Packet family to use, either @c NFPROTO_IPV4 or @c NFPROTO_IPV6 .
+ * @param priority Priority to assign to the link. Will fail if a link with
+ *        the same priority is already attached to the same hook.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_attach_nf(struct bf_link *link, int prog_fd, unsigned int family,
+                      int priority);
+
+/**
+ * Attach a program to a cgroup hook using the link.
+ *
+ * @param link Link to create on the system. Can't be NULL.
+ * @param prog_fd File descriptor of the program to attach. Must be a valid
+ *        file descriptor.
+ * @param cgroup_path Path of the cgroup to attach the program to. Can't be
+ *        NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_attach_cgroup(struct bf_link *link, int prog_fd,
+                          const char *cgroup_path);
+
+/**
+ * Replace the program attached to the link.
+ *
+ * BPF link allows for the program they attach to, to be replaced atomically
+ * with another program. Not all the hooks support this feature.
+ *
+ * @param link Link to update. Can't be NULL.
+ * @param new_prog_fd File descriptor of the new program to attach to the link.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_update(struct bf_link *link, int new_prog_fd);
+
+/**
+ * Detach the BPF link from the hook.
+ *
+ * @param link Link to detach. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_link_detach(struct bf_link *link);
+
+/**
+ * Pin the link to the system.
+ *
+ * @param link Link to pin. Can't be NULL.
+ * @param dir_fd File descriptor of the directory to pin the link into. Must be
+ *        a valid file descriptor.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_link_pin(struct bf_link *link, int dir_fd);
+
+/**
+ * Unpin the link from the system.
+ *
+ * @param link Link to unpin. Can't be NULL.
+ * @param dir_fd File descriptor of the directory to unpin the link from. Must be
+ *        a valid file descriptor.
+ */
+void bf_link_unpin(struct bf_link *link, int dir_fd);
+
+int bf_link_get_info(struct bf_link *link, struct bpf_link_info *info);

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -42,7 +42,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
     _map->value_size = value_size;
     _map->n_elems = n_elems;
 
-    strncpy(_map->name, name, BPF_OBJ_NAME_LEN);
+    (void)snprintf(_map->name, BPF_OBJ_NAME_LEN, name);
 
     *map = TAKE_PTR(_map);
 

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -1261,12 +1261,9 @@ err_destroy_maps:
 
 int bf_program_load(struct bf_program *new_prog, struct bf_program *old_prog)
 {
-    const char *name;
     int r;
 
     bf_assert(new_prog);
-
-    name = new_prog->runtime.chain->hook_opts.name ?: new_prog->prog_name;
 
     r = _bf_program_load_sets_maps(new_prog);
     if (r < 0)
@@ -1283,10 +1280,10 @@ int bf_program_load(struct bf_program *new_prog, struct bf_program *old_prog)
     if (bf_opts_is_verbose(BF_VERBOSE_BYTECODE))
         bf_program_dump_bytecode(new_prog);
 
-    r = bf_bpf_prog_load(name, bf_hook_to_bpf_prog_type(new_prog->hook),
-                         new_prog->img, new_prog->img_size,
-                         bf_hook_to_attach_type(new_prog->hook),
-                         &new_prog->runtime.prog_fd);
+    r = bf_bpf_prog_load(
+        new_prog->prog_name, bf_hook_to_bpf_prog_type(new_prog->hook),
+        new_prog->img, new_prog->img_size,
+        bf_hook_to_attach_type(new_prog->hook), &new_prog->runtime.prog_fd);
     if (r)
         return bf_err_r(r, "failed to load new bf_program");
 

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -291,7 +291,6 @@ struct bf_program
     enum bf_hook hook;
     enum bf_front front;
     char prog_name[BPF_OBJ_NAME_LEN];
-    char link_name[BPF_OBJ_NAME_LEN];
 
     /// Log messages printer
     struct bf_printer *printer;
@@ -302,6 +301,9 @@ struct bf_program
     struct bf_map *pmap;
     /// List of set maps
     bf_list sets;
+
+    /// Link objects attaching the program to a hook.
+    bf_list links;
 
     /** Number of counters in the counters map. Not all of them are used by
      * the program, but this value is common for all the programs of a given
@@ -321,8 +323,6 @@ struct bf_program
     {
         /** File descriptor of the program. */
         int prog_fd;
-        /** File descriptor of the program's link. */
-        int link_fd;
         /** Hook-specific ops to use to generate the program. */
         const struct bf_flavor_ops *ops;
 

--- a/src/bpfilter/cgen/xdp.c
+++ b/src/bpfilter/cgen/xdp.c
@@ -8,12 +8,14 @@
 
 #include <stddef.h>
 
+#include "bpfilter/cgen/prog/link.h"
 #include "bpfilter/cgen/program.h"
 #include "bpfilter/cgen/stub.h"
 #include "core/bpf.h"
 #include "core/flavor.h"
 #include "core/helper.h"
 #include "core/hook.h"
+#include "core/list.h"
 #include "core/logger.h"
 #include "core/verdict.h"
 
@@ -22,8 +24,10 @@
 static int _bf_xdp_gen_inline_prologue(struct bf_program *program);
 static int _bf_xdp_gen_inline_epilogue(struct bf_program *program);
 static int _bf_xdp_get_verdict(enum bf_verdict verdict);
-static int _bf_xdp_attach_prog(struct bf_program *new_prog,
-                               struct bf_program *old_prog);
+static int _bf_xdp_attach_prog(
+    struct bf_program *new_prog, struct bf_program *old_prog,
+    int (*get_new_link_cb)(struct bf_program *prog, struct bf_link *old_link,
+                           struct bf_link **new_link));
 static int _bf_xdp_detach_prog(struct bf_program *program);
 
 const struct bf_flavor_ops bf_flavor_ops_xdp = {
@@ -104,28 +108,37 @@ static int _bf_xdp_get_verdict(enum bf_verdict verdict)
     return verdicts[verdict];
 }
 
-static int _bf_xdp_attach_prog(struct bf_program *new_prog,
-                               struct bf_program *old_prog)
+static int _bf_xdp_attach_prog(
+    struct bf_program *new_prog, struct bf_program *old_prog,
+    int (*get_new_link_cb)(struct bf_program *prog, struct bf_link *old_link,
+                           struct bf_link **new_link))
 {
+    struct bf_link *new_link;
+    struct bf_link *old_link;
+    int new_fd;
+    unsigned int ifindex;
     int r;
 
-    bf_assert(new_prog);
+    bf_assert(new_prog && get_new_link_cb);
 
-    if (old_prog && old_prog->runtime.link_fd != -1) {
-        r = bf_bpf_xdp_link_update(old_prog->runtime.link_fd,
-                                   new_prog->runtime.prog_fd);
+    old_link = old_prog ? bf_list_get_at(&old_prog->links, 0) : NULL;
+    new_fd = new_prog->runtime.prog_fd;
+    ifindex = new_prog->runtime.chain->hook_opts.ifindex;
+
+    r = get_new_link_cb(new_prog, old_link, &new_link);
+    if (r)
+        return bf_err_r(r, "failed to create new XDP link");
+
+    if (old_link) {
+        r = bf_link_update(new_link, new_fd);
         if (r) {
             return bf_err_r(
                 r, "failed to update existing link for XDP bf_program");
         }
-
-        new_prog->runtime.link_fd = TAKE_FD(old_prog->runtime.link_fd);
     } else {
-        r = bf_bpf_xdp_link_create(new_prog->runtime.prog_fd,
-                                   new_prog->runtime.chain->hook_opts.ifindex,
-                                   &new_prog->runtime.link_fd, BF_XDP_MODE_SKB);
+        r = bf_link_attach_xdp(new_link, new_fd, ifindex, BF_XDP_MODE_SKB);
         if (r)
-            return bf_err_r(r, "failed to create new link for XDP bf_program");
+            return bf_err_r(r, "failed to attach XDP program");
     }
 
     return 0;
@@ -135,5 +148,5 @@ static int _bf_xdp_detach_prog(struct bf_program *program)
 {
     bf_assert(program);
 
-    return bf_bpf_link_detach(program->runtime.link_fd);
+    return bf_link_detach(bf_list_get_at(&program->links, 0));
 }

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -503,7 +503,7 @@ static int _bf_ipt_set_rules_handler(struct ipt_replace *replace, size_t len)
                 return r;
             }
 
-            TAKE_PTR(cur_cgen);
+            TAKE_PTR(new_cgen);
         }
     }
 

--- a/src/core/bpf.c
+++ b/src/core/bpf.c
@@ -20,8 +20,6 @@
 #include "core/nf.h"
 #include "core/opts.h"
 
-#define _bf_ptr_to_u64(ptr) ((unsigned long long)(ptr))
-
 #if defined(__i386__)
 #define _BF_NR_bpf 357
 #elif defined(__x86_64__)
@@ -47,9 +45,9 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
     _cleanup_free_ char *log_buf = NULL;
     union bpf_attr attr = {
         .prog_type = prog_type,
-        .insns = _bf_ptr_to_u64(img),
+        .insns = bf_ptr_to_u64(img),
         .insn_cnt = (unsigned int)img_len,
-        .license = _bf_ptr_to_u64("GPL"),
+        .license = bf_ptr_to_u64("GPL"),
         .expected_attach_type = attach_type,
     };
     int r;
@@ -61,7 +59,7 @@ int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
         if (!log_buf)
             return -ENOMEM;
 
-        attr.log_buf = _bf_ptr_to_u64(log_buf);
+        attr.log_buf = bf_ptr_to_u64(log_buf);
         attr.log_size = (uint32_t)(1 << bf_opts_bpf_log_buf_len_pow());
         attr.log_level = 1;
     }
@@ -97,8 +95,8 @@ int bf_bpf_map_update_elem(int fd, const void *key, void *value)
 {
     union bpf_attr attr = {
         .map_fd = fd,
-        .key = _bf_ptr_to_u64(key),
-        .value = _bf_ptr_to_u64(value),
+        .key = bf_ptr_to_u64(key),
+        .value = bf_ptr_to_u64(value),
         .flags = BPF_ANY,
     };
 
@@ -108,7 +106,7 @@ int bf_bpf_map_update_elem(int fd, const void *key, void *value)
 int bf_bpf_obj_pin(const char *path, int fd, int dir_fd)
 {
     union bpf_attr attr = {
-        .pathname = _bf_ptr_to_u64(path),
+        .pathname = bf_ptr_to_u64(path),
         .bpf_fd = fd,
         .file_flags = dir_fd ? BPF_F_PATH_FD : 0,
         .path_fd = dir_fd,
@@ -125,7 +123,7 @@ int bf_bpf_obj_pin(const char *path, int fd, int dir_fd)
 int bf_bpf_obj_get(const char *path, int dir_fd, int *fd)
 {
     union bpf_attr attr = {
-        .pathname = _bf_ptr_to_u64(path),
+        .pathname = bf_ptr_to_u64(path),
         .file_flags = dir_fd ? BPF_F_PATH_FD : 0,
         .path_fd = dir_fd,
     };

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -11,8 +11,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "core/hook.h"
-
 enum bf_xdp_attach_mode
 {
     BF_XDP_MODE_SKB = XDP_FLAGS_SKB_MODE,
@@ -99,89 +97,3 @@ int bf_bpf_obj_pin(const char *path, int fd, int dir_fd);
  * @return 0 on success, or a negative errno value on failure.
  */
 int bf_bpf_obj_get(const char *path, int dir_fd, int *fd);
-
-/**
- * Create a TC BPF link.
- *
- * @param prog_fd File descriptor of the program to attach to the link.
- * @param ifindex Index of the interface to attach the program to.
- * @param hook TC hook (BPF_TCX_INGRESS or BPF_TCX_EGRESS) to attach the
- *        program to.
- * @param link_fd Link file descriptor, only valid if the return value of the
- *        function is 0.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_bpf_tc_link_create(int prog_fd, unsigned int ifindex,
-                          enum bpf_attach_type hook, int *link_fd);
-
-/**
- * Create a Netfilter BPF link.
- *
- * @param prog_fd File descriptor of the program to attach to the link.
- * @param hook Netfilter hook to attach the program to.
- * @param priority Priority of the program on the hook.
- * @param link_fd Link file descriptor, only valid if the return value of the
- *        function is 0.
- * @return 0 on success or negative errno value on failure.
- */
-int bf_bpf_nf_link_create(int prog_fd, enum bf_hook hook, int priority,
-                          int *link_fd);
-
-/**
- * Create a XDP BPF link.
- *
- * @param prog_fd File descriptor of the program to attach to the link.
- * @param ifindex Interface index to attach the program to.
- * @param link_fd Link file descriptor, only valid if the return value of the
- *        function is 0.
- * @param mode XDP program attach mode. See @ref bf_xdp_attach_mode.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_bpf_xdp_link_create(int prog_fd, unsigned int ifindex, int *link_fd,
-                           enum bf_xdp_attach_mode mode);
-
-/**
- * Create a cgroup skb link.
- *
- * @param prog_fd File descriptor of the program to attach to the link.
- * @param cgroup_fd File descriptor of the cgroup to attach the program to.
- * @param type Hook type, defines if the program is attached to the ingress or
- *        egress path.
- * @param link_fd Link file descriptor, only valid if the return value of the
- *        function is 0.
- * @return 0 on success, or a negative errno value on failure.
- */
-int bf_bpf_cgroup_link_create(int prog_fd, int cgroup_fd,
-                              enum bpf_attach_type type, int *link_fd);
-
-/**
- * Update the program attached to an XDP BPF link.
- *
- * The type, interface, or XDP mode of the link are left unchanged.
- *
- * @param link_fd File descriptor of the link to update.
- * @param prog_fd File descriptor of the new program to attach to the link.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_bpf_xdp_link_update(int link_fd, int prog_fd);
-
-/**
- * Update the program attached to a BPF link.
- *
- * Every configuration of the link remain unchanged, only the linked BPF
- * program is modified.
- *
- * @param link_fd File descriptor of the link to update.
- * @param prog_fd File descriptor of the new program to attach to the link.
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_bpf_link_update(int link_fd, int prog_fd);
-
-/**
- * Detach a BPF link using its file descriptor.
- *
- * @param link_fd File descriptor of the link to detach. You can get a file
- *        descriptor using @ref bf_bpf_obj_get.
- * @return 0 on success or negative errno value on failure.
- */
-int bf_bpf_link_detach(int link_fd);

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -20,6 +20,8 @@ enum bf_xdp_attach_mode
     BF_XDP_MODE_HW = XDP_FLAGS_HW_MODE,
 };
 
+#define bf_ptr_to_u64(ptr) ((unsigned long long)(ptr))
+
 /**
  * BPF system call.
  *

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -43,8 +43,7 @@ int bf_chain_new(struct bf_chain **chain, enum bf_hook hook,
     _chain->rules = bf_rule_list();
     if (rules) {
         bf_list_foreach (rules, rule_node) {
-            r = bf_list_add_tail(&_chain->rules,
-                                 bf_list_node_get_data(rule_node));
+            r = bf_chain_add_rule(_chain, bf_list_node_get_data(rule_node));
             if (r)
                 return r;
 
@@ -319,6 +318,8 @@ int bf_chain_add_rule(struct bf_chain *chain, struct bf_rule *rule)
 {
     bf_assert(chain);
     bf_assert(rule);
+
+    rule->index = bf_list_size(&chain->rules);
 
     return bf_list_add_tail(&chain->rules, rule);
 }

--- a/src/core/chain.h
+++ b/src/core/chain.h
@@ -82,4 +82,14 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh);
 
 void bf_chain_dump(const struct bf_chain *chain, prefix_t *prefix);
 
+/**
+ * Insert a rule into the chain.
+ *
+ * The chain will own the rule and is responsible for freeing it. The rule's
+ * index will automatically be updated.
+ *
+ * @param chain Chain to insert the rule into. Can't be NULL.
+ * @param rule Rule to insert into the chain. Can't be NULL.
+ * @return 0 on success, or a negative errno value on error.
+ */
 int bf_chain_add_rule(struct bf_chain *chain, struct bf_rule *rule);

--- a/src/core/flavor.h
+++ b/src/core/flavor.h
@@ -8,6 +8,7 @@
 #include "core/verdict.h"
 
 struct bf_program;
+struct bf_link;
 
 /**
  * @file flavor.h
@@ -82,23 +83,28 @@ struct bf_flavor_ops
     int (*get_verdict)(enum bf_verdict verdict);
 
     /**
-     * Load and attach a BPF program.
+     * Attach a program to a hook on the system.
      *
-     * @p new_prog is the new program to be attached to the hook, and @p
-     * old_prog is the existing one.
-     * @p old_prog can be NULL, if no program is already attached. The exact
-     * load and attach mechanism is up to the flavor: direct attach, BPF link,
-     * ...
-     *
-     * If @p old_prog is not NULL, the replacement of @p old_prog by @p new_prog
-     * must be atomic.
+     * @p new_prog is the new program to be attached to the hook, and
+     * @p old_prog is the existing one. @p old_prog can be NULL, if no program
+     * has been attached yet. If @p old_prog is not NULL, the replacement
+     * of @p old_prog by @p new_prog must performed with no downtime.
      *
      * @param new_prog New BPF program to attach to the kernel. Can't be NULL.
      * @param old_prog Previous program to replace.
+     * @param get_new_link_cb Callback to request a new @ref bf_link to the
+     *        program. The program doesn't know how many links are required to
+     *        the BPF program to the hook, but the flavor doesn't have access
+     *        to high-level information such as the link name. This callback
+     *        provides more flexibility by allowing the flavor to request a
+     *        new link configured by the program. If @c old_link is not NULL,
+     *        the new link with contain a valid FD to old link's BPF object.
      * @return 0 on success, or negative errno value on failure.
      */
-    int (*attach_prog)(struct bf_program *new_prog,
-                       struct bf_program *old_prog);
+    int (*attach_prog)(struct bf_program *new_prog, struct bf_program *old_prog,
+                       int (*get_new_link_cb)(struct bf_program *prog,
+                                              struct bf_link *old_link,
+                                              struct bf_link **new_link));
 
     int (*detach_prog)(struct bf_program *program);
 };

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -88,13 +88,13 @@ enum bpf_attach_type bf_hook_to_attach_type(enum bf_hook hook)
     static const enum bpf_attach_type hooks[] = {
         [BF_HOOK_XDP] = 0,
         [BF_HOOK_TC_INGRESS] = BPF_TCX_INGRESS,
-        [BF_HOOK_NF_PRE_ROUTING] = 0,
+        [BF_HOOK_NF_PRE_ROUTING] = BPF_NETFILTER,
         [BF_HOOK_NF_LOCAL_IN] = BPF_NETFILTER,
         [BF_HOOK_CGROUP_INGRESS] = BPF_CGROUP_INET_INGRESS,
         [BF_HOOK_CGROUP_EGRESS] = BPF_CGROUP_INET_EGRESS,
         [BF_HOOK_NF_FORWARD] = BPF_NETFILTER,
         [BF_HOOK_NF_LOCAL_OUT] = BPF_NETFILTER,
-        [BF_HOOK_NF_POST_ROUTING] = 0,
+        [BF_HOOK_NF_POST_ROUTING] = BPF_NETFILTER,
         [BF_HOOK_TC_EGRESS] = BPF_TCX_EGRESS,
     };
 

--- a/tests/harness/filters.c
+++ b/tests/harness/filters.c
@@ -22,7 +22,6 @@
 #include "core/verdict.h"
 
 #define _clean_bf_list_ __attribute__((__cleanup__(bf_list_clean)))
-#define _BF_CHAIN_SUFFIX_LEN 6
 
 struct bf_hook_opts bf_hook_opts_get(enum bf_hook_opt opt, ...)
 {
@@ -143,29 +142,6 @@ err_free_matchers:
     return NULL;
 }
 
-static const char *_bf_tmpnam(const char *prefix, size_t len)
-{
-    static const char sym[] =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    static const size_t sym_len = sizeof(sym);
-
-    _cleanup_free_ char *name = NULL;
-    size_t prefix_len = strlen(prefix);
-    size_t name_len = prefix_len + len + 1;
-
-    name = malloc(name_len);
-    if (!name)
-        return NULL;
-
-    strncpy(name, prefix, name_len);
-    for (; prefix_len < name_len - 1; ++prefix_len)
-        name[prefix_len] = sym[rand() % sym_len];
-
-    name[prefix_len] = '\0';
-
-    return TAKE_PTR(name);
-}
-
 struct bf_chain *bf_test_chain_get(enum bf_hook hook, enum bf_verdict policy,
                                    struct bf_set **sets, struct bf_rule **rules)
 {
@@ -205,7 +181,7 @@ struct bf_chain *bf_test_chain_get(enum bf_hook hook, enum bf_verdict policy,
         .attach = false,
         .cgroup = strdup("<no_cgroup>"),
         .ifindex = 1,
-        .name = _bf_tmpnam("bf_e2e_", _BF_CHAIN_SUFFIX_LEN),
+        .name = strdup(BF_E2E_NAME),
     };
 
     return TAKE_PTR(chain);

--- a/tests/harness/filters.h
+++ b/tests/harness/filters.h
@@ -30,6 +30,8 @@
  * `bf_test_chain_get()`.
  */
 
+#define BF_E2E_NAME "bf_e2e"
+
 /**
  * Create a new hook options object.
  *

--- a/tests/harness/prog.c
+++ b/tests/harness/prog.c
@@ -17,6 +17,7 @@
 #include "core/chain.h"
 #include "core/helper.h"
 #include "core/logger.h"
+#include "harness/filters.h"
 #include "libbpfilter/bpfilter.h"
 
 struct bf_test_prog *bf_test_prog_get(const struct bf_chain *chain)
@@ -36,7 +37,7 @@ struct bf_test_prog *bf_test_prog_get(const struct bf_chain *chain)
         return NULL;
     }
 
-    r = bf_test_prog_open(prog, chain->hook_opts.name);
+    r = bf_test_prog_open(prog, BF_E2E_NAME "_prg");
     if (r < 0) {
         bf_err_r(r, "failed to open the bf_test_prog's BPF program");
         return NULL;

--- a/tools/benchmarks/benchmark.cpp
+++ b/tools/benchmarks/benchmark.cpp
@@ -767,7 +767,7 @@ int Program::open()
             return r;
         }
 
-        if (::std::string(info.name) == name_) {
+        if (::std::string(info.name) == (name_ + "_prg")) {
             fd_ = prog_fd;
             return 0;
         }


### PR DESCRIPTION
BPF Netfilter hooks [do not allow `NFPROTO_INET`](https://elixir.bootlin.com/linux/v6.13.3/source/net/netfilter/nf_bpf_link.c#L184) packet family to be used. Hence, a `bpfilter` program can not filter on both IPv4 and IPv6 traffic at once. This PR aims to resolve this to ensure Netfilter programs behave similarly to XDP, TC, and cgroup programs.

The core of this PR is the change to `bf_program` to allow multiple BPF links to be created for a single program. In details:
- Ensure `bf_cgen` structures are not erroneously freed during chain creation (fix #218)
- Add missing attach type for `BF_HOOK_NF_PRE_ROUTING` and `BF_HOOK_NF_POST_ROUTING` (fix #211)
- Update the `ipt` front-end to use chains instead of codegen structure (making chains update easier)
- Introduce the `bf_link` object to materialize a BPF link in `bpfilter`
- Store a list of `bf_link` in `bf_program`, instead of a single `int link_fd`
