### PR TITLE
Add support for network and mount namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -95,7 +95,7 @@ CheckOptions:
   # and will behave differently for macros. Hence clang-tidy v18+ won't
   # warn about _cleanup_ identifiers.
   - key: bugprone-reserved-identifier.AllowedIdentifiers
-    value: '^_(_start|_stop|bf|BF|cleanup)_[a-zA-Z0-9_]+$'
+    value: '^_(_start|_stop|bf|BF|cleanup|GNU)_[a-zA-Z0-9_]+$'
   - key: misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
     value: true
   # Unless a *statement* takes 1 line, it should be in braces
@@ -103,10 +103,10 @@ CheckOptions:
     value: 6
   # Allowed short variable names
   - key: readability-identifier-length.IgnoredVariableNames
-    value: '_|i|fd|r|j[0-9]|op'
+    value: '_|i|fd|r|j[0-9]|op|ns'
   # Allowed short parameter names
   - key: readability-identifier-length.IgnoredParameterNames
-    value: 'ip|fd|op|id|cb'
+    value: 'ip|fd|op|id|cb|ns'
   # Allow for magic constants that are power of 2.
   - key: readability-magic-numbers.IgnorePowersOf2IntegerValues
     value: true

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -60,6 +60,7 @@ set(doc_srcs
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/style.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/tests.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/index.rst
+	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/core.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/bpfilter.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/xlate/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/xlate/ipt.rst

--- a/doc/developers/modules/core.rst
+++ b/doc/developers/modules/core.rst
@@ -1,0 +1,8 @@
+core
+====
+
+Namespaces
+----------
+
+.. doxygenfile:: ns.h
+   :sections: briefdescription detaileddescription typedef struct innerclass enum var define func

--- a/doc/developers/modules/index.rst
+++ b/doc/developers/modules/index.rst
@@ -5,6 +5,7 @@ Modules
    :maxdepth: 2
    :caption: Modules
 
+   core
    bpfilter
    xlate/index
 

--- a/doc/usage/daemon.rst
+++ b/doc/usage/daemon.rst
@@ -30,3 +30,12 @@ Runtime data
 
 .. warning::
     If ``bpfilter`` fails to restore its state after restarting, its data can be cleanup up by removing both those directories. Doing so will remove all your filtering rules.
+
+Namespaces
+----------
+
+``bpfilter`` supports the network and mount Linux namespaces. The daemon will automatically switch to the client's namespace before attaching a BPF program, so it is guaranteed to have the same view of the system as the client.
+
+The network namespace will define the available interface indexes to attach the XDP and TC chains, as well as the interface indexes to filter packets on.
+
+The mount namespace is required to ensure the daemon will attach a CGroup chain to the proper CGroup.

--- a/src/bpfilter/cgen/cgen.h
+++ b/src/bpfilter/cgen/cgen.h
@@ -14,6 +14,7 @@
 struct bf_chain;
 struct bf_marsh;
 struct bf_program;
+struct bf_ns;
 
 #define _cleanup_bf_cgen_ __attribute__((cleanup(bf_cgen_free)))
 
@@ -101,9 +102,11 @@ int bf_cgen_marsh(const struct bf_cgen *cgen, struct bf_marsh **marsh);
  *        will take ownership of the new chain and the caller will be
  *        responsible for freeing the old one. Can't be NULL, @c *chain must
  *        point to a valid @ref bf_chain .
+ * @param ns Namespaces to switch to before attaching the programs. Can't be NULL.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **chain);
+int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **chain,
+                   const struct bf_ns *ns);
 
 /**
  * Create a @ref bf_program for each interface, generate the program, load it,
@@ -113,9 +116,10 @@ int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **chain);
  * programs to the systems, starting from a new @ref bf_cgen.
  *
  * @param cgen Codegen to generate the programs for, and load to the system.
+ * @param ns Namespaces to switch to before attaching the programs. Can't be NULL.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_cgen_up(struct bf_cgen *cgen);
+int bf_cgen_up(struct bf_cgen *cgen, const struct bf_ns *ns);
 
 /**
  * Unload a codegen's BPF programs.

--- a/src/bpfilter/ctx.h
+++ b/src/bpfilter/ctx.h
@@ -32,6 +32,7 @@
 
 struct bf_cgen;
 struct bf_marsh;
+struct bf_ns;
 
 /**
  * Initialise the global context.
@@ -125,3 +126,15 @@ int bf_ctx_get_cgens_for_front(bf_list *cgens, enum bf_front front);
  *         depend on the hook), @c -EEXIT is returned.
  */
 int bf_ctx_set_cgen(struct bf_cgen *cgen);
