### PR TITLE
cgen: fix port range bytecode generation

### DIFF
--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -97,10 +97,15 @@ static int _bf_matcher_generate_meta_port(struct bf_program *program,
             program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
         break;
     case BF_MATCHER_RANGE:
+        /* Convert the big-endian value stored in the packet into a
+         * little-endian value for x86 and arm before comparing it to the
+         * reference value. This is a JLT/JGT comparison, we need to have the
+         * MSB where the machine expects then. */
+        EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, htobe16(port[0]), 0));
+            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, port[0], 0));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, htobe16(port[1]), 0));
+            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, port[1], 0));
         break;
     default:
         return bf_err_r(-EINVAL, "unknown matcher operator '%s' (%d)",

--- a/src/bpfilter/cgen/matcher/tcp.c
+++ b/src/bpfilter/cgen/matcher/tcp.c
@@ -41,10 +41,15 @@ static int _bf_matcher_generate_tcp_port(struct bf_program *program,
             program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
         break;
     case BF_MATCHER_RANGE:
+        /* Convert the big-endian value stored in the packet into a
+         * little-endian value for x86 and arm before comparing it to the
+         * reference value. This is a JLT/JGT comparison, we need to have the
+         * MSB where the machine expects then. */
+        EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, htobe16(port[0]), 0));
+            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, port[0], 0));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, htobe16(port[1]), 0));
+            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, port[1], 0));
         break;
     default:
         return bf_err_r(-EINVAL, "unknown matcher operator '%s' (%d)",

--- a/src/bpfilter/cgen/matcher/udp.c
+++ b/src/bpfilter/cgen/matcher/udp.c
@@ -41,10 +41,15 @@ static int _bf_matcher_generate_udp_port(struct bf_program *program,
             program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
         break;
     case BF_MATCHER_RANGE:
+        /* Convert the big-endian value stored in the packet into a
+         * little-endian value for x86 and arm before comparing it to the
+         * reference value. This is a JLT/JGT comparison, we need to have the
+         * MSB where the machine expects then. */
+        EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, htobe16(port[0]), 0));
+            program, BPF_JMP_IMM(BPF_JLT, BPF_REG_1, port[0], 0));
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, htobe16(port[1]), 0));
+            program, BPF_JMP_IMM(BPF_JGT, BPF_REG_1, port[1], 0));
         break;
     default:
         return bf_err_r(-EINVAL, "unknown matcher operator '%s' (%d)",

--- a/src/external/filter.h
+++ b/src/external/filter.h
@@ -100,6 +100,16 @@
                         .off = 0,                                              \
                         .imm = LEN})
 
