### PR TITLE
tests: unit: only generate `lcov.out` if docs are build

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -54,8 +54,6 @@ function(bf_test_configure_non_build_srcs TARGET)
     endforeach()
 endfunction()
 
-find_program(LCOV_BIN lcov REQUIRED)
-
 enable_testing()
 
 set(bf_test_srcs
@@ -133,31 +131,35 @@ target_link_libraries(unit_bin
         gcov
 )
 
-add_custom_command(
-    COMMAND
-        ${CMAKE_COMMAND}
-            -E make_directory
-            ${CMAKE_BINARY_DIR}/output/tests
+add_custom_target(test
     COMMAND
         $<TARGET_FILE:unit_bin>
-    COMMAND
-        ${LCOV_BIN}
-            --capture
-            --directory ${CMAKE_BINARY_DIR}
-            --output-file ${CMAKE_CURRENT_BINARY_DIR}/lcov.out
-	# Only keep the coverage for bpfilter's source files, not the tests.
-	COMMAND
-        ${LCOV_BIN}
-            --output-file ${CMAKE_BINARY_DIR}/output/tests/lcov.out
-            --extract ${CMAKE_CURRENT_BINARY_DIR}/lcov.out
-            --ignore-errors unused
-            "${CMAKE_SOURCE_DIR}/src/\\*"
     DEPENDS
         unit_bin
-    OUTPUT
-        ${CMAKE_BINARY_DIR}/output/tests/lcov.out
     COMMENT "Running tests"
 )
 
+if (NOT ${NO_DOCS})
+    find_program(LCOV_BIN lcov REQUIRED)
 
-add_custom_target(test DEPENDS ${CMAKE_BINARY_DIR}/output/tests/lcov.out)
+    add_custom_command(TARGET test
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND}
+                -E make_directory
+                ${CMAKE_BINARY_DIR}/output/tests
+        COMMAND
+            ${LCOV_BIN}
+                --capture
+                --directory ${CMAKE_BINARY_DIR}
+                --output-file ${CMAKE_CURRENT_BINARY_DIR}/lcov.out
+        # Only keep the coverage for bpfilter's source files, not the tests.
+        COMMAND
+            ${LCOV_BIN}
+                --output-file ${CMAKE_BINARY_DIR}/output/tests/lcov.out
+                --extract ${CMAKE_CURRENT_BINARY_DIR}/lcov.out
+                --ignore-errors unused
+                "${CMAKE_SOURCE_DIR}/src/\\*"
+        COMMENT "Generate the lcov.out summary file"
+    )
+endif ()


### PR DESCRIPTION
The build system will always use lcov to generate `lcov.out` out of the `.gcda` and `.gcno` files after the unit tests are run. `lcov.out` will only be used during the documentation generation. Hence, there is no reason to generate `lcov.out` if `-DNO_DOCS=OFF` is defined.

Gate the generation of `lcov.out` (and the discovery of lcov binary) around the definition of `NO_DOCS` to ensure unit tests don't depend on lcov if `NO_DOCS=ON` is defined.