### PR TITLE
cgen: fix instructions using proper set index

### DIFF
--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -660,10 +660,10 @@ static int _bf_program_fixup(struct bf_program *program,
             value = program->pmap->fd;
             break;
         case BF_FIXUP_TYPE_SET_MAP_FD:
-            map = bf_list_get_at(&program->sets, insn->imm);
+            map = bf_list_get_at(&program->sets, fixup->attr.set_index);
             if (!map) {
-                return bf_err_r(-ENOENT, "can't find set map at index %d",
-                                insn->imm);
+                return bf_err_r(-ENOENT, "can't find set map at index %lu",
+                                fixup->attr.set_index);
             }
             insn_type = BF_FIXUP_INSN_IMM;
             value = map->fd;


### PR DESCRIPTION
The set index a rule should filter on is stored in the fixup's attributes during generation. But `_bf_program_fixup()` uses the instruction's `imm` field as the set index, leading to bpfilter always using the file descriptor of set #0.

Fix `_bf_program_fixup()` by using the set index from the fixup attributes.