### PR TITLE
bfcli: add ruleset-get with counters

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -30,6 +30,21 @@ Define a new ruleset: read the chains and rules defined on the command line or i
     bfcli ruleset set --file myruleset.tx
     bfcli ruleset set --str "chain BF_HOOK_XDP policy ACCEPT rule ip4.saddr in {192.168.1.1} ACCEPT"
 
+``ruleset get``
+~~~~~~~~~~~~~~~
+
+Get all rules: requests the daemon to return all chains and all rules of each chain to the CLI. Optionally include rule counter values.
+
+**Options**
+  - ``--with-counters``: Include if you would like to see counter values for each rule.
+
+**Example**
+
+.. code:: shell
+
+    bfcli ruleset get
+    bfcli ruleset get --with-counters
+
 ``ruleset flush``
 ~~~~~~~~~~~~~~~~~
 

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
     const char *obj_str = NULL;
     const char *action_str = NULL;
     int argv_skip = 0;
-    int r;
+    int r = 0;
 
     if (argc > 1 && argv[1][0] != '-') {
         obj_str = argv[1];
@@ -197,6 +197,20 @@ int main(int argc, char *argv[])
 
     if (streq(obj_str, "ruleset") && streq(action_str, "set")) {
         r = _bf_do_ruleset_set(argc, argv);
+    } else if (streq(obj_str, "ruleset") && streq(action_str, "get")) {
+        if (argc == 1) {
+            r = bf_cli_ruleset_get(false);
+            if (r < 0)
+                bf_err_r(r, "Failed to get ruleset");
+        } else {
+            if (argc == 2 && streq(argv[1], "--with-counters")) {
+                r = bf_cli_ruleset_get(true);
+                if (r < 0)
+                    bf_err_r(r, "Failed to get ruleset");
+            } else {
+                bf_err_r(-EINVAL, "Unrecognized argument '%s'", argv[1]);
+            }
+        }
     } else if (streq(obj_str, "ruleset") && streq(action_str, "flush")) {
         r = bf_cli_ruleset_flush();
     } else {

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -7,15 +7,19 @@
 #include <stdlib.h>
 
 #include "bpfilter/cgen/cgen.h"
+#include "bpfilter/cgen/program.h"
 #include "bpfilter/ctx.h"
 #include "bpfilter/xlate/front.h"
 #include "core/chain.h"
 #include "core/front.h"
 #include "core/helper.h"
+#include "core/hook.h"
+#include "core/list.h"
 #include "core/logger.h"
 #include "core/marsh.h"
 #include "core/request.h"
 #include "core/response.h"
+#include "core/rule.h"
 
 static int _bf_cli_setup(void);
 static int _bf_cli_teardown(void);
@@ -54,6 +58,206 @@ int _bf_cli_ruleset_flush(const struct bf_request *request,
         return bf_err_r(r, "failed to flush the context");
 
     return bf_response_new_success(response, NULL, 0);
+}
+
+static void bf_nop_free(struct bf_chain **chain)
+{
+    UNUSED(chain);
+}
+
+static size_t _bf_cli_num_rules(bf_list *chain_list)
+{
+    bf_assert(chain_list);
+
+    size_t count = 0;
+    bf_list_foreach (chain_list, chain_node) {
+        struct bf_chain *chain = bf_list_node_get_data(chain_node);
+
+        count += bf_list_size(&chain->rules);
+    }
+
+    return count;
+}
+
+static int _bf_get_ctr_vals(bf_list *chain_list, struct bf_counter *counters)
+{
+    int counter_index = 0;
+    int r;
+
+    bf_assert(chain_list);
+    bf_assert(counters);
+
+    bf_list_foreach (chain_list, chain_node) {
+        struct bf_chain *chain = bf_list_node_get_data(chain_node);
+        if (!chain)
+            bf_err("Chain list element pointed to null data\n");
+
+        bf_assert(chain);
+
+        struct bf_cgen *cgen = bf_ctx_get_cgen(chain->hook, NULL);
+        if (!cgen)
+            bf_err("Got a null cgen for chain element\n");
+
+        // Iterate over each rule in the current chain
+        int map_idx = 0;
+        bf_list_foreach (&chain->rules, rule_node) {
+            struct bf_rule *rule = bf_list_node_get_data(rule_node);
+            if (!chain)
+                bf_err("Rule list element pointed to null data\n");
+
+            if (rule->counters) {
+                // Query the BPF map for the counter values
+                r = bf_cgen_get_counter(cgen, map_idx,
+                                        &counters[counter_index]);
+                if (r < 0)
+                    return bf_err_r(r, "Failed to get rule counter\n");
+            }
+
+            /* Note: The map has entries for every rule regardless of whether the
+             * input rule specified "COUNTERS" or not. Thus, advancing map_index
+             * is unconditional. When rule->counters == false, the corresponding
+             * counter value will remain {0,0}. */
+            counter_index++;
+            map_idx++;
+        }
+
+        // Chain's policy counter
+        r = bf_cgen_get_counter(cgen, BF_COUNTER_POLICY,
+                                &counters[counter_index]);
+        if (r < 0)
+            return bf_err_r(r, "Failed to get policy counter\n");
+        counter_index++;
+
+        // Chain's error counter
+        r = bf_cgen_get_counter(cgen, BF_COUNTER_ERRORS,
+                                &counters[counter_index]);
+        if (r < 0)
+            return bf_err_r(r, "Failed to get error counter\n");
+    }
+
+    return 0;
+}
+
+static int _bf_cli_get_chain_list(bf_list **chain_list)
+{
+    bf_list_ops ops = {// chain_list will only contain the chains, not own them.
+                       .free = (bf_list_ops_free)bf_nop_free,
+                       .marsh = (bf_list_ops_marsh)bf_chain_marsh};
+
+    int r = bf_list_new(chain_list, &ops);
+    if (r < 0)
+        return bf_err_r(r, "Failed to create the chain list");
+
+    // Loop over codegens which correspond to hooks
+    for (int i = 0; i < _BF_HOOK_MAX; ++i) {
+        struct bf_cgen *cgen;
+
+        cgen = bf_ctx_get_cgen(i, NULL);
+
+        if (!cgen || !cgen->chain)
+            continue;
+
+        r = bf_list_add_tail(*chain_list, cgen->chain);
+        if (r)
+            return bf_err_r(r, "Failed to add chain to list");
+    }
+
+    return 0;
+}
+
+static int _bf_cli_get_counters_marsh(struct bf_marsh **counter_marsh,
+                                      bf_list *chain_list, bool with_counters)
+{
+    int r;
+    size_t num_counters = 0;
+    struct bf_counter *counters = NULL;
+
+    bf_assert(bf_list_size(chain_list) > 0);
+
+    // If we don't want counters, return an empty marsh
+    if (!with_counters) {
+        r = bf_marsh_new(counter_marsh, NULL, 0);
+        return r;
+    }
+
+    /* Each chain has a policy counter and an error counter.
+     * Each rule has a counter, though it may be unused. */
+    num_counters =
+        (2 * bf_list_size(chain_list)) + _bf_cli_num_rules(chain_list);
+
+    // We must have at least have the two chain counters
+    bf_assert(num_counters >= 2);
+
+    counters = calloc(num_counters, sizeof(struct bf_counter));
+    if (!counters)
+        bf_err_r(-ENOMEM, "Failed to allocate memory for counters\n");
+
+    r = _bf_get_ctr_vals(chain_list, counters);
+    if (r < 0)
+        return bf_err_r(r, "Could not get ctr vals\n");
+
+    size_t marsh_size = num_counters * sizeof(struct bf_counter);
+
+    r = bf_marsh_new(counter_marsh, counters, marsh_size);
+    if (r < 0)
+        if (r < 0)
+            return bf_err_r(r, "Failed to make new marsh\n");
+
+    free(counters);
+
+    return 0;
+}
+
+static int _bf_cli_get_rules(const struct bf_request *request,
+                             struct bf_response **response)
+{
+    _cleanup_bf_marsh_ struct bf_marsh *chain_list_marsh = NULL;
+    _cleanup_bf_marsh_ struct bf_marsh *counter_marsh = NULL;
+    _cleanup_bf_marsh_ struct bf_marsh *result_marsh = NULL;
+    int r;
+
+    // Empty context, nothing to return
+    if (bf_ctx_is_empty()) {
+        return bf_response_new_success(response, NULL, 0);
+    }
+
+    {
+        _cleanup_bf_list_ bf_list *chain_list = NULL;
+
+        r = _bf_cli_get_chain_list(&chain_list);
+        if (r < 0)
+            return bf_err_r(r, "Failed to create the chain list");
+
+        // Because the context is not empty, we must have at least one chain
+        bf_assert(bf_list_size(chain_list) > 0);
+
+        // Marsh the chain list
+        r = bf_list_marsh(chain_list, &chain_list_marsh);
+        if (r < 0)
+            return bf_err_r(r, "Failed to marshal list\n");
+
+        // Marsh the counters
+        r = _bf_cli_get_counters_marsh(&counter_marsh, chain_list,
+                                       request->with_counters);
+        if (r < 0)
+            return bf_err_r(r, "Failed to get counters marsh\n");
+    }
+
+    // Marsh the chain list and counters marshes into a single response
+    r = bf_marsh_new(&result_marsh, NULL, 0);
+    if (r < 0)
+        return bf_err_r(r, "Failed to get new marsh\n");
+
+    r = bf_marsh_add_child_obj(&result_marsh, chain_list_marsh);
+    if (r < 0)
+        return bf_err_r(r, "Failed to add chain list to marsh\n");
+
+    r = bf_marsh_add_child_obj(&result_marsh, counter_marsh);
+    if (r < 0)
+        return bf_err_r(r, "Failed to add counter to marsh\n");
+
+    return bf_response_new_success(response, (void *)result_marsh,
+                                   bf_marsh_size(result_marsh));
 }
 
 int _bf_cli_set_rules(const struct bf_request *request,
@@ -113,6 +317,9 @@ static int _bf_cli_request_handler(struct bf_request *request,
         break;
     case BF_REQ_RULES_SET:
         r = _bf_cli_set_rules(request, response);
+        break;
+    case BF_REQ_RULES_GET:
+        r = _bf_cli_get_rules(request, response);
         break;
     default:
         r = bf_err_r(-EINVAL, "unsupported command %d for CLI front-end",

--- a/src/core/request.h
+++ b/src/core/request.h
@@ -63,6 +63,11 @@ struct bf_request
         {
             int ipt_cmd;
         };
+
+        struct
+        {
+            bool with_counters;
+        };
     };
 
     size_t data_len;

--- a/src/libbpfilter/bpfilter.h
+++ b/src/libbpfilter/bpfilter.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 struct bf_chain;
@@ -27,6 +28,15 @@ const char *bf_version(void);
  * @return 0 on success, or a negative errno value on error.
  */
 int bf_cli_ruleset_flush(void);
+
+/**
+ * Request the daemon to return all the chains and all of
+ * the associated rules.
+ *
+ * @param with_counters If true, the daemon will return the counters.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_cli_ruleset_get(bool with_counters);
 
 /**
  * Send a chain to the daemon.

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -7,12 +7,194 @@
 #include <string.h>
 
 #include "core/chain.h"
+#include "core/counter.h"
 #include "core/front.h"
+#include "core/helper.h"
 #include "core/logger.h"
 #include "core/marsh.h"
 #include "core/request.h"
 #include "core/response.h"
+#include "core/rule.h"
 #include "libbpfilter/generic.h"
+
+// TODO: Obviously resolve this duplication of bf_dump_hex
+#define BF_DUMP_HEXDUMP_LEN 8
+#define BF_DUMP_TOKEN_LEN 5
+
+static void bf_dump_hex_local(const void *data, size_t len)
+{
+    // 5 characters per byte (0x%02x) + 1 for the null terminator.
+    char buf[(BF_DUMP_HEXDUMP_LEN * BF_DUMP_TOKEN_LEN) + 1];
+    const void *end = data + len;
+
+    while (data < end) {
+        char *line = buf;
+        for (size_t i = 0; i < BF_DUMP_HEXDUMP_LEN && data < end; ++i, ++data)
+            line += sprintf(line, "0x%02x ", *(unsigned char *)data);
+
+        // NOLINTNEXTLINE
+        fprintf(stderr, "%s", buf);
+    }
+}
+
+// TODO: Sort out our use of fprintf vs DUMP
+// NOLINTBEGIN
+static void bf_cli_chain_dump(struct bf_chain *chain, bool with_counters,
+                              struct bf_counter **counter)
+{
+    // Dump chain info
+    fprintf(stderr, "chain %s", bf_hook_to_str(chain->hook));
+    fprintf(stderr, "{");
+
+    struct bf_hook_opts *opts = &chain->hook_opts;
+
+    // Ignore unused
+    fprintf(stderr, "attach=%s,", opts->attach ? "yes" : "no");
+    fprintf(stderr, "ifindex=%d", opts->ifindex);
+    if (opts->name)
+        fprintf(stderr, ",name=%s", opts->name);
+    fprintf(stderr, "}");
+    fprintf(stderr, " policy: %s\n", bf_verdict_to_str(chain->policy));
+
+    if (with_counters) {
+        // Policy counter is the first one after the rules; error counter follows it.
+        struct bf_counter *chain_counter =
+            *counter + bf_list_size(&chain->rules);
+        fprintf(stderr, "\tcounters: policy %lu bytes %lu packets; ",
+                chain_counter->bytes, chain_counter->packets);
+
+        chain_counter++;
+
+        fprintf(stderr, "error %lu bytes %lu packets\n", chain_counter->bytes,
+                chain_counter->packets);
+    }
+
+    // Loop over rules
+    bf_list_foreach (&chain->rules, rule_node) {
+        struct bf_rule *rule = bf_list_node_get_data(rule_node);
+
+        fprintf(stderr, "\trule: %d\n", rule->index);
+        // Matchers
+        fprintf(stderr, "\t\tmatcher(s):\n");
+        bf_list_foreach (&rule->matchers, matcher_node) {
+            struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
+            fprintf(stderr, "\t\t\t\%s", bf_matcher_type_to_str(matcher->type));
+            fprintf(stderr, " %s ", bf_matcher_op_to_str(matcher->op));
+
+            bf_opts_set_verbose(BF_VERBOSE_DEBUG);
+            bf_dump_hex_local(matcher->payload,
+                              matcher->len - sizeof(struct bf_matcher));
+            fprintf(stderr, "\n");
+        }
+        // remove yes no print, make this conditional
+        if (with_counters && rule->counters) {
+            fprintf(stderr, "\t\tcounters: %lu bytes %lu packets\n",
+                    (*counter)->bytes, (*counter)->packets);
+            (*counter)++;
+        }
+
+        fprintf(stderr, "\t\tverdict: %s\n", bf_verdict_to_str(rule->verdict));
+    }
+
+    // Skip over the policy and error counters
+    (*counter) += 2;
+
+    fprintf(stderr, "\n");
+}
+
+// NOLINTEND
+
+static int bf_cli_request_ruleset(struct bf_response **response,
+                                  bool with_counters)
+{
+    _cleanup_bf_request_ struct bf_request *request = NULL;
+    int r;
+
+    r = bf_request_new(&request, NULL, 0);
+    if (r < 0)
+        return bf_err_r(r, "Failed to init request");
+
+    request->front = BF_FRONT_CLI;
+    request->cmd = BF_REQ_RULES_GET;
+    request->with_counters = with_counters;
+
+    r = bf_send(request, response);
+    if (r < 0)
+        return bf_err_r(r, "Failed to send a ruleset get request");
+
+    if ((*response)->type == BF_RES_FAILURE)
+        return (*response)->error;
+
+    return 0;
+}
+
+static int bf_cli_dump_ruleset(struct bf_marsh *chain_list_marsh,
+                               struct bf_marsh *counters_marsh,
+                               bool with_counters)
+{
+    bf_assert(chain_list_marsh);
+    bf_assert(counters_marsh);
+
+    struct bf_counter *counters = (struct bf_counter *)counters_marsh->data;
+    struct bf_marsh *chain_marsh = NULL;
+    int r;
+
+    // Loop over the chains
+    while (true) {
+        // Get the next child
+        chain_marsh = bf_marsh_next_child(chain_list_marsh, chain_marsh);
+        if (!chain_marsh) {
+            break;
+        }
+
+        _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+        r = bf_chain_new_from_marsh(&chain, chain_marsh);
+        if (r < 0)
+            return bf_err_r(r, "Failed to unmarsh chain");
+
+        bf_cli_chain_dump(chain, with_counters, &counters);
+    }
+
+    return 0;
+}
+
+int bf_cli_ruleset_get(bool with_counters)
+{
+    int r;
+
+    _cleanup_bf_response_ struct bf_response *response = NULL;
+    r = bf_cli_request_ruleset(&response, with_counters);
+    if (r < 0)
+        return bf_err_r(r, "Failed to request ruleset\n");
+
+    if (response->type == BF_RES_FAILURE)
+        return bf_err_r(response->error, "Failed to get ruleset\n");
+
+    if (response->data_len == 0) {
+        // NOLINTNEXTLINE
+        fprintf(stderr, "No ruleset returned\n");
+        return 0;
+    }
+
+    struct bf_marsh *chains_and_counters_marsh =
+        (struct bf_marsh *)response->data;
+
+    // Get the chain list
+    struct bf_marsh *chain_list_marsh =
+        bf_marsh_next_child(chains_and_counters_marsh, NULL);
+    if (!chain_list_marsh) {
+        bf_err("Failed to locate chain list from daemon response\n");
+    }
+
+    // Get the array of counters
+    struct bf_marsh *counters_marsh =
+        bf_marsh_next_child(chains_and_counters_marsh, chain_list_marsh);
+    if (!counters_marsh) {
+        bf_err("Failed to locate counter array from daemon response\n");
+    }
+
+    return bf_cli_dump_ruleset(chain_list_marsh, counters_marsh, with_counters);
+}
 
 int bf_cli_ruleset_flush(void)
 {


### PR DESCRIPTION
Extends the bfcli front-end API to include a "get" action for the "ruleset" object. When used, bfcli requests the ruleset from the running daemon and the daemon responds with the ruleset. The ruleset contains all of the loaded chains and their associated rules. When the user specifies the --with-counters flag after the "get" action, the daemon additionally returns counters for the chains and rules. bfcli prints the ruleset and counters to standard error.

Some opportunities for improvement: 1) Adding tests. 2) bfcli's functionality for printing the ruleset (bf_cli_chain_dump()) should be considered a draft pending further discussion on how best to carry this out. Perhaps the DUMP() macros should be used instead of bare calls to fprintf().