### PR TITLE
Use argp global variables to generate version flag in bpfilter and bfcli

### DIFF
--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -27,10 +27,20 @@
 #include "libbpfilter/bpfilter.h"
 #include "version.h"
 
+static void _bfc_print_version(FILE *stream, struct argp_state *state)
+{
+    UNUSED(state);
+
+    (void)fprintf(stream, "bfcli version %s, libbpfilter version %s\n",
+                  BF_VERSION, bf_version());
+}
+
 int main(int argc, char *argv[])
 {
     _clean_bfc_opts_ struct bfc_opts opts = bfc_opts_default();
     int r;
+
+    argp_program_version_hook = &_bfc_print_version;
 
     r = bfc_opts_parse(&opts, argc, argv);
     if (r < 0)

--- a/src/bpfilter/main.c
+++ b/src/bpfilter/main.c
@@ -5,6 +5,7 @@
 
 #define _GNU_SOURCE
 
+#include <argp.h>
 #include <errno.h>
 #include <signal.h>
 #include <string.h>
@@ -25,6 +26,7 @@
 #include "core/ns.h"
 #include "core/request.h"
 #include "core/response.h"
+#include "version.h"
 
 /**
  * Global flag to indicate whether the daemon should stop.
@@ -467,6 +469,8 @@ int main(int argc, char *argv[])
     int r;
 
     bf_logger_setup();
+
+    argp_program_version = "bpfilter version " BF_VERSION;
 
     r = bf_btf_setup();
     if (r < 0)

--- a/src/bpfilter/opts.c
+++ b/src/bpfilter/opts.c
@@ -16,7 +16,6 @@
 #include "core/front.h"
 #include "core/helper.h"
 #include "core/logger.h"
-#include "version.h"
 
 #define BF_DEFAULT_BPFFS_PATH "/sys/fs/bpf"
 
@@ -104,7 +103,6 @@ static struct argp_option options[] = {
      0},
     {"verbose", 'v', "VERBOSE_FLAG", 0,
      "Verbose flags to enable. Can be used more than once.", 0},
-    {"version", BF_OPT_VERSION, 0, 0, "Print the version and return.", 0},
     {0},
 };
 
@@ -161,9 +159,6 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
             bf_log_set_level(BF_LOG_DBG);
         args->verbose |= BF_FLAG(opt);
         break;
-    case BF_OPT_VERSION:
-        bf_info("bpfilter version %s", BF_VERSION);
-        exit(0);
     default:
         return ARGP_ERR_UNKNOWN;
     }


### PR DESCRIPTION
[argp](https://www.gnu.org/software/libc/manual/html_node/Argp.html) has a feature to autogenerate the `--version` flag using [global variables](https://www.gnu.org/software/libc/manual/html_node/Argp-Global-Variables.html)
This PR aims to replace the manual implementation in `bpfilter` and `bfcli` binairies with this feature