### PR TITLE
build: allow `DEFAULT_PROJECT_VERSION` to be set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,12 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+if (NOT DEFINED DEFAULT_PROJECT_VERSION)
+    set(DEFAULT_PROJECT_VERSION 0.0.0)
+endif ()
+
 project(bpfilter
-    VERSION 0.0.0   # Leave as is, version number is updated based on Git
+    VERSION ${DEFAULT_PROJECT_VERSION}
     DESCRIPTION "BPF-based packet filtering framework"
     LANGUAGES C
 )
@@ -12,7 +16,6 @@ project(bpfilter
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/tools/cmake")
 
 include(GitVersion)
-
 get_version_from_git()
 message(NOTICE "bpfilter version ${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX}")
 


### PR DESCRIPTION
By default, if the current project version can't be deduced from the Git history, the project will use 0.0.0. This can cause issues when building the RPM package as it uses a tarball instead of the repository, meaning there is no Git history.

DEFAULT_PROJECT_VERSION can be set from the command line to define the version of the project.