### PR TITLE
cli: set IPv4 masks to network byte order

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -4,6 +4,7 @@
  */
 
 %{
+    #include <endian.h>
     #include <stdio.h>
     #include <stdlib.h>
     #include <stdbool.h>
@@ -350,6 +351,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                             bf_parse_err("failed to parse IPv4 mask: %s\n", mask);
 
                         addr.mask = ((uint32_t)~0) << (32 - m);
+                        addr.mask = htobe32(addr.mask);
                     } else {
                         addr.mask = (uint32_t)~0;
                     }


### PR DESCRIPTION
IPv4 addresses parsed by bfcli are converted into network byte order by default, but masks are not. Hence, as soon as a mask different from 32 is used, it is incorrectly applied.

Fix this bug by converting the IPv4 mask to network byte order.