### PR TITLE
cgen: ip4: fix IPv4 mask support

### DIFF
--- a/src/bpfilter/cgen/matcher/ip4.c
+++ b/src/bpfilter/cgen/matcher/ip4.c
@@ -38,6 +38,7 @@ _bf_matcher_generate_ip4_addr_unique(struct bf_program *program,
 
     if (addr->mask != ~0U) {
         EMIT(program, BPF_MOV32_IMM(BPF_REG_3, addr->mask));
+        EMIT(program, BPF_ALU32_REG(BPF_AND, BPF_REG_1, BPF_REG_3));
         EMIT(program, BPF_ALU32_REG(BPF_AND, BPF_REG_2, BPF_REG_3));
     }
 


### PR DESCRIPTION
The IPv4 address mask defined in a matcher was applied to the reference address (also defined in the matcher), but not the IPv4 address in the packet.

Apply the mask to both the address in the matcher and in the packet before comparing them.