### PR TITLE
Use Fedora 42 for CI, disable false positive clang-tidy options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,11 @@
 #   Avoid usage of Annex K functions for portability reasons.
 # - clang-analyzer-unix.Malloc
 #   Generates false positives.
+# - misc-include-cleaner
+#   False positives, e.g. with errno.h: E* macros are not directly defined in it,
+#   but it's the header we should include.
+# - misc-redundant-expression
+#   Macros having the same values can't be or'd without a warning.
 # - misc-static-assert
 #   We use bf_assert(0) for impossible default in switch...case.
 # - modernize-macro-to-enum
@@ -71,6 +76,8 @@ Checks: >
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     -clang-analyzer-unix.Malloc,
   misc-*,
+    -misc-include-cleaner,
+    -misc-redundant-expression,
     -misc-static-assert,
   modernize-*,
     -modernize-macro-to-enum,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
     needs: create-images
     timeout-minutes: 5
     runs-on: [ "ubuntu-24.04" ]
-    container: ghcr.io/facebook/bpfilter:fedora-41-x64
+    container: ghcr.io/facebook/bpfilter:fedora-42-x64
     name: "Check"
     steps:
       - name: Checkout bpfilter
@@ -108,7 +108,7 @@ jobs:
           - { name: 4-core-ubuntu-arm, arch: arm64 }
     runs-on: [ "${{ matrix.host.name }}" ]
     container:
-      image: ghcr.io/facebook/bpfilter:fedora-41-${{ matrix.host.arch }}
+      image: ghcr.io/facebook/bpfilter:fedora-42-${{ matrix.host.arch }}
       options: --privileged
     name: "Test: ${{ matrix.host.arch }}"
     steps:
@@ -137,7 +137,7 @@ jobs:
           - { name: 4-core-ubuntu-arm, arch: arm64 }
     runs-on: [ "${{ matrix.host.name }}" ]
     container:
-      image: ghcr.io/facebook/bpfilter:fedora-41-${{ matrix.host.arch }}
+      image: ghcr.io/facebook/bpfilter:fedora-42-${{ matrix.host.arch }}
       options: --privileged
     name: "Benchmark: ${{ matrix.host.arch }}"
     steps:
@@ -160,7 +160,7 @@ jobs:
     needs: [ test, benchmark ]
     timeout-minutes: 5
     runs-on: [ "ubuntu-24.04" ]
-    container: ghcr.io/facebook/bpfilter:fedora-41-x64
+    container: ghcr.io/facebook/bpfilter:fedora-42-x64
     name: "Documentation"
     steps:
       - name: Checkout bpfilter


### PR DESCRIPTION
Pretty much the title