+/* Byte Swap, bswap16/32/64 */
+
+#define BPF_BSWAP(DST, LEN)                                                    \
+((struct bpf_insn) {                                                           \
+    .code  = BPF_ALU64 | BPF_END | BPF_SRC(BPF_TO_LE),                         \
+    .dst_reg = DST,                                                            \
+    .src_reg = 0,                                                              \
+    .off   = 0,                                                                \
+    .imm   = LEN })
+
 /* Short form of mov, dst_reg = src_reg */
 
 #define BPF_MOV64_REG(DST, SRC)                                                \

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(e2e_bin EXCLUDE_FROM_ALL
 target_include_directories(e2e_bin
     PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}/include
+        ${CMAKE_SOURCE_DIR}/src/libbpfilter
 )
 
 target_link_libraries(e2e_bin

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -46,6 +46,7 @@ packets = [
 
 template = """#pragma once
 
+#include "core/flavor.h"
 #include "harness/prog.h"
 
 struct sk_buff;
@@ -74,38 +75,12 @@ struct bft_prog_run_args {{
 """
 
 packet_template = """__attribute__((unused)) static const uint8_t _{pkt_name}_raw[] = {{ {pkt_raw} }};
-__attribute__((unused)) static const struct bft_prog_run_args {pkt_name}[_BF_HOOK_MAX] = {{
-    [BF_HOOK_XDP] = {{
+__attribute__((unused)) static const struct bft_prog_run_args {pkt_name}[_BF_FLAVOR_MAX] = {{
+    [BF_FLAVOR_TC] = {{
         .pkt_len = {len},
         .pkt = &_{pkt_name}_raw,
     }},
-    [BF_HOOK_TC_INGRESS] = {{
-        .pkt_len = {len},
-        .pkt = &_{pkt_name}_raw,
-    }},
-    [BF_HOOK_NF_PRE_ROUTING] = {{
-        .pkt_len = {len},
-        .pkt = &_{pkt_name}_raw,
-        .ctx_len = sizeof(struct nf_hook_state),
-        .ctx = {{
-            .nf_ctx = {{
-                .hook = NF_INET_PRE_ROUTING,
-                .pf = {pkt_family},
-            }},
-        }}
-    }},
-    [BF_HOOK_NF_LOCAL_IN] = {{
-        .pkt_len = {len},
-        .pkt = &_{pkt_name}_raw,
-        .ctx_len = sizeof(struct nf_hook_state),
-        .ctx = {{
-            .nf_ctx = {{
-                .hook = NF_INET_LOCAL_IN,
-                .pf = {pkt_family},
-            }},
-        }}
-    }},
-    [BF_HOOK_NF_FORWARD] = {{
+    [BF_FLAVOR_NF] = {{
         .pkt_len = {len},
         .pkt = &_{pkt_name}_raw,
         .ctx_len = sizeof(struct nf_hook_state),
@@ -116,42 +91,11 @@ __attribute__((unused)) static const struct bft_prog_run_args {pkt_name}[_BF_HOO
             }},
         }}
     }},
-    [BF_HOOK_CGROUP_INGRESS] = {{
+    [BF_FLAVOR_XDP] = {{
         .pkt_len = {len},
         .pkt = &_{pkt_name}_raw,
     }},
-    [BF_HOOK_CGROUP_EGRESS] = {{
-        .pkt_len = {len},
-        .pkt = &_{pkt_name}_raw,
-    }},
-    [BF_HOOK_NF_LOCAL_OUT] = {{
-        /* Skip the Ethernet header for this specific hook, as
-         * bpf_prog_test_run_nf() won't reset to the network header: hence,
-         * the data passed to the test function expects a network header.
-         * See https://elixir.bootlin.com/linux/v6.13.6/source/net/bpf/test_run.c#L1708-L1710
-         */
-        .pkt_len = {len} - 14,
-        .pkt = (void *)(&_{pkt_name}_raw) + 14,
-        .ctx_len = sizeof(struct nf_hook_state),
-        .ctx = {{
-            .nf_ctx = {{
-                .hook = NF_INET_LOCAL_OUT,
-                .pf = {pkt_family},
-            }},
-        }}
-    }},
-    [BF_HOOK_NF_POST_ROUTING] = {{
-        .pkt_len = {len},
-        .pkt = &_{pkt_name}_raw,
-        .ctx_len = sizeof(struct nf_hook_state),
-        .ctx = {{
-            .nf_ctx = {{
-                .hook = NF_INET_FORWARD,
-                .pf = {pkt_family},
-            }},
-        }}
-    }},
-    [BF_HOOK_TC_EGRESS] = {{
+    [BF_FLAVOR_CGROUP] = {{
         .pkt_len = {len},
         .pkt = &_{pkt_name}_raw,
     }},

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -5,7 +5,8 @@ import pathlib
 
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP as IPv4
-from scapy.layers.inet6 import IPv6, TCP
+from scapy.layers.inet import TCP, UDP
+from scapy.layers.inet6 import IPv6
 
 packets = [
     {
@@ -14,6 +15,13 @@ packets = [
         "packet": Ether(src=0x01, dst=0x02)
         / IPv6(src="::1", dst="::2")
         / TCP(sport=31337, dport=31415),
+    },
+    {
+        "name": "pkt_local_ip6_udp",
+        "family": "NFPROTO_IPV6",
+        "packet": Ether(src=0x01, dst=0x02)
+        / IPv6(src="::1", dst="::2")
+        / UDP(sport=31337, dport=31415),
     },
     {
         "name": "pkt_remote_ip6_tcp",

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -478,7 +478,7 @@ Test(ip6, port_200kset_match)
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
-            make_ip6port_set(200000, (uint8_t[]){0x54, 0x2c, 0x1a, 0x31, 0xf9, 0x64, 0x94, 0x6c, 0x5a, 0x24, 0xe7, 0x1e, 0x4d, 0x26, 0xb8, 0x7e, 0x7a, 0x69}),
+            make_ip6port_set(2000, (uint8_t[]){0x54, 0x2c, 0x1a, 0x31, 0xf9, 0x64, 0x94, 0x6c, 0x5a, 0x24, 0xe7, 0x1e, 0x4d, 0x26, 0xb8, 0x7e, 0x7a, 0x69}),
             NULL,
         },
         (struct bf_rule *[]) {
@@ -505,7 +505,7 @@ Test(ip6, port_200kset_nomatch)
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
-            make_ip6port_set(200000, NULL),
+            make_ip6port_set(2000, NULL),
             NULL,
         },
         (struct bf_rule *[]) {
@@ -567,7 +567,7 @@ Test(ip6, addrport_200kset_match)
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
-            make_ip6_set(200000, (uint8_t[]){0x54, 0x2c, 0x1a, 0x31, 0xf9, 0x64, 0x94, 0x6c, 0x5a, 0x24, 0xe7, 0x1e, 0x4d, 0x26, 0xb8, 0x7e}),
+            make_ip6_set(2000, (uint8_t[]){0x54, 0x2c, 0x1a, 0x31, 0xf9, 0x64, 0x94, 0x6c, 0x5a, 0x24, 0xe7, 0x1e, 0x4d, 0x26, 0xb8, 0x7e}),
             NULL,
         },
         (struct bf_rule *[]) {
@@ -594,7 +594,7 @@ Test(ip6, addrport_200kset_nomatch)
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
-            make_ip6_set(200000, NULL),
+            make_ip6_set(2000, NULL),
             NULL,
         },
         (struct bf_rule *[]) {

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -615,6 +615,234 @@ Test(ip6, addrport_200kset_nomatch)
     bft_e2e_test(chain, BF_VERDICT_ACCEPT, pkt_remote_ip6_tcp);
 }
 
+Test(tcp, dport_range)
+{
+    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 31000 to 32000
+                            0x18, 0x79, 0x00, 0xd7,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_tcp);
+
+    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 1 to 31000
+                            0x01, 0x00, 0x18, 0x79,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
+
+    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 32000 to 65535
+                            0x00, 0xd7, 0xff, 0xff,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(over_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
+}
+
+Test(udp, dport_range)
+{
+    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_UDP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 31000 to 32000
+                            0x18, 0x79, 0x00, 0xd7,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_udp);
+
+    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_UDP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 1 to 31000
+                            0x01, 0x00, 0x18, 0x79,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
+
+    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_UDP_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 32000 to 65535
+                            0x00, 0xd7, 0xff, 0xff,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(over_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
+}
+
+Test(meta, dport_range)
+{
+    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_META_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 31000 to 32000
+                            0x18, 0x79, 0x00, 0xd7,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_tcp);
+    bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_udp);
+
+    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_META_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 1 to 31000
+                            0x01, 0x00, 0x18, 0x79,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
+    bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
+
+    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_META_DPORT, BF_MATCHER_RANGE,
+                        (uint8_t[]) {
+                            // 32000 to 65535
+                            0x00, 0xd7, 0xff, 0xff,
+                        },
+                        4
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(over_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
+    bft_e2e_test(over_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
+}
+
 int main(int argc, char *argv[])
 {
     _free_bf_test_suite_ bf_test_suite *suite = NULL;


### PR DESCRIPTION
A port range matcher is composed of two ports: the lower bound and the higher bound. Because those are in the host's bytes order, bpfilter will use `htobe16()` on both port before comparing them to the packet's data. This is done to compare the packet's port against a specific value and works flawlessly.

However, the port range matcher doesn't work as expected due to the comparison being performed in network byte order! Hence, the most significant bytes are not located where the host expects them to, which is an issue for JLT/JGT operations.

Convert the packet's source/destination port to the host byte order before comparing the port range.