### PR TITLE
cli: refactor the commands parser

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -102,7 +102,7 @@ CheckOptions:
   # and will behave differently for macros. Hence clang-tidy v18+ won't
   # warn about _cleanup_ identifiers.
   - key: bugprone-reserved-identifier.AllowedIdentifiers
-    value: '^_(_start|_stop|bf|bfc|BF|cleanup|GNU)_[a-zA-Z0-9_]+$'
+    value: '^_(_start|_stop|bf|bfc|BF|BFC|cleanup|GNU)_[a-zA-Z0-9_]+$'
   - key: misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
     value: true
   # Unless a *statement* takes 1 line, it should be in braces

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ make -C $BUILD_DIR install
 sudo $BUILD_DIR/output/sbin/bpfilter
 
 # Count the number of ping coming to interface #2
-sudo $BUILD_DIR/output/sbin/bfcli ruleset set --str "chain BF_HOOK_XDP{ifindex=2} policy ACCEPT rule ip4.proto icmp counter ACCEPT"
+sudo $BUILD_DIR/output/sbin/bfcli ruleset set --from-str "chain BF_HOOK_XDP{ifindex=2} policy ACCEPT rule ip4.proto icmp counter ACCEPT"
 ```
 
 The complete documentation is available on [bpfilter.io](https://bpfilter.io/).

--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -14,17 +14,17 @@ Commands
 Define a new ruleset: replace all the existing chains with the ruleset provided. Replacement is not atomic.
 
 **Options**
-  - ``--str RULESET``: read and apply the ruleset defining from the command line.
-  - ``--file FILE``: read ``FILE`` and apply the ruleset contained in it.
+  - ``--from-str RULESET``: read and apply the ruleset defining from the command line.
+  - ``--from-file FILE``: read ``FILE`` and apply the ruleset contained in it.
 
-``--str`` and ``--file`` are mutually exclusive.
+``--from-str`` and ``--from-file`` are mutually exclusive.
 
 **Example**
 
 .. code:: shell
 
-    bfcli ruleset set --file myruleset.txt
-    bfcli ruleset set --str "chain my_xdp_chain BF_HOOK_XDP ACCEPT rule ip4.saddr in {192.168.1.1} ACCEPT"
+    bfcli ruleset set --from-file myruleset.txt
+    bfcli ruleset set --from-str "chain my_xdp_chain BF_HOOK_XDP ACCEPT rule ip4.saddr in {192.168.1.1} ACCEPT"
 
 ``ruleset get``
 ~~~~~~~~~~~~~~~

--- a/doc/usage/index.rst
+++ b/doc/usage/index.rst
@@ -75,14 +75,14 @@ Now that the daemon is up and running, we will use ``bfcli`` to send a filtering
 
 .. code-block:: bash
 
-	$ sudo bfcli ruleset set --str "
+	$ sudo bfcli ruleset set --from-str "
 	chain BF_HOOK_NF_LOCAL_OUT policy ACCEPT
 	    rule
 	        ip4.proto icmp
 	        DROP
 	"
 
-We split the chain over multiple lines, to it's easier to read. Alternatively, you can write the chain in a file and call ``bfcli ruleset set --file $MYFILE``. We choose to create a chain attached to ``BF_HOOK_NF_LOCAL_OUT`` which is called for every packet leaving this host with ``ACCEPT`` as the default policy: if a packet doesn't match any of the rules defined, it will be accepted by default.
+We split the chain over multiple lines, to it's easier to read. Alternatively, you can write the chain in a file and call ``bfcli ruleset set --from-file $MYFILE``. We choose to create a chain attached to ``BF_HOOK_NF_LOCAL_OUT`` which is called for every packet leaving this host with ``ACCEPT`` as the default policy: if a packet doesn't match any of the rules defined, it will be accepted by default.
 
 Our chain contains a single rule matching against the IPv4's ``protocol`` field. Packets matching this rule will be ``DROP`` ed.
 

--- a/src/bfcli/CMakeLists.txt
+++ b/src/bfcli/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(bfcli
     ${CMAKE_CURRENT_SOURCE_DIR}/chain.h     ${CMAKE_CURRENT_SOURCE_DIR}/chain.c
     ${CMAKE_CURRENT_SOURCE_DIR}/helper.h    ${CMAKE_CURRENT_SOURCE_DIR}/helper.c
     ${CMAKE_CURRENT_SOURCE_DIR}/print.h     ${CMAKE_CURRENT_SOURCE_DIR}/print.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/ruleset.h   ${CMAKE_CURRENT_SOURCE_DIR}/ruleset.c
     ${CMAKE_BINARY_DIR}/include/version.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated/include/bfcli/parser.h
     ${CMAKE_CURRENT_BINARY_DIR}/generated/bfcli/parser.c

--- a/src/bfcli/CMakeLists.txt
+++ b/src/bfcli/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(bfcli
     ${CMAKE_CURRENT_SOURCE_DIR}/main.c
     ${CMAKE_CURRENT_SOURCE_DIR}/chain.h     ${CMAKE_CURRENT_SOURCE_DIR}/chain.c
     ${CMAKE_CURRENT_SOURCE_DIR}/helper.h    ${CMAKE_CURRENT_SOURCE_DIR}/helper.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/opts.h      ${CMAKE_CURRENT_SOURCE_DIR}/opts.c
     ${CMAKE_CURRENT_SOURCE_DIR}/print.h     ${CMAKE_CURRENT_SOURCE_DIR}/print.c
     ${CMAKE_CURRENT_SOURCE_DIR}/ruleset.h   ${CMAKE_CURRENT_SOURCE_DIR}/ruleset.c
     ${CMAKE_BINARY_DIR}/include/version.h

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 
 #include "bfcli/helper.h"
+#include "bfcli/opts.h"
 #include "bfcli/print.h"
 #include "bfcli/ruleset.h"
 #include "core/chain.h"
@@ -23,67 +24,6 @@
 #include "libbpfilter/bpfilter.h"
 
 struct bfc_chain_opts;
-
-#define bf_ruleset_default()                                                   \
-    {                                                                          \
-        .chains = bf_list_default(bf_chain_free, bf_chain_marsh),              \
-        .sets = bf_list_default(bf_set_free, bf_set_marsh),                    \
-        .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),      \
-    }
-
-typedef int (*bfc_chain_opts_validation_cb_t)(struct bfc_chain_opts *opts,
-                                              struct argp_state *state);
-
-#define BFC_CHAIN_OPT_NAME {"name", 'n', "NAME", 0, "Name of the chain", 0}
-#define BFC_CHAIN_OPT_FROM_STR                                                 \
-    {"from-str", 's', "CHAIN", 0, "Chain(s) to use", 0}
-#define BFC_CHAIN_OPT_FROM_FILE                                                \
-    {"from-file", 'f', "FILE", 0, "File containing the chain(s) to use", 0}
-#define BFC_CHAIN_OPT_HOOKOPT                                                  \
-    {"option", 'o', "HOOKOPT=VALUE", 0, "Hook option to attach the chain", 0}
-
-struct bfc_chain_opts
-{
-    const char *name;
-    const char *from_str;
-    const char *from_file;
-    struct bf_hookopts *hookopts;
-    bfc_chain_opts_validation_cb_t validation_cb;
-};
-
-extern char *program_invocation_name;
-
-static error_t _bfc_chain_opts_parser(int key, const char *arg,
-                                      struct argp_state *state)
-{
-    struct bfc_chain_opts *opts = state->input;
-    int r = 0;
-
-    switch (key) {
-    case 'n':
-        opts->name = arg;
-        break;
-    case 's':
-        opts->from_str = arg;
-        break;
-    case 'f':
-        opts->from_file = arg;
-        break;
-    case 'o':
-        r = bf_hookopts_parse_opt(opts->hookopts, arg);
-        if (r)
-            bf_err_r(r, "failed to parse hook option '%s'", arg);
-        break;
-    case ARGP_KEY_END:
-        if (opts->validation_cb)
-            r = opts->validation_cb(opts, state);
-        break;
-    default:
-        return ARGP_ERR_UNKNOWN;
-    }
-
-    return r;
-}
 
 static int _bfc_get_chain_from_ruleset(const struct bfc_ruleset *ruleset,
                                        const char *name,
@@ -133,56 +73,21 @@ static int _bfc_get_chain_from_ruleset(const struct bfc_ruleset *ruleset,
     return 0;
 }
 
-static int _bfc_chain_set_validate_cb(struct bfc_chain_opts *opts,
-                                      struct argp_state *state)
+int bfc_chain_set(const struct bfc_opts *opts)
 {
-    if (opts->from_str && opts->from_file) {
-        argp_error(state, "--from-str is incompatible with --from-file");
-        return -EINVAL;
-    }
-
-    if (!opts->from_str && !opts->from_file) {
-        argp_error(state, "either --from-str or --from-file is required");
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
-int bfc_chain_set(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_NAME,
-        BFC_CHAIN_OPT_FROM_STR,
-        BFC_CHAIN_OPT_FROM_FILE,
-        {0},
-    };
-
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_set_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bfc_ruleset_default();
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    bf_info("chain: '%s'", opts.from_str);
-    if (opts.from_str)
-        r = bfc_parse_str(opts.from_str, &ruleset);
+    if (opts->from_str)
+        r = bfc_parse_str(opts->from_str, &ruleset);
     else
-        r = bfc_parse_file(opts.from_file, &ruleset);
+        r = bfc_parse_file(opts->from_file, &ruleset);
     if (r)
         return bf_err_r(r, "failed to parse the chain(s)");
 
-    r = _bfc_get_chain_from_ruleset(&ruleset, opts.name, &chain, &hookopts);
+    r = _bfc_get_chain_from_ruleset(&ruleset, opts->name, &chain, &hookopts);
     if (r)
         return r;
 
@@ -193,43 +98,16 @@ int bfc_chain_set(int argc, char **argv)
     return 0;
 }
 
-static int _bfc_chain_get_validate_cb(struct bfc_chain_opts *opts,
-                                      struct argp_state *state)
+int bfc_chain_get(const struct bfc_opts *opts)
 {
-    if (!opts->name) {
-        argp_error(state, "the --name (-n) parameter is required");
-        return -ENOENT;
-    }
-
-    return 0;
-}
-
-int bfc_chain_get(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_NAME,
-        {0},
-    };
-
     _cleanup_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
     _clean_bf_list_ bf_list counters = bf_list_default(bf_counter_free, NULL);
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_get_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    r = bf_chain_get(opts.name, &chain, &hookopts, &counters);
+    r = bf_chain_get(opts->name, &chain, &hookopts, &counters);
     if (r == -ENOENT)
-        return bf_err_r(r, "chain '%s' not found", opts.name);
+        return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
         return bf_err_r(r, "unknown error");
 
@@ -238,55 +116,21 @@ int bfc_chain_get(int argc, char **argv)
     return 0;
 }
 
-static int _bfc_chain_load_validate_cb(struct bfc_chain_opts *opts,
-                                       struct argp_state *state)
+int bfc_chain_load(const struct bfc_opts *opts)
 {
-    if (opts->from_str && opts->from_file) {
-        argp_error(state, "--from-str is incompatible with --from-file");
-        return -EINVAL;
-    }
-
-    if (!opts->from_str && !opts->from_file) {
-        argp_error(state, "either --from-str or --from-file is required");
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
-int bfc_chain_load(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_FROM_STR,
-        BFC_CHAIN_OPT_FROM_FILE,
-        BFC_CHAIN_OPT_NAME,
-        {0},
-    };
-
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_load_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bfc_ruleset_default();
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    if (opts.from_str)
-        r = bfc_parse_str(opts.from_str, &ruleset);
+    if (opts->from_str)
+        r = bfc_parse_str(opts->from_str, &ruleset);
     else
-        r = bfc_parse_file(opts.from_file, &ruleset);
+        r = bfc_parse_file(opts->from_file, &ruleset);
     if (r)
         return bf_err_r(r, "failed to parse the chain(s)");
 
-    r = _bfc_get_chain_from_ruleset(&ruleset, opts.name, &chain, &hookopts);
+    r = _bfc_get_chain_from_ruleset(&ruleset, opts->name, &chain, &hookopts);
     if (r)
         return r;
 
@@ -300,103 +144,34 @@ int bfc_chain_load(int argc, char **argv)
     return 0;
 }
 
-static int _bfc_chain_attach_validate_cb(struct bfc_chain_opts *opts,
-                                         struct argp_state *state)
+int bfc_chain_attach(const struct bfc_opts *opts)
 {
-    if (!opts->name) {
-        argp_error(state, "--name is required");
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
-int bfc_chain_attach(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_NAME,
-        BFC_CHAIN_OPT_HOOKOPT,
-        {0},
-    };
-
-    _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_attach_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
     int r;
 
-    r = bf_hookopts_new(&hookopts);
-    if (r)
-        return r;
-
-    opts.hookopts = hookopts;
-
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    r = bf_chain_attach(opts.name, opts.hookopts);
+    r = bf_chain_attach(opts->name, &opts->hookopts);
     if (r == -ENOENT)
-        return bf_err_r(r, "chain '%s' not found", opts.name);
+        return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
         return bf_err_r(r, "unknown error");
 
     return r;
 }
 
-static int _bfc_chain_update_validate_cb(struct bfc_chain_opts *opts,
-                                         struct argp_state *state)
+int bfc_chain_update(const struct bfc_opts *opts)
 {
-    if (opts->from_str && opts->from_file) {
-        argp_error(state, "--from-str is incompatible with --from-file");
-        return -EINVAL;
-    }
-
-    if (!opts->from_str && !opts->from_file) {
-        argp_error(state, "either --from-str or --from-file is required");
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
-int bfc_chain_update(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_FROM_STR,
-        BFC_CHAIN_OPT_FROM_FILE,
-        BFC_CHAIN_OPT_NAME,
-        {0},
-    };
-
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_update_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bfc_ruleset_default();
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    if (opts.from_str)
-        r = bfc_parse_str(opts.from_str, &ruleset);
+    if (opts->from_str)
+        r = bfc_parse_str(opts->from_str, &ruleset);
     else
-        r = bfc_parse_file(opts.from_file, &ruleset);
+        r = bfc_parse_file(opts->from_file, &ruleset);
     if (r)
         return bf_err_r(r, "failed to parse the chain(s)");
 
-    r = _bfc_get_chain_from_ruleset(&ruleset, opts.name, &chain, &hookopts);
+    r = _bfc_get_chain_from_ruleset(&ruleset, opts->name, &chain, &hookopts);
     if (r)
         return r;
 
@@ -405,49 +180,22 @@ int bfc_chain_update(int argc, char **argv)
 
     r = bf_chain_update(chain);
     if (r == -ENOENT)
-        return bf_err_r(r, "chain '%s' not found", opts.name);
+        return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r == -ENOLINK)
-        return bf_err_r(r, "chain '%s' is not attached to a hook", opts.name);
+        return bf_err_r(r, "chain '%s' is not attached to a hook", opts->name);
     if (r)
         return bf_err_r(r, "unknown error");
 
     return r;
 }
 
-static int _bfc_chain_flush_validate_cb(struct bfc_chain_opts *opts,
-                                        struct argp_state *state)
+int bfc_chain_flush(const struct bfc_opts *opts)
 {
-    if (!opts->name) {
-        argp_error(state, "the --name (-n) parameter is required");
-        return -ENOENT;
-    }
-
-    return 0;
-}
-
-int bfc_chain_flush(int argc, char **argv)
-{
-    static struct argp_option options[] = {
-        BFC_CHAIN_OPT_NAME,
-        {0},
-    };
-
-    struct bfc_chain_opts opts = {
-        .validation_cb = _bfc_chain_flush_validate_cb,
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bfc_chain_opts_parser, NULL, NULL, 0, NULL,
-        NULL,
-    };
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    r = bf_chain_flush(opts.name);
+    r = bf_chain_flush(opts->name);
     if (r == -ENOENT)
-        return bf_err_r(r, "chain '%s' not found", opts.name);
+        return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
         return bf_err_r(r, "unknown error");
 

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -12,6 +12,7 @@
 
 #include "bfcli/helper.h"
 #include "bfcli/print.h"
+#include "bfcli/ruleset.h"
 #include "core/chain.h"
 #include "core/counter.h"
 #include "core/helper.h"
@@ -84,7 +85,7 @@ static error_t _bfc_chain_opts_parser(int key, const char *arg,
     return r;
 }
 
-static int _bfc_get_chain_from_ruleset(const struct bf_ruleset *ruleset,
+static int _bfc_get_chain_from_ruleset(const struct bfc_ruleset *ruleset,
                                        const char *name,
                                        struct bf_chain **chain,
                                        struct bf_hookopts **hookopts)
@@ -159,7 +160,7 @@ int bfc_chain_set(int argc, char **argv)
 
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bf_ruleset_ struct bf_ruleset ruleset = bf_ruleset_default();
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
     struct bfc_chain_opts opts = {
         .validation_cb = _bfc_chain_set_validate_cb,
     };
@@ -264,7 +265,7 @@ int bfc_chain_load(int argc, char **argv)
 
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bf_ruleset_ struct bf_ruleset ruleset = bf_ruleset_default();
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
     struct bfc_chain_opts opts = {
         .validation_cb = _bfc_chain_load_validate_cb,
     };
@@ -374,7 +375,7 @@ int bfc_chain_update(int argc, char **argv)
 
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
-    _clean_bf_ruleset_ struct bf_ruleset ruleset = bf_ruleset_default();
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bf_ruleset_default();
     struct bfc_chain_opts opts = {
         .validation_cb = _bfc_chain_update_validate_cb,
     };

--- a/src/bfcli/chain.h
+++ b/src/bfcli/chain.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
-int bfc_chain_set(int argc, char **argv);
-int bfc_chain_get(int argc, char **argv);
-int bfc_chain_load(int argc, char **argv);
-int bfc_chain_attach(int argc, char **argv);
-int bfc_chain_update(int argc, char **argv);
-int bfc_chain_flush(int argc, char **argv);
+struct bfc_opts;
+
+int bfc_chain_set(const struct bfc_opts *opts);
+int bfc_chain_get(const struct bfc_opts *opts);
+int bfc_chain_load(const struct bfc_opts *opts);
+int bfc_chain_attach(const struct bfc_opts *opts);
+int bfc_chain_update(const struct bfc_opts *opts);
+int bfc_chain_flush(const struct bfc_opts *opts);

--- a/src/bfcli/helper.c
+++ b/src/bfcli/helper.c
@@ -11,20 +11,9 @@
 
 #include "bfcli/lexer.h"
 #include "bfcli/parser.h"
-#include "core/helper.h"
-#include "core/list.h"
 #include "core/logger.h"
 
-void bf_ruleset_clean(struct bf_ruleset *ruleset)
-{
-    bf_assert(ruleset);
-
-    bf_list_clean(&ruleset->chains);
-    bf_list_clean(&ruleset->hookopts);
-    bf_list_clean(&ruleset->sets);
-}
-
-int bfc_parse_file(const char *file, struct bf_ruleset *ruleset)
+int bfc_parse_file(const char *file, struct bfc_ruleset *ruleset)
 {
     FILE *rules;
     int r;
@@ -44,7 +33,7 @@ int bfc_parse_file(const char *file, struct bf_ruleset *ruleset)
     return r;
 }
 
-int bfc_parse_str(const char *str, struct bf_ruleset *ruleset)
+int bfc_parse_str(const char *str, struct bfc_ruleset *ruleset)
 {
     YY_BUFFER_STATE buffer;
     int r;

--- a/src/bfcli/helper.h
+++ b/src/bfcli/helper.h
@@ -8,16 +8,7 @@
 
 #include "core/list.h"
 
-struct bf_ruleset
-{
-    bf_list chains;
-    bf_list sets;
-    bf_list hookopts;
-};
+struct bfc_ruleset;
 
-#define _clean_bf_ruleset_ __attribute__((__cleanup__(bf_ruleset_clean)))
-
-void bf_ruleset_clean(struct bf_ruleset *ruleset);
-
-int bfc_parse_file(const char *file, struct bf_ruleset *ruleset);
-int bfc_parse_str(const char *str, struct bf_ruleset *ruleset);
+int bfc_parse_file(const char *file, struct bfc_ruleset *ruleset);
+int bfc_parse_str(const char *str, struct bfc_ruleset *ruleset);

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -52,9 +52,11 @@ static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
         break;
     case ARGP_KEY_END:
         if (!opts->input_file && !opts->input_string)
-            return bf_err_r(-EINVAL, "--file or --str argument is required");
+            return bf_err_r(-EINVAL,
+                            "--from-file or --from-str argument is required");
         if (opts->input_file && opts->input_string)
-            return bf_err_r(-EINVAL, "--file is incompatible with --str");
+            return bf_err_r(-EINVAL,
+                            "--from-file is incompatible with --from-str");
         break;
     default:
         return ARGP_ERR_UNKNOWN;
@@ -69,8 +71,8 @@ int _bf_do_ruleset_set(int argc, char *argv[])
         .input_file = NULL,
     };
     static struct argp_option options[] = {
-        {"file", 'f', "INPUT_FILE", 0, "Input file to use a rules source", 0},
-        {"str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
+        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source", 0},
+        {"from-str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
         {0},
     };
     struct argp argp = {

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -26,138 +26,8 @@
 #include "libbpfilter/bpfilter.h"
 #include "version.h"
 
-int bf_send(const struct bf_request *request, struct bf_response **response);
-
-struct bfc_ruleset_set_opts
-{
-    const char *input_file;
-    const char *input_string;
-};
-
-struct bfc_ruleset_get_opts
-{
-    bool with_counters;
-};
-
-static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
-                                           struct argp_state *state)
-{
-    struct bfc_ruleset_set_opts *opts = state->input;
-
-    switch (key) {
-    case 'f':
-        opts->input_file = arg;
-        break;
-    case 's':
-        opts->input_string = arg;
-        break;
-    case ARGP_KEY_END:
-        if (!opts->input_file && !opts->input_string)
-            return bf_err_r(-EINVAL,
-                            "--from-file or --from-str argument is required");
-        if (opts->input_file && opts->input_string)
-            return bf_err_r(-EINVAL,
-                            "--from-file is incompatible with --from-str");
-        break;
-    default:
-        return ARGP_ERR_UNKNOWN;
-    }
-
-    return 0;
-}
-
-int _bf_do_ruleset_set(int argc, char *argv[])
-{
-    static struct bfc_ruleset_set_opts opts = {
-        .input_file = NULL,
-    };
-    static struct argp_option options[] = {
-        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source",
-         0},
-        {"from-str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
-        {0},
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bf_ruleset_set_opts_parser,
-        NULL,    NULL,
-        0,       NULL,
-        NULL,
-    };
-    struct bfc_ruleset ruleset = {
-        .chains = bf_list_default(bf_chain_free, bf_chain_marsh),
-        .sets = bf_set_list(),
-        .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),
-    };
-    int r;
-
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r) {
-        bf_err_r(r, "failed to parse arguments");
-        goto end_clean;
-    }
-
-    if (opts.input_file)
-        r = bfc_parse_file(opts.input_file, &ruleset);
-    else
-        r = bfc_parse_str(opts.input_string, &ruleset);
-    if (r) {
-        bf_err_r(r, "failed to parse ruleset");
-        goto end_clean;
-    }
-
-    // Send the chains to the daemon
-    r = bf_cli_ruleset_set(&ruleset.chains, &ruleset.hookopts);
-    if (r)
-        bf_err_r(r, "failed to set ruleset");
-
-end_clean:
-    bf_list_clean(&ruleset.chains);
-    bf_list_clean(&ruleset.sets);
-    bf_list_clean(&ruleset.hookopts);
-
-    return r;
-}
 
 #define streq(str, expected) (str) && bf_streq(str, expected)
-
-static error_t _bf_ruleset_get_opts_parser(int key, const char *arg,
-                                           struct argp_state *state)
-{
-    UNUSED(key);
-    UNUSED(arg);
-    UNUSED(state);
-
-    return ARGP_ERR_UNKNOWN;
-}
-
-int _bf_do_ruleset_get(int argc, char *argv[])
-{
-    static struct argp_option options[] = {};
-    struct argp argp = {
-        options, (argp_parser_t)_bf_ruleset_get_opts_parser,
-        NULL,    NULL,
-        0,       NULL,
-        NULL,
-    };
-    _clean_bf_list_ bf_list chains = bf_list_default(bf_chain_free, NULL);
-    _clean_bf_list_ bf_list hookopts = bf_list_default(bf_hookopts_free, NULL);
-    _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
-    int r;
-
-    r = argp_parse(&argp, argc, argv, 0, 0, NULL);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
-
-    r = bf_cli_ruleset_get(&chains, &hookopts, &counters);
-    if (r < 0)
-        return bf_err_r(r, "failed to request ruleset");
-
-    r = bfc_ruleset_dump(&chains, &hookopts, &counters);
-    if (r)
-        return bf_err_r(r, "failed to dump ruleset");
-
-    return 0;
-}
 
 #define BFC_COMMAND_NAME_LEN 32
 static char _bfc_command_name[BFC_COMMAND_NAME_LEN];
@@ -199,9 +69,9 @@ int main(int argc, char *argv[])
     argv[0] = _bfc_command_name;
 
     if (streq(obj_str, "ruleset") && streq(action_str, "set")) {
-        r = _bf_do_ruleset_set(argc, argv);
+        r = bfc_ruleset_set(argc, argv);
     } else if (streq(obj_str, "ruleset") && streq(action_str, "get")) {
-        r = _bf_do_ruleset_get(argc, argv);
+        r = bfc_ruleset_get(argc, argv);
     } else if (streq(obj_str, "ruleset") && streq(action_str, "flush")) {
         r = bf_cli_ruleset_flush();
     } else if (streq(obj_str, "chain") && streq(action_str, "set")) {

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -13,6 +13,7 @@
 
 #include "bfcli/chain.h"
 #include "bfcli/helper.h"
+#include "bfcli/opts.h"
 #include "bfcli/print.h"
 #include "bfcli/ruleset.h"
 #include "core/chain.h"
@@ -26,72 +27,16 @@
 #include "libbpfilter/bpfilter.h"
 #include "version.h"
 
-
-#define streq(str, expected) (str) && bf_streq(str, expected)
-
-#define BFC_COMMAND_NAME_LEN 32
-static char _bfc_command_name[BFC_COMMAND_NAME_LEN];
-
 int main(int argc, char *argv[])
 {
-    const char *name = argv[0];
-    const char *obj_str = NULL;
-    const char *action_str = NULL;
-    int argv_skip = 0;
+    _clean_bfc_opts_ struct bfc_opts opts = bfc_opts_default();
     int r;
 
-    if (argc > 1 && argv[1][0] != '-') {
-        obj_str = argv[1];
-        ++argv_skip;
-    }
+    r = bfc_opts_parse(&opts, argc, argv);
+    if (r < 0)
+        return r;
 
-    if (obj_str && argc > 2 && argv[2][0] != '-') {
-        action_str = argv[2];
-        ++argv_skip;
-    }
-
-    argv += argv_skip;
-    argc -= argv_skip;
-
-    bf_logger_setup();
-
-    // If any of the arguments is --version, print the version and return.
-    for (int i = 0; i < argc; ++i) {
-        if (bf_streq("--version", argv[i])) {
-            bf_info("bfcli version %s, libbpfilter version %s", BF_VERSION,
-                    bf_version());
-            exit(0);
-        }
-    }
-
-    (void)snprintf(_bfc_command_name, BFC_COMMAND_NAME_LEN, "%s %s %s", name,
-                   obj_str, action_str);
-    argv[0] = _bfc_command_name;
-
-    if (streq(obj_str, "ruleset") && streq(action_str, "set")) {
-        r = bfc_ruleset_set(argc, argv);
-    } else if (streq(obj_str, "ruleset") && streq(action_str, "get")) {
-        r = bfc_ruleset_get(argc, argv);
-    } else if (streq(obj_str, "ruleset") && streq(action_str, "flush")) {
-        r = bf_cli_ruleset_flush();
-    } else if (streq(obj_str, "chain") && streq(action_str, "set")) {
-        r = bfc_chain_set(argc, argv);
-    } else if (streq(obj_str, "chain") && streq(action_str, "get")) {
-        r = bfc_chain_get(argc, argv);
-    } else if (streq(obj_str, "chain") && streq(action_str, "load")) {
-        r = bfc_chain_load(argc, argv);
-    } else if (streq(obj_str, "chain") && streq(action_str, "attach")) {
-        r = bfc_chain_attach(argc, argv);
-    } else if (streq(obj_str, "chain") && streq(action_str, "update")) {
-        r = bfc_chain_update(argc, argv);
-    } else if (streq(obj_str, "chain") && streq(action_str, "flush")) {
-        r = bfc_chain_flush(argc, argv);
-    } else {
-        return bf_err_r(-EINVAL, "unrecognized object '%s' and action '%s'",
-                        obj_str, action_str);
-    }
-
-    return r;
+    return opts.cmd->cb(&opts);
 }
 
 void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...)

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -14,6 +14,7 @@
 #include "bfcli/chain.h"
 #include "bfcli/helper.h"
 #include "bfcli/print.h"
+#include "bfcli/ruleset.h"
 #include "core/chain.h"
 #include "core/helper.h"
 #include "core/hook.h"
@@ -27,13 +28,13 @@
 
 int bf_send(const struct bf_request *request, struct bf_response **response);
 
-struct bf_ruleset_set_opts
+struct bfc_ruleset_set_opts
 {
     const char *input_file;
     const char *input_string;
 };
 
-struct bf_ruleset_get_opts
+struct bfc_ruleset_get_opts
 {
     bool with_counters;
 };
@@ -41,7 +42,7 @@ struct bf_ruleset_get_opts
 static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
                                            struct argp_state *state)
 {
-    struct bf_ruleset_set_opts *opts = state->input;
+    struct bfc_ruleset_set_opts *opts = state->input;
 
     switch (key) {
     case 'f':
@@ -67,11 +68,12 @@ static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
 
 int _bf_do_ruleset_set(int argc, char *argv[])
 {
-    static struct bf_ruleset_set_opts opts = {
+    static struct bfc_ruleset_set_opts opts = {
         .input_file = NULL,
     };
     static struct argp_option options[] = {
-        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source", 0},
+        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source",
+         0},
         {"from-str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
         {0},
     };
@@ -81,7 +83,7 @@ int _bf_do_ruleset_set(int argc, char *argv[])
         0,       NULL,
         NULL,
     };
-    struct bf_ruleset ruleset = {
+    struct bfc_ruleset ruleset = {
         .chains = bf_list_default(bf_chain_free, bf_chain_marsh),
         .sets = bf_set_list(),
         .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),
@@ -222,7 +224,7 @@ int main(int argc, char *argv[])
     return r;
 }
 
-void yyerror(struct bf_ruleset *ruleset, const char *fmt, ...)
+void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...)
 {
     UNUSED(ruleset);
 

--- a/src/bfcli/opts.c
+++ b/src/bfcli/opts.c
@@ -1,0 +1,428 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bfcli/opts.h"
+
+#include <argp.h>
+
+#include "bfcli/chain.h"
+#include "bfcli/ruleset.h"
+#include "core/helper.h"
+
+/**
+ * @brief Create a section header in the documentation.
+ *
+ * By creating an `argp_option` with no name or key, argph will print the option
+ * as a section header.
+ *
+ * @param object Object type to create a section for.
+ */
+#define BFC_HELP_SECTION(object)                                               \
+    {.group = (int)(object) + 1, .doc = _bfc_object_strs[object]}
+
+/**
+ * @brief Create a entry in the previous documentation section.
+ *
+ * @param action Action to create an entry for.
+ * @param help Documentation for that entry.
+ */
+#define BFC_HELP_ENTRY(action, help)                                           \
+    {.name = _bfc_action_strs[action], .doc = (help), .flags = OPTION_DOC}
+
+static const char * const _bfc_object_strs[] = {
+    "ruleset", // BFC_OBJECT_RULESET
+    "chain", // BFC_OBJECT_CHAIN
+};
+static_assert(ARRAY_SIZE(_bfc_object_strs) == _BFC_OBJECT_MAX,
+              "missing entries in bfc_object strings array");
+
+static const char *bfc_object_to_str(enum bfc_object object)
+{
+    return _bfc_object_strs[object];
+}
+
+enum bfc_object bfc_object_from_str(const char *str)
+{
+    bf_assert(str);
+
+    for (enum bfc_object object = 0; object < _BFC_OBJECT_MAX; ++object) {
+        if (bf_streq(_bfc_object_strs[object], str))
+            return object;
+    }
+
+    return -EINVAL;
+}
+
+static const char * const _bfc_action_strs[] = {
+    "set", // BFC_ACTION_SET
+    "get", // BFC_ACTION_GET
+    "load", // BFC_ACTION_LOAD
+    "attach", //BFC_ACTION_ATTACH
+    "update", // BFC_ACTION_UPDATE
+    "flush", // BFC_ACTION_FLUSH
+};
+static_assert(ARRAY_SIZE(_bfc_action_strs) == _BFC_ACTION_MAX,
+              "missing entries in bfc_action strings array");
+
+static const char *bfc_action_to_str(enum bfc_action action)
+{
+    return _bfc_action_strs[action];
+}
+
+enum bfc_action bfc_action_from_str(const char *str)
+{
+    bf_assert(str);
+
+    for (enum bfc_action action = 0; action < _BFC_ACTION_MAX; ++action) {
+        if (bf_streq(_bfc_action_strs[action], str))
+            return action;
+    }
+
+    return -EINVAL;
+}
+
+enum bfc_opts_option_id
+{
+    BFC_OPT_RULESET_FROM_STR,
+    BFC_OPT_RULESET_FROM_FILE,
+    BFC_OPT_CHAIN_FROM_STR,
+    BFC_OPT_CHAIN_FROM_FILE,
+    BFC_OPT_CHAIN_NAME,
+    BFC_OPT_CHAIN_HOOK_OPTS,
+    _BFC_OPT_MAX,
+};
+
+static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
+    {
+        .name = "bfcli ruleset set",
+        .object = BFC_OBJECT_RULESET,
+        .action = BFC_ACTION_SET,
+        .valid_opts =
+            1 << BFC_OPT_RULESET_FROM_STR | 1 << BFC_OPT_RULESET_FROM_FILE,
+        .doc =
+            "Set the ruleset.\vRemove all the chains on the system and "
+            "replaced them with the one provided in --from-file or --from-str.",
+        .cb = bfc_ruleset_set,
+    },
+    {
+        .name = "bfcli ruleset get",
+        .object = BFC_OBJECT_RULESET,
+        .action = BFC_ACTION_GET,
+        .doc = "Print the ruleset.\vPrint the current ruleset.",
+        .cb = bfc_ruleset_get,
+    },
+    {
+        .name = "bfcli ruleset flush",
+        .object = BFC_OBJECT_RULESET,
+        .action = BFC_ACTION_FLUSH,
+        .doc = "Delete the ruleset.\vRemove every chain from the system.",
+        .cb = bfc_ruleset_flush,
+    },
+    {
+        .name = "bfcli chain set",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_SET,
+        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
+                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .doc =
+            "Set a new chain\vCreate a new chain, attach it if hook options "
+            "are defined. Any existing chain with the same --name will be "
+            "replaced. If --from-str or --from-file contains multiple chains, "
+            "--name is used to select the right one.",
+        .cb = bfc_chain_set,
+    },
+    {
+        .name = "bfcli chain get",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_GET,
+        .valid_opts = 1 << BFC_OPT_CHAIN_NAME,
+        .doc =
+            "Print an existing chain\vRequest the chain --name from the daemon "
+            "and print it.",
+        .cb = bfc_chain_get,
+    },
+    {
+        .name = "bfcli chain load",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_LOAD,
+        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
+                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .doc =
+            "Load a new chain\vCreate a new chain, and load it into the "
+            "kernel. An error will be returned if any existing chain has the "
+            "same name. If --from-str or --from-file contains multiple chains, "
+            "--name is used to select the right one.",
+        .cb = bfc_chain_load,
+    },
+    {
+        .name = "bfcli chain attach",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_ATTACH,
+        .valid_opts = 1 << BFC_OPT_CHAIN_HOOK_OPTS | 1 << BFC_OPT_CHAIN_NAME,
+        .doc =
+            "Attach an existing chain\vAttach a loaded chain to a hook. Hook "
+            "options defined with --option are specific to the chain and the "
+            "hook to attach to.",
+        .cb = bfc_chain_attach,
+    },
+    {
+        .name = "bfcli chain update",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_UPDATE,
+        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
+                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .doc = "Update a chain\vAtomically update chain --name with the new "
+               "definition provided by --from-str or --from-file.",
+        .cb = bfc_chain_update,
+    },
+    {
+        .name = "bfcli chain flush",
+        .object = BFC_OBJECT_CHAIN,
+        .action = BFC_ACTION_FLUSH,
+        .valid_opts = 1 << BFC_OPT_CHAIN_NAME,
+        .doc = "Delete a chain\vRemove a chain from the system.",
+        .cb = bfc_chain_flush,
+    },
+};
+
+const struct bfc_opts_cmd *_bfc_opts_get_cmd(enum bfc_object object,
+                                             enum bfc_action action)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(_bfc_opts_cmds); ++i) {
+        if (_bfc_opts_cmds[i].object == object &&
+            _bfc_opts_cmds[i].action == action)
+            return &_bfc_opts_cmds[i];
+    }
+
+    return NULL;
+}
+
+static error_t _bfc_opts_parser(int key, char *arg, struct argp_state *state)
+{
+    struct bfc_opts *opts = state->input;
+
+    switch (key) {
+    case ARGP_KEY_ARG:
+        if (state->arg_num == 0) {
+            opts->object = bfc_object_from_str(arg);
+            if ((int)opts->object < 0)
+                argp_error(state, "unknown object '%s'", arg);
+        } else if (state->arg_num == 1) {
+            opts->action = bfc_action_from_str(arg);
+            if ((int)opts->action < 0)
+                argp_error(state, "unknown action '%s'", arg);
+            opts->cmd = _bfc_opts_get_cmd(opts->object, opts->action);
+            if (!opts->cmd)
+                argp_error(state, "object '%s' does not support action '%s'",
+                           bfc_object_to_str(opts->object),
+                           bfc_action_to_str(opts->action));
+            state->next = state->argc;
+        } else {
+            return ARGP_ERR_UNKNOWN;
+        }
+        break;
+    case ARGP_KEY_END:
+        if (opts->object == _BFC_OBJECT_MAX || opts->action == _BFC_ACTION_MAX)
+            argp_usage(state);
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+static void _bfc_opts_from_str_cb(struct argp_state *state, const char *arg,
+                                  struct bfc_opts *opts)
+{
+    if (opts->from_file)
+        argp_error(state, "--from-str is incompatible with --from-file");
+
+    opts->from_str = arg;
+};
+
+static void _bfc_opts_from_file_cb(struct argp_state *state, const char *arg,
+                                   struct bfc_opts *opts)
+{
+    if (opts->from_str)
+        argp_error(state, "--from-file is incompatible with --from-str");
+
+    opts->from_file = arg;
+};
+
+static void _bfc_opts_chain_name_cb(struct argp_state *state, const char *arg,
+                                    struct bfc_opts *opts)
+{
+    if (strlen(arg) == 0)
+        argp_error(state, "--name can't be empty");
+
+    opts->name = arg;
+};
+
+static void _bfc_opts_chain_hook_opts_cb(struct argp_state *state,
+                                         const char *arg, struct bfc_opts *opts)
+{
+    if (bf_hookopts_parse_opt(&opts->hookopts, arg))
+        argp_error(state, "failed to parse hook option '%s'", arg);
+};
+
+struct bfc_opts_opt
+{
+    enum bfc_opts_option_id id;
+    int key;
+    const char *name;
+    const char *arg;
+    const char *doc;
+    void (*parser)(struct argp_state *state, const char *arg,
+                   struct bfc_opts *opts);
+} _bfc_options[] = {
+    {
+        .id = BFC_OPT_RULESET_FROM_STR,
+        .key = 's',
+        .name = "from-str",
+        .arg = "STR",
+        .doc = "String defining the ruleset",
+        .parser = _bfc_opts_from_str_cb,
+    },
+    {
+        .id = BFC_OPT_RULESET_FROM_FILE,
+        .key = 'f',
+        .name = "from-file",
+        .arg = "FILE",
+        .doc = "File defining the ruleset",
+        .parser = _bfc_opts_from_file_cb,
+    },
+    {
+        .id = BFC_OPT_CHAIN_FROM_STR,
+        .key = 's',
+        .name = "from-str",
+        .arg = "STRING",
+        .doc = "String defining the chain",
+        .parser = _bfc_opts_from_str_cb,
+    },
+    {
+        .id = BFC_OPT_CHAIN_FROM_FILE,
+        .key = 'f',
+        .name = "from-file",
+        .arg = "FILE",
+        .doc = "File defining the chain",
+        .parser = _bfc_opts_from_file_cb,
+    },
+    {
+        .id = BFC_OPT_CHAIN_NAME,
+        .key = 'n',
+        .name = "name",
+        .arg = "NAME",
+        .doc = "Name of the chain",
+        .parser = _bfc_opts_chain_name_cb,
+    },
+    {
+        .id = BFC_OPT_CHAIN_HOOK_OPTS,
+        .key = 'o',
+        .name = "option",
+        .arg = "HOOKOPT=VALUE",
+        .doc = "Hook option to attach the chain",
+        .parser = _bfc_opts_chain_hook_opts_cb,
+    },
+};
+
+static error_t _bfc_opts_cmd_parser(int key, char *arg,
+                                    struct argp_state *state)
+{
+    struct bfc_opts *opts = state->input;
+    const struct bfc_opts_cmd *cmd = opts->cmd;
+
+    for (int i = 0; i < _BFC_OPT_MAX; ++i) {
+        struct bfc_opts_opt *opt = &_bfc_options[i];
+
+        if (!(cmd->valid_opts & (1 << i)) || key != opt->key)
+            continue;
+
+        opt->parser(state, arg, opts);
+
+        return 0;
+    }
+
+    return ARGP_ERR_UNKNOWN;
+}
+
+void bfc_opts_clean(struct bfc_opts *opts)
+{
+    bf_assert(opts);
+
+    bf_hookopts_clean(&opts->hookopts);
+}
+
+#define _BFC_NAME_LEN 32
+static char _bfc_name[_BFC_NAME_LEN] = {};
+
+int bfc_opts_parse(struct bfc_opts *opts, int argc, char **argv)
+{
+    static const struct argp_option options[] = {
+        BFC_HELP_SECTION(BFC_OBJECT_RULESET),
+        BFC_HELP_ENTRY(BFC_ACTION_SET,
+                       "Set the current ruleset, replace any existing rule"),
+        BFC_HELP_ENTRY(BFC_ACTION_GET, "Print the current ruleset"),
+        BFC_HELP_ENTRY(BFC_ACTION_FLUSH, "Flush (drop) the current ruleset"),
+        BFC_HELP_SECTION(BFC_OBJECT_CHAIN),
+        BFC_HELP_ENTRY(
+            BFC_ACTION_SET,
+            "Set a new chain, replace any existing chain with the same name, attach if required"),
+        BFC_HELP_ENTRY(BFC_ACTION_GET, "Print an existing chain"),
+        BFC_HELP_ENTRY(BFC_ACTION_LOAD, "Load a new chain, do not attach it"),
+        BFC_HELP_ENTRY(BFC_ACTION_ATTACH, "Attach a loaded chain"),
+        BFC_HELP_ENTRY(BFC_ACTION_FLUSH, "Remove a chain"),
+        {0},
+    };
+    static const struct argp parser = {
+        .options = options,
+        .parser = _bfc_opts_parser,
+        .args_doc = "OBJECT ACTION",
+        .doc =
+            "Configure bpfilter chains and filtering rules.\v"
+            "Examples:\n"
+            "  # Set a ruleset from file\n"
+            "  bfcli ruleset set --from-file myruleset.txt\n\n"
+            "  # Create an XDP chain\n"
+            "  bfcli chain set --from-str \"chain my_xdp_chain BF_HOOK_XDP ACCEPT rule ip4.saddr in {192.168.1.1} ACCEPT\"\n\n"
+            "  # Get current ruleset\n"
+            "  bfcli ruleset get\n\n"
+            "  # Flush all rules\n"
+            "  bfcli ruleset flush\n",
+    };
+    struct argp_option suboptions[_BFC_OPT_MAX + 1] = {};
+    struct argp subparser = {.parser = _bfc_opts_cmd_parser};
+    int suboptions_idx = 0;
+    int r;
+
+    r = argp_parse(&parser, argc, argv, ARGP_IN_ORDER, NULL, opts);
+    if (r)
+        return r;
+
+    for (int i = 0; i < _BFC_OPT_MAX; ++i) {
+        if (opts->cmd->valid_opts & (1 << i)) {
+            suboptions[suboptions_idx++] = (struct argp_option) {
+                .name = _bfc_options[i].name,
+                .key = _bfc_options[i].key,
+                .arg = _bfc_options[i].arg,
+                .doc = _bfc_options[i].doc,
+            };
+        }
+    }
+
+    subparser.options = !opts->cmd->valid_opts ? NULL : suboptions;
+    subparser.doc = opts->cmd->doc;
+
+    (void)snprintf(_bfc_name, _BFC_NAME_LEN, "%s %s %s", argv[0],
+                   bfc_object_to_str(opts->object),
+                   bfc_action_to_str(opts->action));
+    argv[2] = _bfc_name;
+    argc -= 2;
+    argv += 2;
+
+    r = argp_parse(&subparser, argc, argv, 0, NULL, opts);
+
+    return r;
+}

--- a/src/bfcli/opts.h
+++ b/src/bfcli/opts.h
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/hook.h"
+
+/**
+ * @file opts.h
+ *
+ * bfcli commands are constructed as `bfcli OBJECT ACTION [OPTIONS...]`, with
+ * `OBJECT` the type of bpfilter object to manipulate, and `ACTION` the action
+ * to apply to the object.
+ *
+ * This file provides the mechanism to define and parse command line object for
+ * all the existing commands supported by bfcli.
+ *
+ * Two `argp.h` parsers are required to parse bfcli commands. The first parser
+ * will validate the `OBJECT` and `ACTION`. The second parser is constructed
+ * based on `OBJECT` and `ACTION` to only parse the options supported by this
+ * specific command.
+ */
+
+#define _clean_bfc_opts_ __attribute__((__cleanup__(bfc_opts_clean)))
+
+/**
+ * @brief Type of objects supported by bfcli
+ */
+enum bfc_object
+{
+    BFC_OBJECT_RULESET,
+    BFC_OBJECT_CHAIN,
+    _BFC_OBJECT_MAX,
+};
+
+/**
+ * @brief Type of actions supported by bfcli
+ */
+enum bfc_action
+{
+    BFC_ACTION_SET,
+    BFC_ACTION_GET,
+    BFC_ACTION_LOAD,
+    BFC_ACTION_ATTACH,
+    BFC_ACTION_UPDATE,
+    BFC_ACTION_FLUSH,
+    _BFC_ACTION_MAX,
+};
+
+struct bfc_opts_cmd;
+
+/**
+ * @brief Command line options configured for bfcli
+ */
+struct bfc_opts
+{
+    const struct bfc_opts_cmd *cmd;
+
+    enum bfc_object object;
+    enum bfc_action action;
+
+    const char *from_str;
+    const char *from_file;
+    const char *name;
+    struct bf_hookopts hookopts;
+};
+
+struct bfc_opts_cmd
+{
+    enum bfc_object object;
+    enum bfc_action action;
+    const char *name;
+    int valid_opts;
+    const char *doc;
+    int (*cb)(const struct bfc_opts *opts);
+};
+
+/**
+ * @brief Initialize a `bfc_opts` object to default values.
+ */
+#define bfc_opts_default()                                                     \
+    {.object = _BFC_OBJECT_MAX, .action = _BFC_ACTION_MAX};
+
+void bfc_opts_clean(struct bfc_opts *opts);
+int bfc_opts_parse(struct bfc_opts *opts, int argc, char **argv);

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -10,13 +10,13 @@
     #include <stdbool.h>
 
     #include "core/list.h"
-    #include "bfcli/helper.h"
+    #include "bfcli/ruleset.h"
 
     extern int yylex();
     extern int yyparse();
     extern FILE *yyin;
 
-    void yyerror(struct bf_ruleset *ruleset, const char *fmt, ...);
+    void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...);
 %}
 
 %code requires {
@@ -53,7 +53,7 @@
 }
 
 %define parse.error detailed
-%parse-param {struct bf_ruleset *ruleset}
+%parse-param {struct bfc_ruleset *ruleset}
 
 %union {
     bool bval;

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -6,15 +6,9 @@
 
 #include "bfcli/ruleset.h"
 
-#include <argp.h>
-
 #include "bfcli/helper.h"
+#include "bfcli/opts.h"
 #include "bfcli/print.h"
-#include "core/chain.h"
-#include "core/helper.h"
-#include "core/list.h"
-#include "core/logger.h"
-#include "core/set.h"
 #include "libbpfilter/bpfilter.h"
 
 void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
@@ -26,123 +20,33 @@ void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
     bf_list_clean(&ruleset->sets);
 }
 
-struct bfc_ruleset_set_opts
+int bfc_ruleset_set(const struct bfc_opts *opts)
 {
-    const char *input_file;
-    const char *input_string;
-};
-
-struct bfc_ruleset_get_opts
-{
-    bool with_counters;
-};
-
-static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
-                                           struct argp_state *state)
-{
-    struct bfc_ruleset_set_opts *opts = state->input;
-
-    switch (key) {
-    case 'f':
-        opts->input_file = arg;
-        break;
-    case 's':
-        opts->input_string = arg;
-        break;
-    case ARGP_KEY_END:
-        if (!opts->input_file && !opts->input_string)
-            return bf_err_r(-EINVAL,
-                            "--from-file or --from-str argument is required");
-        if (opts->input_file && opts->input_string)
-            return bf_err_r(-EINVAL,
-                            "--from-file is incompatible with --from-str");
-        break;
-    default:
-        return ARGP_ERR_UNKNOWN;
-    }
-
-    return 0;
-}
-
-int bfc_ruleset_set(int argc, char *argv[])
-{
-    static struct bfc_ruleset_set_opts opts = {
-        .input_file = NULL,
-    };
-    static struct argp_option options[] = {
-        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source",
-         0},
-        {"from-str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
-        {0},
-    };
-    struct argp argp = {
-        options, (argp_parser_t)_bf_ruleset_set_opts_parser,
-        NULL,    NULL,
-        0,       NULL,
-        NULL,
-    };
-    struct bfc_ruleset ruleset = {
-        .chains = bf_list_default(bf_chain_free, bf_chain_marsh),
-        .sets = bf_set_list(),
-        .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),
-    };
+    _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bfc_ruleset_default();
     int r;
 
-    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
-    if (r) {
-        bf_err_r(r, "failed to parse arguments");
-        goto end_clean;
-    }
-
-    if (opts.input_file)
-        r = bfc_parse_file(opts.input_file, &ruleset);
+    if (opts->from_file)
+        r = bfc_parse_file(opts->from_file, &ruleset);
     else
-        r = bfc_parse_str(opts.input_string, &ruleset);
-    if (r) {
+        r = bfc_parse_str(opts->from_str, &ruleset);
+    if (r)
         bf_err_r(r, "failed to parse ruleset");
-        goto end_clean;
-    }
 
-    // Send the chains to the daemon
     r = bf_cli_ruleset_set(&ruleset.chains, &ruleset.hookopts);
     if (r)
         bf_err_r(r, "failed to set ruleset");
 
-end_clean:
-    bf_list_clean(&ruleset.chains);
-    bf_list_clean(&ruleset.sets);
-    bf_list_clean(&ruleset.hookopts);
-
     return r;
 }
 
-static error_t _bf_ruleset_get_opts_parser(int key, const char *arg,
-                                           struct argp_state *state)
+int bfc_ruleset_get(const struct bfc_opts *opts)
 {
-    UNUSED(key);
-    UNUSED(arg);
-    UNUSED(state);
+    UNUSED(opts);
 
-    return ARGP_ERR_UNKNOWN;
-}
-
-int bfc_ruleset_get(int argc, char *argv[])
-{
-    static struct argp_option options[] = {};
-    struct argp argp = {
-        options, (argp_parser_t)_bf_ruleset_get_opts_parser,
-        NULL,    NULL,
-        0,       NULL,
-        NULL,
-    };
     _clean_bf_list_ bf_list chains = bf_list_default(bf_chain_free, NULL);
     _clean_bf_list_ bf_list hookopts = bf_list_default(bf_hookopts_free, NULL);
     _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
     int r;
-
-    r = argp_parse(&argp, argc, argv, 0, 0, NULL);
-    if (r)
-        return bf_err_r(r, "failed to parse arguments");
 
     r = bf_cli_ruleset_get(&chains, &hookopts, &counters);
     if (r < 0)
@@ -153,4 +57,11 @@ int bfc_ruleset_get(int argc, char *argv[])
         return bf_err_r(r, "failed to dump ruleset");
 
     return 0;
+}
+
+int bfc_ruleset_flush(const struct bfc_opts *opts)
+{
+    UNUSED(opts);
+
+    return bf_cli_ruleset_flush();
 }

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -6,7 +6,16 @@
 
 #include "bfcli/ruleset.h"
 
+#include <argp.h>
+
+#include "bfcli/helper.h"
+#include "bfcli/print.h"
+#include "core/chain.h"
 #include "core/helper.h"
+#include "core/list.h"
+#include "core/logger.h"
+#include "core/set.h"
+#include "libbpfilter/bpfilter.h"
 
 void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
 {
@@ -15,4 +24,133 @@ void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
     bf_list_clean(&ruleset->chains);
     bf_list_clean(&ruleset->hookopts);
     bf_list_clean(&ruleset->sets);
+}
+
+struct bfc_ruleset_set_opts
+{
+    const char *input_file;
+    const char *input_string;
+};
+
+struct bfc_ruleset_get_opts
+{
+    bool with_counters;
+};
+
+static error_t _bf_ruleset_set_opts_parser(int key, const char *arg,
+                                           struct argp_state *state)
+{
+    struct bfc_ruleset_set_opts *opts = state->input;
+
+    switch (key) {
+    case 'f':
+        opts->input_file = arg;
+        break;
+    case 's':
+        opts->input_string = arg;
+        break;
+    case ARGP_KEY_END:
+        if (!opts->input_file && !opts->input_string)
+            return bf_err_r(-EINVAL,
+                            "--from-file or --from-str argument is required");
+        if (opts->input_file && opts->input_string)
+            return bf_err_r(-EINVAL,
+                            "--from-file is incompatible with --from-str");
+        break;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+
+    return 0;
+}
+
+int bfc_ruleset_set(int argc, char *argv[])
+{
+    static struct bfc_ruleset_set_opts opts = {
+        .input_file = NULL,
+    };
+    static struct argp_option options[] = {
+        {"from-file", 'f', "INPUT_FILE", 0, "Input file to use a rules source",
+         0},
+        {"from-str", 's', "INPUT_STRING", 0, "String to use as rules", 0},
+        {0},
+    };
+    struct argp argp = {
+        options, (argp_parser_t)_bf_ruleset_set_opts_parser,
+        NULL,    NULL,
+        0,       NULL,
+        NULL,
+    };
+    struct bfc_ruleset ruleset = {
+        .chains = bf_list_default(bf_chain_free, bf_chain_marsh),
+        .sets = bf_set_list(),
+        .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),
+    };
+    int r;
+
+    r = argp_parse(&argp, argc, argv, 0, 0, &opts);
+    if (r) {
+        bf_err_r(r, "failed to parse arguments");
+        goto end_clean;
+    }
+
+    if (opts.input_file)
+        r = bfc_parse_file(opts.input_file, &ruleset);
+    else
+        r = bfc_parse_str(opts.input_string, &ruleset);
+    if (r) {
+        bf_err_r(r, "failed to parse ruleset");
+        goto end_clean;
+    }
+
+    // Send the chains to the daemon
+    r = bf_cli_ruleset_set(&ruleset.chains, &ruleset.hookopts);
+    if (r)
+        bf_err_r(r, "failed to set ruleset");
+
+end_clean:
+    bf_list_clean(&ruleset.chains);
+    bf_list_clean(&ruleset.sets);
+    bf_list_clean(&ruleset.hookopts);
+
+    return r;
+}
+
+static error_t _bf_ruleset_get_opts_parser(int key, const char *arg,
+                                           struct argp_state *state)
+{
+    UNUSED(key);
+    UNUSED(arg);
+    UNUSED(state);
+
+    return ARGP_ERR_UNKNOWN;
+}
+
+int bfc_ruleset_get(int argc, char *argv[])
+{
+    static struct argp_option options[] = {};
+    struct argp argp = {
+        options, (argp_parser_t)_bf_ruleset_get_opts_parser,
+        NULL,    NULL,
+        0,       NULL,
+        NULL,
+    };
+    _clean_bf_list_ bf_list chains = bf_list_default(bf_chain_free, NULL);
+    _clean_bf_list_ bf_list hookopts = bf_list_default(bf_hookopts_free, NULL);
+    _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
+    int r;
+
+    r = argp_parse(&argp, argc, argv, 0, 0, NULL);
+    if (r)
+        return bf_err_r(r, "failed to parse arguments");
+
+    r = bf_cli_ruleset_get(&chains, &hookopts, &counters);
+    if (r < 0)
+        return bf_err_r(r, "failed to request ruleset");
+
+    r = bfc_ruleset_dump(&chains, &hookopts, &counters);
+    if (r)
+        return bf_err_r(r, "failed to dump ruleset");
+
+    return 0;
 }

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -1,0 +1,18 @@
+
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bfcli/ruleset.h"
+
+#include "core/helper.h"
+
+void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
+{
+    bf_assert(ruleset);
+
+    bf_list_clean(&ruleset->chains);
+    bf_list_clean(&ruleset->hookopts);
+    bf_list_clean(&ruleset->sets);
+}

--- a/src/bfcli/ruleset.h
+++ b/src/bfcli/ruleset.h
@@ -1,0 +1,20 @@
+
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2025 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include "core/list.h"
+
+struct bfc_ruleset
+{
+    bf_list chains;
+    bf_list sets;
+    bf_list hookopts;
+};
+
+#define _clean_bfc_ruleset_ __attribute__((__cleanup__(bfc_ruleset_clean)))
+
+void bfc_ruleset_clean(struct bfc_ruleset *ruleset);

--- a/src/bfcli/ruleset.h
+++ b/src/bfcli/ruleset.h
@@ -18,3 +18,6 @@ struct bfc_ruleset
 #define _clean_bfc_ruleset_ __attribute__((__cleanup__(bfc_ruleset_clean)))
 
 void bfc_ruleset_clean(struct bfc_ruleset *ruleset);
+
+int bfc_ruleset_set(int argc, char *argv[]);
+int bfc_ruleset_get(int argc, char *argv[]);

--- a/src/bfcli/ruleset.h
+++ b/src/bfcli/ruleset.h
@@ -6,7 +6,19 @@
 
 #pragma once
 
+#include "core/chain.h"
+#include "core/hook.h"
 #include "core/list.h"
+#include "core/set.h"
+
+#define bfc_ruleset_default()                                                  \
+    {                                                                          \
+        .chains = bf_list_default(bf_chain_free, bf_chain_marsh),              \
+        .sets = bf_list_default(bf_set_free, bf_set_marsh),                    \
+        .hookopts = bf_list_default(bf_hookopts_free, bf_hookopts_marsh),      \
+    }
+
+#define _clean_bfc_ruleset_ __attribute__((__cleanup__(bfc_ruleset_clean)))
 
 struct bfc_ruleset
 {
@@ -15,9 +27,10 @@ struct bfc_ruleset
     bf_list hookopts;
 };
 
-#define _clean_bfc_ruleset_ __attribute__((__cleanup__(bfc_ruleset_clean)))
+struct bfc_opts;
 
 void bfc_ruleset_clean(struct bfc_ruleset *ruleset);
 
-int bfc_ruleset_set(int argc, char *argv[]);
-int bfc_ruleset_get(int argc, char *argv[]);
+int bfc_ruleset_set(const struct bfc_opts *opts);
+int bfc_ruleset_get(const struct bfc_opts *opts);
+int bfc_ruleset_flush(const struct bfc_opts *opts);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -57,7 +57,8 @@
 
 #include "external/filter.h"
 
-#define _BF_LOG_BUF_SIZE (UINT32_MAX >> 8) /* verifier maximum in kernels <= 5.1 */
+#define _BF_LOG_BUF_SIZE                                                       \
+    (UINT32_MAX >> 8) /* verifier maximum in kernels <= 5.1 */
 #define _BF_PROGRAM_DEFAULT_IMG_SIZE (1 << 6)
 
 static const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -434,6 +434,11 @@ int bf_hookopts_new_from_marsh(struct bf_hookopts **hookopts,
     return 0;
 }
 
+void bf_hookopts_clean(struct bf_hookopts *hookopts)
+{
+    freep((void *)&hookopts->cgpath);
+}
+
 void bf_hookopts_free(struct bf_hookopts **hookopts)
 {
     bf_assert(hookopts);
@@ -441,7 +446,7 @@ void bf_hookopts_free(struct bf_hookopts **hookopts)
     if (!*hookopts)
         return;
 
-    freep((void *)&(*hookopts)->cgpath);
+    bf_hookopts_clean(*hookopts);
     freep((void *)hookopts);
 }
 

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -135,6 +135,7 @@ enum bf_hookopts_type
     _BF_HOOKOPTS_MAX,
 };
 
+#define _clean_bf_hookopts_ __attribute__((cleanup(bf_hookopts_clean)))
 #define _free_bf_hookopts_ __attribute__((cleanup(bf_hookopts_free)))
 
 /**
@@ -156,6 +157,15 @@ int bf_hookopts_new(struct bf_hookopts **hookopts);
  */
 int bf_hookopts_new_from_marsh(struct bf_hookopts **hookopts,
                                const struct bf_marsh *marsh);
+
+/**
+ * @brief Cleanup a `bf_hookopts` object.
+ *
+ * Release the allocated memory *in* the object, but not the object itself.
+ *
+ * @param hookopts `bf_hookopts` object to cleanup. Can't be NULL.
+ */
+void bf_hookopts_clean(struct bf_hookopts *hookopts);
 
 /**
  * Deallocate a `bf_hookopts` object.

--- a/tests/e2e/cli.sh
+++ b/tests/e2e/cli.sh
@@ -228,11 +228,11 @@ FROM_NS="nsenter --all --target ${BPFILTER_PID}"
 
 log "[SUITE] netns: define chains from ns"
 expect_failure "can't attach chain to host iface from ns" \
-    ${FROM_NS} ${BFCLI} ruleset set --str \"chain xdp BF_HOOK_XDP\{ifindex=${HOST_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${HOST_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
 expect_success "can ping host iface from netns" \
     ${FROM_NS} ping -c 1 -W 0.25 ${HOST_IP_ADDR}
 expect_success "attach chain to ns iface" \
-    ${FROM_NS} ${BFCLI} ruleset set --str \"chain xdp BF_HOOK_TC_INGRESS\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_TC_INGRESS\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
 expect_failure "can't ping ns iface from host" \
     ping -c 1 -W 0.25 ${NS_IP_ADDR}
 expect_success "pings have been blocked on ingress" \
@@ -242,11 +242,11 @@ expect_success "flushing the ruleset" \
 
 log "[SUITE] Define chain from the netns"
 expect_failure "can't attach chain to host iface from netns" \
-    ${FROM_NS} ${BFCLI} ruleset set --str \"chain xdp BF_HOOK_XDP\{ifindex=${HOST_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${HOST_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
 expect_success "can ping the netns iface from the host" \
     ping -c 1 -W 0.25 ${NS_IP_ADDR}
 expect_success "attach chain to the netns iface" \
-    ${FROM_NS} ${BFCLI} ruleset set --str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip4.proto icmp counter DROP\"
 expect_failure "can't ping the netns iface from the host" \
     ping -c 1 -W 0.25 ${NS_IP_ADDR}
 expect_success "pings have been blocked on ingress" \

--- a/tools/benchmarks/benchmark.cpp
+++ b/tools/benchmarks/benchmark.cpp
@@ -809,7 +809,7 @@ int Chain::apply()
     for (const auto &rule: rules_)
         chain += rule + " ";
 
-    const ::std::vector<::std::string> args {"ruleset", "set", "--str", chain};
+    const ::std::vector<::std::string> args {"ruleset", "set", "--from-str", chain};
 
     const auto [r, out, err] = run(bin_, args);
     if (r != 0) {


### PR DESCRIPTION
bfcli commands are composed of an object, an action, and options. Both the object and the action are required. Ruleset and chain commands currently implement different mechanism to parse the options, which requires a lot of duplicated code.

This refactor creates a generic framework to parse the bfcli commands in a standard way for all the commands supported by bpfilter.

Additionally, it adds support for bfcli-level help message, and command-level help message (e.g. bfcli chain set --help).

This PR is required by two changes requests (#252 and #249), both on bfcli options parsing. I reused most of @ryantimwilson 's documentation but implemented through argp, thanks to him!