### PR TITLE
core: list: add `bf_list_move()` to safely move an initialized list

### DIFF
--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -322,7 +322,7 @@ static int _bf_ctx_get_cgens_for_front(const struct bf_ctx *ctx, bf_list *cgens,
         }
     }
 
-    bf_swap(*cgens, _cgens);
+    *cgens = bf_list_move(_cgens);
 
     return 0;
 }

--- a/src/core/list.h
+++ b/src/core/list.h
@@ -142,6 +142,25 @@ typedef struct
     ((bf_list) {.ops = bf_list_ops_default(free_cb, marsh_cb)})
 
 /**
+ * Move a list.
+ *
+ * Move a list from @p list and return it. Once moved, the original list will
+ * be empty, and @ref bf_list_clean can be called on it safely. The list it
+ * has been moved to will be overriden and @ref bf_list_clean should be
+ * called on it.
+ *
+ * @param list List to move.
+ * @return The moved list.
+ */
+#define bf_list_move(list)                                                     \
+    ({                                                                         \
+        bf_list *__list = &(list);                                             \
+        bf_list _list = *__list;                                               \
+        *__list = bf_list_default(NULL, NULL);                                 \
+        _list;                                                                 \
+    })
+
+/**
  * Allocate and initialise a new list.
  *
  * @param list Pointer to the list to initialise. Must be non-NULL.


### PR DESCRIPTION
`bf_list_move()` moves a list from a variable to another. The moved source variable doesn't reference any data anymore and `bf_list_clean()` can be called on it safely. The moved to variable has to call `bf_list_clean()` to free the resources.