### PR TITLE
Customize bpffs path

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,6 +36,8 @@
 # - misc-include-cleaner
 #   False positives, e.g. with errno.h: E* macros are not directly defined in it,
 #   but it's the header we should include.
+# - misc-no-recursion
+#   Let me use recursion.
 # - misc-redundant-expression
 #   Macros having the same values can't be or'd without a warning.
 # - misc-static-assert
@@ -77,6 +79,7 @@ Checks: >
     -clang-analyzer-unix.Malloc,
   misc-*,
     -misc-include-cleaner,
+    -misc-no-recursion,
     -misc-redundant-expression,
     -misc-static-assert,
   modernize-*,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,8 @@ jobs:
         with:
           path: build/output/tests
           key: tests-results-${{ github.run_id }}
+      - name: Mount bpffs
+        run: mount bpffs /sys/fs/bpf -t bpf
       - name: Configure the build
         run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build
       - name: Run unit tests

--- a/doc/usage/daemon.rst
+++ b/doc/usage/daemon.rst
@@ -9,7 +9,8 @@ It is possible to customize the daemon's behavior using the following command-li
 - ``--no-cli``: disable ``bfcli`` support.
 - ``--no-nftables``: disable ``nftables`` support.
 - ``--no-iptables``: disable ``iptables`` support.
-- ``--with-bpf-token``: if set, the daemon will associate a BPF token to every ``bpf()`` system call. This is required when the daemon runs in user namespaces. The daemon will create the token from the bpffs mounted at ``/sys/fs/bpf``. The user is responsible for configuring the file system, so a token can be created. Only supported for kernel v6.9+, if the current kernel doesn't support BPF token, the daemon will stop with a non-zero exit code.
+- ``--with-bpf-token``: if set, the daemon will associate a BPF token to every ``bpf()`` system call. This is required when the daemon runs in user namespaces. The daemon will create the token from the bpffs mounted at ``--bpffs-path``. The user is responsible for configuring the file system, so a token can be created. Only supported for kernel v6.9+, if the current kernel doesn't support BPF token, the daemon will stop with a non-zero exit code.
+- ``--bpffs-path``: use a custom BPF filesystem directory. By default, bpfilter will pin the BPF objects in a ``bpfilter`` directory in ``/sys/fs/bpf``, this option will move the ``bpfilter`` folder into a different directory. The path provided must be a directory on a BPF filesystem.
 - ``-v=VERBOSE_FLAG``, ``--verbose=VERBOSE_FLAG``: enable verbose logs for ``VERBOSE_FLAG``. Currently, 3 verbose flags are supported:
 
   - ``debug``: enable all the debug logs in the application.

