### PR TITLE
Fix `benchreport` commit details

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -127,6 +127,7 @@ add_custom_command(
 add_custom_command(
 	COMMAND
 		${CMAKE_CURRENT_SOURCE_DIR}/benchreport
+			--sources ${CMAKE_SOURCE_DIR}
 			--results ${CMAKE_BINARY_DIR}/output/benchmarks
 			--template ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks.html.template
 			--output ${CMAKE_CURRENT_BINARY_DIR}/html/external/benchmarks/index.html

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -31,7 +31,9 @@ def main() -> None:
     commits = []
     benchNames = []
     parser = argparse.ArgumentParser(
-        prog="benreport", description="Generate an HTML report for bpfilter benchmarks"
+        prog="benchreport",
+        description="Generate an HTML report for bpfilter benchmarks",
+    )
     )
     parser.add_argument(
         "-r", "--results", help="Directory containing the benchmark results"

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -8,30 +8,36 @@ import sys
 import os
 import argparse
 
+
 def log(msg: str, verbose: bool = True) -> None:
     if verbose:
         print(msg)
 
+
 def warning(msg: str) -> None:
-    print('\033[1;93m' + msg + '\033[0m')
+    print("\033[1;93m" + msg + "\033[0m")
+
 
 def error(msg: str) -> None:
-    print('\033[1;31m' + msg + '\033[0m')
+    print("\033[1;31m" + msg + "\033[0m")
+
 
 def main() -> None:
     benchmarks = {"commits": [], "results": {}}
     commits = []
     benchNames = []
     parser = argparse.ArgumentParser(
-                    prog='benreport',
-                    description='Generate an HTML report for bpfilter benchmarks')
-    parser.add_argument('-r', '--results', help="Directory containing the benchmark results")
-    parser.add_argument('-t', '--template', help="HTML report template file")
-    parser.add_argument('-o', '--output', help="Output HTML file")
+        prog="benreport", description="Generate an HTML report for bpfilter benchmarks"
+    )
+    parser.add_argument(
+        "-r", "--results", help="Directory containing the benchmark results"
+    )
+    parser.add_argument("-t", "--template", help="HTML report template file")
+    parser.add_argument("-o", "--output", help="Output HTML file")
     args = parser.parse_args()
 
     verbose = False
-    if int(os.environ.get('VERBOSE', '0')):
+    if int(os.environ.get("VERBOSE", "0")):
         verbose = True
 
     files = list(pathlib.Path(args.results).glob("*.json"))
@@ -89,5 +95,5 @@ def main() -> None:
     log(f"Benchmark report generated at '{args.output}'", verbose)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -8,9 +8,11 @@ import sys
 import os
 import argparse
 
+VERBOSE: bool = False
 
-def log(msg: str, verbose: bool = True) -> None:
-    if verbose:
+
+def log(msg: str) -> None:
+    if VERBOSE:
         print(msg)
 
 
@@ -23,6 +25,8 @@ def error(msg: str) -> None:
 
 
 def main() -> None:
+    global VERBOSE
+
     benchmarks = {"commits": [], "results": {}}
     commits = []
     benchNames = []
@@ -34,11 +38,12 @@ def main() -> None:
     )
     parser.add_argument("-t", "--template", help="HTML report template file")
     parser.add_argument("-o", "--output", help="Output HTML file")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Produce a verbose output"
+    )
     args = parser.parse_args()
 
-    verbose = False
-    if int(os.environ.get("VERBOSE", "0")):
-        verbose = True
+    VERBOSE = args.verbose
 
     files = list(pathlib.Path(args.results).glob("*.json"))
     if not files:
@@ -47,7 +52,7 @@ def main() -> None:
 
     for file in files:
         with open(file, "r", encoding="utf-8") as f:
-            log(f"Reading results from {file}", verbose)
+            log(f"Reading benchmark results from {file}")
             d = json.load(f)
 
             gitrev = d["context"]["gitrev"]
@@ -92,7 +97,7 @@ def main() -> None:
         with open(args.template, "r", encoding="utf-8") as template_file:
             template = template_file.read()
         f.write(template.replace("{{ DATA }}", json.dumps(benchmarks)))
-    log(f"Benchmark report generated at '{args.output}'", verbose)
+    log(f"Benchmark report generated at {args.output}")
 
 
 if __name__ == "__main__":

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -34,6 +34,8 @@ def main() -> None:
         prog="benchreport",
         description="Generate an HTML report for bpfilter benchmarks",
     )
+    parser.add_argument(
+        "-s", "--sources", default=".", help="Sources directory containing .git"
     )
     parser.add_argument(
         "-r", "--results", help="Directory containing the benchmark results"
@@ -77,7 +79,7 @@ def main() -> None:
                     error("Only ns time unit is supported")
                     sys.exit(-1)
 
-    repo = git.Repo.init("~/Projects/bpfilter")
+    repo = git.Repo.init(args.sources)
 
     for commit, date, _ in sorted(commits, key=lambda tup: tup[2]):
         try:


### PR DESCRIPTION
The benchmark report published on [bpfilter.io/external/benchmarks](https://bpfilter.io/external/benchmarks/index.html) doesn't provide details about the commits. This is due to the hardcoded path to the sources directory in `benchreport`. Because the path is invalid on the CI machine, `benchreport` could not find the Git history. Make the path configurable so it is defined based on `CMAKE_SOURCE_DIR`.