+
+/**
+ * Get the daemon's original namespaces.
+ *
+ * During the creation of the global context, the daemon will open a reference
+ * to its namespaces. This is required to jump a a client's namespace on request
+ * and come back to the original namespace afterward. This function returns a
+ * pointer to the `bf_ns` object referencing the original namespaces.
+ *
+ * @return A `bf_ns` object pointer.
+ */
+struct bf_ns *bf_ctx_get_ns(void);

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -79,7 +79,7 @@ int _bf_cli_set_rules(const struct bf_request *request,
         if (r)
             return r;
 
-        r = bf_cgen_up(cgen);
+        r = bf_cgen_up(cgen, request->ns);
         if (r < 0) {
             bf_cgen_free(&cgen);
             return bf_err_r(r, "failed to generate and load new program");
@@ -91,7 +91,7 @@ int _bf_cli_set_rules(const struct bf_request *request,
             return bf_err_r(r, "failed to store codegen in runtime context");
         }
     } else {
-        r = bf_cgen_update(cgen, &chain);
+        r = bf_cgen_update(cgen, &chain, request->ns);
         if (r < 0)
             return bf_warn_r(r, "failed to update existing codegen");
     }

--- a/src/bpfilter/xlate/nft/nft.c
+++ b/src/bpfilter/xlate/nft/nft.c
@@ -267,7 +267,7 @@ static int _bf_nft_newchain_cb(const struct bf_nfmsg *req)
 
     cgen = bf_ctx_get_cgen(BF_HOOK_NF_LOCAL_IN, NULL);
     if (cgen && verdict != cgen->chain->policy) {
-        r = bf_cgen_update(cgen, &chain);
+        r = bf_cgen_update(cgen, &chain, NULL);
         if (r < 0)
             return bf_err_r(r, "failed to update codegen");
 
@@ -277,7 +277,7 @@ static int _bf_nft_newchain_cb(const struct bf_nfmsg *req)
         if (r < 0)
             return bf_err_r(r, "failed to create bf_cgen");
 
-        r = bf_cgen_up(cgen);
+        r = bf_cgen_up(cgen, NULL);
         if (r < 0)
             return bf_err_r(r, "failed to generate codegen");
 
@@ -578,7 +578,7 @@ static int _bf_nft_newrule_cb(const struct bf_nfmsg *req)
         return bf_err_r(r, "failed to add rule to chain");
     TAKE_PTR(rule);
 
-    r = bf_cgen_update(cgen, &cgen->chain);
+    r = bf_cgen_update(cgen, &cgen->chain, NULL);
     if (r < 0)
         return bf_err_r(r, "failed to update codegen");
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -21,6 +21,7 @@ set(core_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/logger.h           ${CMAKE_CURRENT_SOURCE_DIR}/logger.c
     ${CMAKE_CURRENT_SOURCE_DIR}/marsh.h            ${CMAKE_CURRENT_SOURCE_DIR}/marsh.c
     ${CMAKE_CURRENT_SOURCE_DIR}/matcher.h          ${CMAKE_CURRENT_SOURCE_DIR}/matcher.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/ns.h               ${CMAKE_CURRENT_SOURCE_DIR}/ns.c
     ${CMAKE_CURRENT_SOURCE_DIR}/opts.h             ${CMAKE_CURRENT_SOURCE_DIR}/opts.c
     ${CMAKE_CURRENT_SOURCE_DIR}/request.h          ${CMAKE_CURRENT_SOURCE_DIR}/request.c
     ${CMAKE_CURRENT_SOURCE_DIR}/response.h         ${CMAKE_CURRENT_SOURCE_DIR}/response.c

--- a/src/core/ns.c
+++ b/src/core/ns.c
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#define _GNU_SOURCE
+
+#include "core/ns.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "core/helper.h"
+#include "core/logger.h"
+
+#define NS_DIR_PATH_LEN 32
+
+/**
+ * Initialize a `bf_ns_info` structure for a given namespace.
+ *
+ * @param info `bf_ns_info` object to initialise. On failure, this parameter is
+ *             unchanged. Can't be NULL.
+ * @param name Name of the namespace to open. Can't be NULL.
+ * @param dir_fd File descriptor of the directory to open the namespace from.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+static int _bf_ns_info_init(struct bf_ns_info *info, const char *name,
+                            int dir_fd)
+{
+    _cleanup_close_ int fd = -1;
+    struct stat stats;
+    int r;
+
+    bf_assert(info && name);
+
+    fd = openat(dir_fd, name, O_RDONLY, 0);
+    if (fd < 0)
+        return -errno;
+
+    r = fstat(fd, &stats);
+    if (r)
+        return -errno;
+
+    info->fd = TAKE_FD(fd);
+    info->inode = stats.st_ino;
+
+    return 0;
+}
+
+int bf_ns_init(struct bf_ns *ns, pid_t pid)
+{
+    _clean_bf_ns_ struct bf_ns _ns = bf_ns_default();
+    _cleanup_close_ int dirfd = -1;
+    char ns_dir_path[NS_DIR_PATH_LEN];
+    int r;
+
+    bf_assert(ns);
+
+    (void)snprintf(ns_dir_path, NS_DIR_PATH_LEN, "/proc/%d/ns", pid);
+    dirfd = open(ns_dir_path, O_DIRECTORY, O_RDONLY);
+    if (dirfd < 0)
+        return bf_err_r(errno, "failed to open ns directory '%s'", ns_dir_path);
+
+    r = _bf_ns_info_init(&_ns.net, "net", dirfd);
+    if (r) {
+        return bf_err_r(r, "failed to read 'net' namespace in '%s'",
+                        ns_dir_path);
+    }
+
+    r = _bf_ns_info_init(&_ns.mnt, "mnt", dirfd);
+    if (r) {
+        return bf_err_r(r, "failed to read 'mnt' namespace in '%s'",
+                        ns_dir_path);
+    }
+
+    *ns = bf_ns_move(_ns);
+
+    return 0;
+}
+
+void bf_ns_clean(struct bf_ns *ns)
+{
+    bf_assert(ns);
+
+    closep(&ns->net.fd);
+    closep(&ns->mnt.fd);
+}
+
+int bf_ns_set(const struct bf_ns *ns, const struct bf_ns *oldns)
+{
+    int r;
+
+    if (!oldns || ns->net.inode != oldns->net.inode) {
+        r = setns(ns->net.fd, CLONE_NEWNET);
+        if (r)
+            return bf_err_r(r, "failed to switch to a network namespace");
+    }
+
+    if (!oldns || ns->mnt.inode != oldns->mnt.inode) {
+        r = setns(ns->mnt.fd, CLONE_NEWNS);
+        if (r)
+            return bf_err_r(r, "failed to switch to a mount namespace");
+    }
+
+    return 0;
+}

--- a/src/core/ns.h
+++ b/src/core/ns.h
@@ -1,0 +1,120 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <unistd.h>
+
+/**
+ * @file ns.h
+ *
+ * `bpfilter` supports the following namespaces:
+ * - **Network**: for interfaces index to attach XDP and TC programs to, and
+ *   interface indexes to filter on.
+ * - **Mount**: for CGroup path to attach `cgroup_skb` programs to.
+ *
+ * For each supported namespace, the `bf_ns` structure stores the namespace's
+ * ID (the namespace file inode number), and a file descriptor to the namespace.
+ *
+ * When a request is received, `bpfilter` will create a new `bf_ns` object
+ * to refer to the client's namespaces. Before calling
+ * `bf_flavor_ops.attach_prog`, `bpfilter` will jump to the request's
+ * namespace, attach the program, then jump back to the original namespace.
+ */
+
+struct bf_ns_info
+{
+    int fd;
+    uint32_t inode;
+};
+
+/**
+ * Contains information about namespaces relevant to bpfilter.
+ */
+struct bf_ns
+{
+    struct bf_ns_info net;
+    struct bf_ns_info mnt;
+};
+
+/**
+ * Call `bf_ns_clean` on an `auto` stored `bf_ns` when it goes out of scope to
+ * avoid resources leakage.
+ */
+#define _clean_bf_ns_ __attribute__((cleanup(bf_ns_clean)))
+
+/**
+ * Initialize a new `bf_ns` to default values.
+ *
+ * Ensure an `auto` stored `bf_ns` are initialized to sane defaults, so
+ * `bf_ns_clean()` can be called safely.
+ *
+ * @return An initialized `bf_ns` object.
+ */
+#define bf_ns_default()                                                        \
+    (struct bf_ns)                                                             \
+    {                                                                          \
+        .net = {.fd = -1}, .mnt = {.fd = -1}                                   \
+    }
+
+/**
+ * Move a `bf_ns` object.
+ *
+ * Move the `bf_ns` object from `ns` and return it. Once moved, `ns` will be
+ * reset to default values (see `bf_ns_default()`) on which `bf_ns_clean()` can
+ * safely be called. The caller is responsible for cleaning up the `bf_ns`
+ * object returned.
+ *
+ * @param ns Variable to move the `bf_ns` object out of.
+ * @return A `bf_ns` object.
+ */
+#define bf_ns_move(ns)                                                         \
+    ({                                                                         \
+        struct bf_ns *__ns = &(ns);                                            \
+        struct bf_ns _ns = *__ns;                                              \
+        *__ns = bf_ns_default();                                               \
+        _ns;                                                                   \
+    })
+
+/**
+ * Initialize an allocated `bf_ns` object.
+ *
+ * The `procfs` entry of `pid` will be used to open a reference to its
+ * network and mount namespaces and store it in `ns`.
+ *
+ * @param ns Object to initialize. On failure, this parameter is unchanged.
+ *        Can't be NULL.
+ * @param pid PID of the process to open the namespaces of.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_ns_init(struct bf_ns *ns, pid_t pid);
+
+/**
+ * Clean a `bf_ns` object.
+ *
+ * @param ns Object to clean. Can't be NULL.
+ */
+void bf_ns_clean(struct bf_ns *ns);
+
+/**
+ * Move the current process to different namespaces.
+ *
+ * This function will change the current namespace to the one defined in `ns`.
+ * It is critical for this function to succeed; otherwise the process will be
+ * in an unstable state: partially in a new namespace, partially in its original
+ * namespace.
+ *
+ * @param ns Namespaces to move to. Can't be NULL.
+ * @param oldns Namespaces to move out of. This information is needed as
+ *        `setns()` will fail if we try to move to a namespace we are already in.
+ *        It is not possible for `setns()` to look up the current namespace
+ *        itself, as we must assume a new `/proc` has been mounted too,
+ *        hiding the information about the current process. Hence, the only
+ *        reliable solution is to collect this information before calling
+ *        `setns()`.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_ns_set(const struct bf_ns *ns, const struct bf_ns *oldns);

--- a/src/core/request.h
+++ b/src/core/request.h
@@ -10,6 +10,8 @@
 #include "core/front.h"
 #include "core/helper.h"
 
+struct bf_ns;
+
 #define _cleanup_bf_request_ __attribute__((cleanup(bf_request_free)))
 
 /**
@@ -56,6 +58,10 @@ struct bf_request
 {
     enum bf_front front;
     enum bf_request_cmd cmd;
+
+    /** Namespaces the request is coming from. This field will be automatically
+     * populated by the daemon when receiving the request. */
+    struct bf_ns *ns;
 
     union
     {

--- a/tests/e2e/netns.sh
+++ b/tests/e2e/netns.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -e
+
+# Define variables
+NAMESPACE="test_ns"
+PROGNAME="bfe2e"
+VETH_HOST="veth_host"
+VETH_NS="veth_ns"
+HOST_IP="10.0.0.1/24"
+NS_IP="10.0.0.2/24"
+HOST_IP_ADDR="10.0.0.1"
+NS_IP_ADDR="10.0.0.2"
+
+log() {
+    local ORANGE='\033[1;33m'
+    local RESET='\033[0m'
+    echo -e "${ORANGE}[.]${RESET} $1"
+}
+
+success() {
+    local GREEN='\033[1;32m'
+    local RESET='\033[0m'
+    echo -e "${GREEN}[+]${RESET} -> Success" >&2
+}
+
+failure() {
+    local RED='\033[1;31m'
+    local RESET='\033[0m'
+    echo -e "${RED}[-]${RESET} -> Failure" >&2
+    exit 1
+}
+
+# Function to cleanup on exit or error
+cleanup() {
+    log "Cleanup"
+
+    if [ -n "$BPFILTER_PID" ]; then
+        kill $BPFILTER_PID 2>/dev/null || true
+    fi
+
+    if [ "${1:-0}" -ne 0 ] && [ -f "$BPFILTER_OUTPUT_FILE" ]; then
+        log "bpfilter output:"
+        cat "$BPFILTER_OUTPUT_FILE"
+    fi
+
+    ip netns del ${NAMESPACE} 2>/dev/null || true
+    exit ${1:-0}
+}
+
+# Set trap to ensure cleanup happens
+trap 'cleanup $?' EXIT
+trap 'cleanup 1' INT TERM
+
+
+################################################################################
+#
+# Configure the network namespace
+#
+################################################################################
+
+ip netns add ${NAMESPACE}
+ip link add ${VETH_HOST} type veth peer name ${VETH_NS}
+
+ip link set ${VETH_NS} netns ${NAMESPACE}
+
+ip addr add ${HOST_IP} dev ${VETH_HOST}
+ip netns exec ${NAMESPACE} ip addr add ${NS_IP} dev ${VETH_NS}
+
+ip link set ${VETH_HOST} up
+ip netns exec ${NAMESPACE} ip link set ${VETH_NS} up
+ip netns exec ${NAMESPACE} ip link set lo up
+
+HOST_IFINDEX=$(ip -o link show ${VETH_HOST} | awk '{print $1}' | cut -d: -f1)
+NS_IFINDEX=$(ip netns exec ${NAMESPACE} ip -o link show ${VETH_NS} | awk '{print $1}' | cut -d: -f1)
+
+log "Network interfaces configured:"
+log "  ${HOST_IFINDEX}: ${VETH_HOST} @ ${HOST_IP_ADDR}"
+log "  ${NS_IFINDEX}: ${VETH_NS} @ ${NS_IP_ADDR}"
+
+log "[TEST] Validate initial connectivity"
+ip netns exec ${NAMESPACE} ping -c 1 ${HOST_IP_ADDR} > /dev/null 2>&1 && success || failure
+
+
+################################################################################
+#
+# Start bpfilter
+#
+################################################################################
+
+log "Starting bpfilter in background..."
+BPFILTER_OUTPUT_FILE=$(mktemp)
+bpfilter --transient --verbose debug --verbose bpf > "$BPFILTER_OUTPUT_FILE" 2>&1 &
+BPFILTER_PID=$!
+
+# Wait for bpfilter to initialize
+sleep 0.25
+
+
+################################################################################
+#
+# Run tests
+#
+################################################################################
+
+log "[TEST] Can't attach chain to netns iface from host"
+! bfcli ruleset set --str "chain BF_HOOK_XDP{ifindex=${NS_IFINDEX},name=${PROGNAME}} policy ACCEPT rule ip4.proto icmp counter DROP" > /dev/null 2>&1 && success || failure
+
+log "[TEST] Can ping host iface from netns"
+ip netns exec ${NAMESPACE} ping -c 1 -W 0.25 ${HOST_IP_ADDR} > /dev/null 2>&1 && success || failure
+
+log "[TEST] Attach chain to host iface"
+bfcli ruleset set --str "chain BF_HOOK_XDP{ifindex=${HOST_IFINDEX},name=${PROGNAME}} policy ACCEPT rule ip4.proto icmp counter DROP" && success || failure
+
+log "[TEST] Can't ping host iface from netns"
+! ip netns exec ${NAMESPACE} ping -c 1 -W 0.25 ${HOST_IP_ADDR} > /dev/null 2>&1 && success || failure
+
+log "[TEST] Pings have been blocked on ingress"
+bpftool --json map dump name ${PROGNAME}_cmp | jq --exit-status '.[0].formatted.value.packets == 1' > /dev/null 2>&1 && success || failure
+
+log "Flushing the ruleset"
+bfcli ruleset flush && success || failure
+
+log "[TEST] Can't attach chain to host iface from netns"
+! ip netns exec ${NAMESPACE} bfcli ruleset set --str "chain BF_HOOK_XDP{ifindex=${HOST_IFINDEX},name=${PROGNAME}} policy ACCEPT rule ip4.proto icmp counter DROP" > /dev/null 2>&1 && success || failure
+
+log "[TEST] Can ping the netns iface from the host"
+ping -c 1 -W 0.25 ${NS_IP_ADDR} > /dev/null 2>&1  && success || failure
+
+log "[TEST] Attach chain to the netns iface"
+ip netns exec ${NAMESPACE} bfcli ruleset set --str "chain BF_HOOK_XDP{ifindex=${NS_IFINDEX},name=${PROGNAME}} policy ACCEPT rule ip4.proto icmp counter DROP" > /dev/null 2>&1 && success || failure
+
+log "[TEST] Can't ping the netns iface from the host"
+! ping -c 1 -W 0.25 ${NS_IP_ADDR} > /dev/null 2>&1 && success || failure
+
+log "[TEST] Pings have been blocked on ingress"
+bpftool --json map dump name ${PROGNAME}_cmp | jq --exit-status '.[0].formatted.value.packets == 1' > /dev/null 2>&1 && success || failure
+
+log "Flushing the ruleset"
+bfcli ruleset flush && success || failure
+
+log "[TEST] Attach chain to the netns iface"
+ip netns exec ${NAMESPACE} bfcli ruleset set --str "chain BF_HOOK_NF_LOCAL_IN{name=${PROGNAME}} policy ACCEPT" > /dev/null 2>&1 && success || failure
+
+log "[TEST] Pinging the host interface should not update the counters of the program in the namespace"
+ping -c 1 -W 0.25 ${HOST_IP_ADDR} > /dev/null 2>&1 && success || failure
+bpftool --json map dump name ${PROGNAME}_cmp | jq --exit-status '.[0].formatted.value.packets == 0' > /dev/null 2>&1 && success || failure
+
+log "[TEST] Pinging the namespace interface should not update the counters of the program in the namespace"
+ping -c 1 -W 0.25 ${NS_IP_ADDR} > /dev/null 2>&1 && success || failure
+bpftool --json map dump name ${PROGNAME}_cmp | jq --exit-status '.[0].formatted.value.packets == 1' > /dev/null 2>&1 && success || failure
+
+
+################################################################################
+#
+# Cleanup
+#
+################################################################################
+
+kill $BPFILTER_PID
+exit 0


### PR DESCRIPTION
Introduce `bf_ns` structure to represent the namespaces used by a client. This structure is stored in the request to be processed by the daemon. Then, before attaching the BPF program, the daemon will switch to the namespaces stored in the `bf_ns` object, and switch back to its original namespaces.

This change only allows `bpfilter` to attach BPF programs to the correct location according to the client's namespace, as well as filter on the expected interface. More changes will come to limit clients to the chains defined in their namespaces.

The documentation has been updated to reflect the changes, and `tests/netns.sh` has been added to validate the feature.

More details in the commit messages.