### PR TITLE
cgen: copy BPF object names using `strncpy()` instead of `snprintf()`

### DIFF
--- a/src/bpfilter/cgen/prog/link.c
+++ b/src/bpfilter/cgen/prog/link.c
@@ -33,8 +33,7 @@ int bf_link_new(struct bf_link **link, const char *name, enum bf_hook hook)
     if (!_link)
         return -ENOMEM;
 
-    // snprintf() will write the \0 as part of the BPF_OBJ_NAME_LEN bytes
-    (void)snprintf(_link->name, BPF_OBJ_NAME_LEN, name);
+    strncpy(_link->name, name, BPF_OBJ_NAME_LEN);
 
     _link->fd = -1;
     _link->hook = hook;

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -42,7 +42,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
     _map->value_size = value_size;
     _map->n_elems = n_elems;
 
-    (void)snprintf(_map->name, BPF_OBJ_NAME_LEN, name);
+    strncpy(_map->name, name, BPF_OBJ_NAME_LEN);
 
     *map = TAKE_PTR(_map);
 

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -125,8 +125,8 @@ static int _bf_program_genid(struct bf_program *program)
 
     // If the chain has a name, use it as ID
     if (program->runtime.chain->hook_opts.used_opts & (1 << BF_HOOK_OPT_NAME)) {
-        (void)snprintf(program->id, BF_PROG_ID_LEN,
-                       program->runtime.chain->hook_opts.name);
+        strncpy(program->id, program->runtime.chain->hook_opts.name,
+                BF_PROG_ID_LEN);
         return 0;
     }
 


### PR DESCRIPTION
GCC complains about `snprintf()` usage if the format string doesn't contain any format argument. This warning is turned into an error when creating the package.