### PR TITLE
Fix typos in documentation/website

### DIFF
--- a/doc/developers/modules/index.rst
+++ b/doc/developers/modules/index.rst
@@ -12,7 +12,7 @@ Modules
 
 ``bpfilter`` is composed of multiple modules depending on each other. Splitting the project in different modules allows for the source code to be efficiently reused, be it for ``bfcli``, ``bpfilter``'s daemon, or ``libbpfilter``:
 
-- ``core``: core definitions used by the daemon, ``bfcli``, and ``libpfilter``.
+- ``core``: core definitions used by the daemon, ``bfcli``, and ``libbpfilter``.
 - ``bpfilter``: daemon logic, including translation of the front-end (client) data into ``bpfilter``'s internal format, and the BPF bytecode generation logic.
 - ``bfcli``: generic client to communicate with the daemon.
 - ``libbpfilter``: static and shared library to communicate with the daemon.

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -77,7 +77,7 @@
  * - Preprocess the L2, L3, and L4 headers
  *
  * The header's preprocessing is required to discover the protocols used in the
- * packet: processing L2 will rovide us with information about L3, and so on. The
+ * packet: processing L2 will provide us with information about L3, and so on. The
  * logic used to process layer X is responsible for discovering layer X+1: the L2
  * header preprocessing logic will discover the L3 protocol ID. When processing
  * layer X, if the protocol is not supported, the protocol ID is reset to 0 (so


### PR DESCRIPTION
Found some typos on the [website](https://bpfilter.io/) while reading the documentation
Here's a PR to fix them