--- a/src/bpfilter/cgen/cgen.h
+++ b/src/bpfilter/cgen/cgen.h
@@ -96,6 +96,20 @@ void bf_cgen_free(struct bf_cgen **cgen);
 int bf_cgen_marsh(const struct bf_cgen *cgen, struct bf_marsh **marsh);
 
 /**
+ * @brief Set a chain.
+ *
+ * Generate and load a new chain. Attach the chain if `hookopts` is not NULL. It
+ * is assumed that no chain with the same name exist.
+ *
+ * @param cgen Codegen to attach to the kernel. Can't be NULL.
+ * @param ns Namespaces to switch to before attaching the programs. Can't be NULL.
+ * @param hookopts Hook options.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_cgen_set(struct bf_cgen *cgen, const struct bf_ns *ns,
+                struct bf_hookopts **hookopts);
+
+/**
  * Create and load a `bf_program` into the kernel.
  *
  * Create a new `bf_program` for `cgen`, and generate it based on the chain

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -178,7 +178,9 @@
  */
 #define EMIT_LOAD_SET_FD_FIXUP(program, reg, index)                            \
     ({                                                                         \
-        union bf_fixup_attr __attr = {.set_index = (index)};                   \
+        union bf_fixup_attr __attr;                                            \
+        memset(&__attr, 0, sizeof(__attr));                                    \
+        __attr.set_index = (index);                                            \
         const struct bpf_insn ld_insn[2] = {BPF_LD_MAP_FD(reg, 0)};            \
         int __r = bf_program_emit_fixup((program), BF_FIXUP_TYPE_SET_MAP_FD,   \
                                         ld_insn[0], &__attr);                  \

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -386,6 +386,30 @@ int bf_program_load(struct bf_program *prog);
 int bf_program_attach(struct bf_program *prog, struct bf_hookopts **hookopts);
 
 /**
+ * @brief Pin the BPF program.
+ *
+ * The program and all the BPF objects it uses will be pinned into `dir_fd`.
+ * The BPF link is only pinned if the program is attached to a hook.
+ *
+ * @param prog Program to pin. Can't be NULL.
+ * @param dir_fd File descriptor of the directory to pin the program and its
+ *        BPF objects into.
+ * @return 0 on success, or a negative errno value on error.
+ */
+int bf_program_pin(struct bf_program *prog, int dir_fd);
+
+/**
+ * @brief Unpin the BPF program.
+ *
+ * This function never fails. If the program is not pinned, no file will be
+ * removed.
+ *
+ * @param prog Program to unpin. Can't be NULL.
+ * @param dir_fd File descriptor of the directory containing the pinned objects.
+ */
+void bf_program_unpin(struct bf_program *prog, int dir_fd);
+
+/**
  * Detach the program from the kernel.
  *
  * The program is detached but not unloaded.

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -338,7 +338,7 @@ void bf_program_free(struct bf_program **program);
 int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh);
 int bf_program_unmarsh(const struct bf_marsh *marsh,
                        struct bf_program **program,
-                       const struct bf_chain *chain);
+                       const struct bf_chain *chain, int dir_fd);
 void bf_program_dump(const struct bf_program *program, prefix_t *prefix);
 int bf_program_grow_img(struct bf_program *program);
 

--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -25,7 +25,6 @@
 #include "core/marsh.h"
 #include "core/ns.h"
 
-#define BF_BPFFS_DIR "/sys/fs/bpf"
 #define _cleanup_bf_ctx_ __attribute__((cleanup(_bf_ctx_free)))
 
 /**
@@ -57,21 +56,21 @@ static int _bf_ctx_gen_token(void)
     _cleanup_close_ int token_fd = -1;
     union bpf_attr _attr = {};
 
-    mnt_fd = open(BF_BPFFS_DIR, O_DIRECTORY);
+    mnt_fd = open(bf_opts_bpffs_path(), O_DIRECTORY);
     if (mnt_fd < 0)
-        return bf_err_r(errno, "failed to open '%s'", BF_BPFFS_DIR);
+        return bf_err_r(errno, "failed to open '%s'", bf_opts_bpffs_path());
 
     bpffs_fd = openat(mnt_fd, ".", 0, O_RDWR);
     if (bpffs_fd < 0)
         return bf_err_r(errno, "failed to get bpffs FD from '%s'",
-                        BF_BPFFS_DIR);
+                        bf_opts_bpffs_path());
 
     _attr.token_create.bpffs_fd = bpffs_fd;
 
     token_fd = bf_bpf(BPF_TOKEN_CREATE, &_attr);
     if (token_fd < 0) {
         return bf_err_r(token_fd, "failed to create BPF token for '%s'",
-                        BF_BPFFS_DIR);
+                        bf_opts_bpffs_path());
     }
 
     return TAKE_FD(token_fd);

--- a/src/bpfilter/ctx.h
+++ b/src/bpfilter/ctx.h
@@ -152,3 +152,23 @@ struct bf_ns *bf_ctx_get_ns(void);
  * @return The BPF token file descriptor, or -1 if no token is used.
  */
 int bf_ctx_token(void);
+
+/**
+ * @brief Return a file descriptor to bpfilter's pin directory.
+ *
+ * @return File descriptor to bpfilter's pin directory, or a negative errno
+ *         value on failure.
+ */
+int bf_ctx_get_pindir_fd(void);
+
+/**
+ * @brief Remove the pin directory.
+ *
+ * If the pin directory can't be removed, an error is printed. However, if it's
+ * due to the directory not being empty, or not existing, no error is printed,
+ * but the errno value is returned anyway. The called will know how to deal with
+ * this situation.
+ *
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_ctx_rm_pindir(void);

--- a/src/bpfilter/main.c
+++ b/src/bpfilter/main.c
@@ -359,7 +359,12 @@ static int _bf_process_request(struct bf_request *request,
     }
 
     if (!bf_opts_transient() && (request->cmd == BF_REQ_RULESET_FLUSH ||
-                                 request->cmd == BF_REQ_RULESET_SET))
+                                 request->cmd == BF_REQ_RULESET_SET ||
+                                 request->cmd == BF_REQ_CHAIN_SET ||
+                                 request->cmd == BF_REQ_CHAIN_LOAD ||
+                                 request->cmd == BF_REQ_CHAIN_ATTACH ||
+                                 request->cmd == BF_REQ_CHAIN_UPDATE ||
+                                 request->cmd == BF_REQ_CHAIN_FLUSH))
         r = _bf_save(ctx_path);
 
     return r;

--- a/src/bpfilter/main.c
+++ b/src/bpfilter/main.c
@@ -280,6 +280,7 @@ static int _bf_init(int argc, char *argv[])
  */
 static int _bf_clean(void)
 {
+    _cleanup_close_ int pindir_fd = -1;
     int r;
 
     for (enum bf_front front = 0; front < _BF_FRONT_MAX; ++front) {
@@ -295,8 +296,9 @@ static int _bf_clean(void)
 
     bf_ctx_teardown(bf_opts_transient());
 
-    // BF_PIN_DIR will be removed only if it's empty (see rmdir(3))
-    rmdir(BF_PIN_DIR);
+    r = bf_ctx_rm_pindir();
+    if (r < 0 && r != -ENOENT && errno != -ENOTEMPTY)
+        return bf_err_r(r, "failed to remove pin directory");
 
     return 0;
 }

--- a/src/bpfilter/opts.h
+++ b/src/bpfilter/opts.h
@@ -22,5 +22,6 @@ bool bf_opts_transient(void);
 bool bf_opts_persist(void);
 bool bf_opts_is_front_enabled(enum bf_front front);
 bool bf_opts_with_bpf_token(void);
+const char *bf_opts_bpffs_path(void);
 bool bf_opts_is_verbose(enum bf_verbose opt);
 void bf_opts_set_verbose(enum bf_verbose opt);

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -389,11 +389,10 @@ int _bf_cli_chain_load(const struct bf_request *request,
             "request payload is expected to have the same size as the marsh");
     }
 
-    bf_info("marsh=%p, child=%p", marsh, child);
     child = bf_marsh_next_child(marsh, child);
     if (!child)
         return bf_err_r(-ENOENT, "expecting marsh for chain, none found");
-    bf_info("chaib load unmarsh chain: %p", child);
+
     r = bf_chain_new_from_marsh(&chain, child);
     if (r)
         return r;

--- a/src/core/bpf.h
+++ b/src/core/bpf.h
@@ -51,7 +51,8 @@ int bf_bpf(enum bpf_cmd cmd, union bpf_attr *attr);
  */
 int bf_bpf_prog_load(const char *name, unsigned int prog_type, void *img,
                      size_t img_len, enum bpf_attach_type attach_type,
-                     char *log_buf, size_t log_size, int token_fd, int *fd);
+                     const char *log_buf, size_t log_size, int token_fd,
+                     int *fd);
 
 /**
  * Get an element from a map.

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -3,7 +3,11 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include "core/io.h"
+
+#include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -213,6 +217,102 @@ int bf_ensure_dir(const char *dir)
 
     if (stat(dir, &stats) != 0 || !S_ISDIR(stats.st_mode))
         return bf_err_r(-EINVAL, "'%s' is not a valid directory", dir);
+
+    return 0;
+}
+
+int bf_opendir(const char *path)
+{
+    _cleanup_close_ int fd = -1;
+
+    bf_assert(path);
+
+    fd = open(path, O_DIRECTORY);
+    if (fd < 0)
+        return -errno;
+
+    return TAKE_FD(fd);
+}
+
+int bf_opendir_at(int parent_fd, const char *dir_name, bool mkdir_if_missing)
+{
+    _cleanup_close_ int fd = -1;
+    int r;
+
+    bf_assert(dir_name);
+
+retry:
+    fd = openat(parent_fd, dir_name, O_DIRECTORY);
+    if (fd < 0) {
+        if (errno != ENOENT || !mkdir_if_missing)
+            return -errno;
+
+        r = mkdirat(parent_fd, dir_name, BF_PERM_755);
+        if (r)
+            return -errno;
+
+        goto retry;
+    }
+
+    return TAKE_FD(fd);
+}
+
+static void bf_free_dir(DIR **dir)
+{
+    if (!*dir)
+        return;
+
+    closedir(*dir);
+    *dir = NULL;
+}
+
+#define _free_dir_ __attribute__((__cleanup__(bf_free_dir)))
+
+int bf_rmdir_at(int parent_fd, const char *dir_name, bool recursive)
+{
+    int r;
+
+    bf_assert(dir_name);
+
+    if (recursive) {
+        _cleanup_close_ int child_fd = -1;
+        _free_dir_ DIR *dir = NULL;
+        struct dirent *entry;
+
+        child_fd = openat(parent_fd, dir_name, O_DIRECTORY);
+        if (child_fd < 0) {
+            return bf_err_r(errno,
+                            "failed to open child directory for removal");
+        }
+
+        dir = fdopendir(child_fd);
+        if (!dir)
+            return bf_err_r(errno, "failed to open DIR from file descriptor");
+
+        while ((entry = readdir(dir))) {
+            struct stat stat;
+
+            if (bf_streq(entry->d_name, ".") || bf_streq(entry->d_name, ".."))
+                continue;
+
+            if (fstatat(child_fd, entry->d_name, &stat, 0) < 0) {
+                return bf_err_r(errno,
+                                "failed to fstatat() file '%s' for removal",
+                                entry->d_name);
+            }
+
+            if (S_ISDIR(stat.st_mode))
+                r = bf_rmdir_at(child_fd, entry->d_name, true);
+            else
+                r = unlinkat(child_fd, entry->d_name, 0) == 0 ? 0 : -errno;
+            if (r)
+                return bf_err_r(r, "failed to remove '%s'", entry->d_name);
+        }
+    }
+
+    r = unlinkat(parent_fd, dir_name, AT_REMOVEDIR);
+    if (r)
+        return -errno;
 
     return 0;
 }

--- a/src/core/io.h
+++ b/src/core/io.h
@@ -10,7 +10,6 @@
 
 #define BF_RUNTIME_DIR "/run/bpfilter"
 #define BF_SOCKET_PATH BF_RUNTIME_DIR "/daemon.sock"
-#define BF_PIN_DIR "/sys/fs/bpf/bpfilter"
 
 struct bf_request;
 struct bf_response;

--- a/src/core/io.h
+++ b/src/core/io.h
@@ -5,6 +5,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 #define BF_RUNTIME_DIR "/run/bpfilter"
 #define BF_SOCKET_PATH BF_RUNTIME_DIR "/daemon.sock"
 #define BF_PIN_DIR "/sys/fs/bpf/bpfilter"
@@ -65,3 +68,37 @@ int bf_recv_response(int fd, struct bf_response **response);
  * @return 0 on success, or a negative errno value on failure.
  */
 int bf_ensure_dir(const char *dir);
+
+/**
+ * @brief Open a directory and return its file descriptor.
+ *
+ * @param path Path of the directory to open. Can't be NULL.
+ * @return A file descriptor of the open directory on success, or a negative
+ *         errno value on failure.
+ */
+int bf_opendir(const char *path);
+
+/**
+ * @brief Open a directory from a parent directory file descriptor.
+ *
+ * @param parent_fd File descriptor of the parent directory to open the
+ *        directory from.
+ * @param dir_name Name of the directory to open. Can't be NULL.
+ * @param mkdir_if_missing If true, `dir_name` will be created (if missing)
+ *        before opening it.
+ * @return File descriptor of the open directory, or a negative errno value
+ *         on failure.
+ */
+int bf_opendir_at(int parent_fd, const char *dir_name, bool mkdir_if_missing);
+
+/**
+ * @brief Remove a directory from a parent directory file descriptor.
+ *
+ * @param parent_fd File descriptor of the parent directory to remove
+ *        `dir_name` from.
+ * @param dir_name Name of the directory to remove. Can't be NULL.
+ * @param recursive If true, remove the content of the directory before removing
+ *        the directory. If false, fails if the directory is not empty.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_rmdir_at(int parent_fd, const char *dir_name, bool recursive);

--- a/src/core/request.c
+++ b/src/core/request.c
@@ -56,3 +56,26 @@ void bf_request_free(struct bf_request **request)
     free(*request);
     *request = NULL;
 }
+
+const char *bf_request_cmd_to_str(enum bf_request_cmd cmd)
+{
+    static const char *cmd_strs[] = {
+        [BF_REQ_RULESET_FLUSH] = "BF_REQ_RULESET_FLUSH",
+        [BF_REQ_RULESET_GET] = "BF_REQ_RULESET_GET",
+        [BF_REQ_RULESET_SET] = "BF_REQ_RULESET_SET",
+        [BF_REQ_CHAIN_SET] = "BF_REQ_CHAIN_SET",
+        [BF_REQ_CHAIN_GET] = "BF_REQ_CHAIN_GET",
+        [BF_REQ_CHAIN_LOAD] = "BF_REQ_CHAIN_LOAD",
+        [BF_REQ_CHAIN_ATTACH] = "BF_REQ_CHAIN_ATTACH",
+        [BF_REQ_CHAIN_UPDATE] = "BF_REQ_CHAIN_UPDATE",
+        [BF_REQ_CHAIN_FLUSH] = "BF_REQ_CHAIN_FLUSH",
+        [BF_REQ_COUNTERS_SET] = "BF_REQ_COUNTERS_SET",
+        [BF_REQ_COUNTERS_GET] = "BF_REQ_COUNTERS_GET",
+        [BF_REQ_CUSTOM] = "BF_REQ_CUSTOM",
+    };
+
+    static_assert(ARRAY_SIZE(cmd_strs) == _BF_REQ_CMD_MAX,
+                  "missing entries in bf_request_cmd array");
+
+    return cmd_strs[cmd];
+}

--- a/src/core/request.h
+++ b/src/core/request.h
@@ -129,3 +129,11 @@ static inline size_t bf_request_size(const struct bf_request *request)
 
     return sizeof(struct bf_request) + request->data_len;
 }
+
+/**
+ * @brief Convert a `bf_request_cmd` value to a string.
+ *
+ * @param cmd The request command to convert. Must be a valid command.
+ * @return String representation of `cmd`.
+ */
+const char *bf_request_cmd_to_str(enum bf_request_cmd cmd);

--- a/tests/e2e/cli.sh
+++ b/tests/e2e/cli.sh
@@ -431,6 +431,17 @@ expect_success "pings from host to netns are accepted" \
 expect_success "flush chain_load_xdp_3" \
     ${FROM_NS} ${BFCLI} chain flush --name chain_load_xdp_3
 
+log "[SUITE] ruleset"
+expect_success "ruleset set" \
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain ruleset_set_xdp_0 BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT chain ruleset_set_xdp_1 BF_HOOK_XDP DROP chain ruleset_set_tc_0 BF_HOOK_NF_LOCAL_IN\{family=inet4,priorities=103-104\} ACCEPT\"
+expect_success "flush chain ruleset_set_xdp_0" \
+    ${FROM_NS} ${BFCLI} chain flush --name ruleset_set_xdp_0
+expect_success "ruleset get" \
+    ${FROM_NS} ${BFCLI} ruleset get
+expect_success "replace ruleset" \
+    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain ruleset_set_xdp_0 BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT chain ruleset_set_xdp_1 BF_HOOK_XDP DROP chain ruleset_set_tc_0 BF_HOOK_NF_LOCAL_IN\{family=inet4,priorities=103-104\} ACCEPT\"
+expect_success "ruleset flush" \
+    ${FROM_NS} ${BFCLI} ruleset flush
 
 ################################################################################
 #


### PR DESCRIPTION
Using the `--bpffs-path`, the user can change the location of the bpffs path used by the daemon. In a containerized environment (especially with userns), users might dedicate a specific bpffs for bpfilter, with support for BPF token.

The program pinning/unpinning logic has been removed from program.c into cgen.c, as cgen.c has access to both the old and new program on update. The tests have been updated to use a custom bpffs path and validate the implementation.