### PR TITLE
core: helper: add `BF_FLAGS()` macro to generate bitflags

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -99,13 +99,11 @@ FormatStyle: none
 UseColor: yes
 
 CheckOptions:
-  # Allow use of reserved identifiers as long as they start with "_bf",
-  # "_BF", or "_cleanup". This check has been modified starting with
-  # clang-tools-extra v18 (https://releases.llvm.org/18.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy)
-  # and will behave differently for macros. Hence clang-tidy v18+ won't
-  # warn about _cleanup_ identifiers.
+  # Allow use of reserved identifier was (_)+ underscore, followed by a bpfilter
+  # specific prefix (.e.g _BF). Other idenfitiers defined by GCC are allowed,
+  # such as _start, _end...
   - key: bugprone-reserved-identifier.AllowedIdentifiers
-    value: '^_(_start|_stop|bf|bfc|BF|BFC|cleanup|GNU)_[a-zA-Z0-9_]+$'
+    value: '^(_)+(start|stop|bf|bfc|BF|BFC|cleanup|GNU)_[a-zA-Z0-9_]+$'
   - key: misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
     value: true
   # Unless a *statement* takes 1 line, it should be in braces

--- a/src/bfcli/opts.c
+++ b/src/bfcli/opts.c
@@ -100,7 +100,7 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .object = BFC_OBJECT_RULESET,
         .action = BFC_ACTION_SET,
         .valid_opts =
-            1 << BFC_OPT_RULESET_FROM_STR | 1 << BFC_OPT_RULESET_FROM_FILE,
+            BF_FLAGS(BFC_OPT_RULESET_FROM_STR, BFC_OPT_RULESET_FROM_FILE),
         .doc =
             "Set the ruleset.\vRemove all the chains on the system and "
             "replaced them with the one provided in --from-file or --from-str.",
@@ -124,8 +124,8 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain set",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_SET,
-        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
-                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_FROM_STR, BFC_OPT_CHAIN_FROM_FILE,
+                               BFC_OPT_CHAIN_NAME),
         .doc =
             "Set a new chain\vCreate a new chain, attach it if hook options "
             "are defined. Any existing chain with the same --name will be "
@@ -137,7 +137,7 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain get",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_GET,
-        .valid_opts = 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_NAME),
         .doc =
             "Print an existing chain\vRequest the chain --name from the daemon "
             "and print it.",
@@ -147,8 +147,8 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain load",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_LOAD,
-        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
-                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_FROM_STR, BFC_OPT_CHAIN_FROM_FILE,
+                               BFC_OPT_CHAIN_NAME),
         .doc =
             "Load a new chain\vCreate a new chain, and load it into the "
             "kernel. An error will be returned if any existing chain has the "
@@ -160,7 +160,7 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain attach",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_ATTACH,
-        .valid_opts = 1 << BFC_OPT_CHAIN_HOOK_OPTS | 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_HOOK_OPTS, BFC_OPT_CHAIN_NAME),
         .doc =
             "Attach an existing chain\vAttach a loaded chain to a hook. Hook "
             "options defined with --option are specific to the chain and the "
@@ -171,8 +171,8 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain update",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_UPDATE,
-        .valid_opts = 1 << BFC_OPT_CHAIN_FROM_STR |
-                      1 << BFC_OPT_CHAIN_FROM_FILE | 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_FROM_STR, BFC_OPT_CHAIN_FROM_FILE,
+                               BFC_OPT_CHAIN_NAME),
         .doc = "Update a chain\vAtomically update chain --name with the new "
                "definition provided by --from-str or --from-file.",
         .cb = bfc_chain_update,
@@ -181,7 +181,7 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli chain flush",
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_FLUSH,
-        .valid_opts = 1 << BFC_OPT_CHAIN_NAME,
+        .valid_opts = BF_FLAGS(BFC_OPT_CHAIN_NAME),
         .doc = "Delete a chain\vRemove a chain from the system.",
         .cb = bfc_chain_flush,
     },
@@ -337,7 +337,7 @@ static error_t _bfc_opts_cmd_parser(int key, char *arg,
     for (int i = 0; i < _BFC_OPT_MAX; ++i) {
         struct bfc_opts_opt *opt = &_bfc_options[i];
 
-        if (!(cmd->valid_opts & (1 << i)) || key != opt->key)
+        if (!(cmd->valid_opts & BF_FLAG(i)) || key != opt->key)
             continue;
 
         opt->parser(state, arg, opts);
@@ -402,7 +402,7 @@ int bfc_opts_parse(struct bfc_opts *opts, int argc, char **argv)
         return r;
 
     for (int i = 0; i < _BFC_OPT_MAX; ++i) {
-        if (opts->cmd->valid_opts & (1 << i)) {
+        if (opts->cmd->valid_opts & BF_FLAG(i)) {
             suboptions[suboptions_idx++] = (struct argp_option) {
                 .name = _bfc_options[i].name,
                 .key = _bfc_options[i].key,

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -526,7 +526,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                             continue;
                         }
 
-                        flags |= 1 << flag;
+                        flags |= BF_FLAG(flag);
                     }
 
                     free($3);

--- a/src/bpfilter/opts.c
+++ b/src/bpfilter/opts.c
@@ -130,15 +130,15 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
         break;
     case BF_OPT_NO_IPTABLES_KEY:
         bf_info("disabling iptables support");
-        args->fronts &= ~(1 << BF_FRONT_IPT);
+        args->fronts &= ~BF_FLAG(BF_FRONT_IPT);
         break;
     case BF_OPT_NO_NFTABLES_KEY:
         bf_info("disabling nftables support");
-        args->fronts &= ~(1 << BF_FRONT_NFT);
+        args->fronts &= ~BF_FLAG(BF_FRONT_NFT);
         break;
     case BF_OPT_NO_CLI_KEY:
         bf_info("disabling CLI support");
-        args->fronts &= ~(1 << BF_FRONT_CLI);
+        args->fronts &= ~BF_FLAG(BF_FRONT_CLI);
         break;
     case BF_OPT_WITH_BPF_TOKEN:
         args->with_bpf_token = true;
@@ -159,7 +159,7 @@ static error_t _bf_opts_parser(int key, char *arg, struct argp_state *state)
         bf_info("enabling verbose for '%s'", arg);
         if (opt == BF_VERBOSE_DEBUG)
             bf_log_set_level(BF_LOG_DBG);
-        args->verbose |= (1 << opt);
+        args->verbose |= BF_FLAG(opt);
         break;
     case BF_OPT_VERSION:
         bf_info("bpfilter version %s", BF_VERSION);
@@ -190,7 +190,7 @@ bool bf_opts_persist(void)
 
 bool bf_opts_is_front_enabled(enum bf_front front)
 {
-    return _bf_opts.fronts & (1 << front);
+    return _bf_opts.fronts & BF_FLAG(front);
 }
 
 bool bf_opts_with_bpf_token(void)
@@ -205,10 +205,10 @@ const char *bf_opts_bpffs_path(void)
 
 bool bf_opts_is_verbose(enum bf_verbose opt)
 {
-    return _bf_opts.verbose & (1 << opt);
+    return _bf_opts.verbose & BF_FLAG(opt);
 }
 
 void bf_opts_set_verbose(enum bf_verbose opt)
 {
-    _bf_opts.verbose |= (1 << opt);
+    _bf_opts.verbose |= BF_FLAG(opt);
 }

--- a/src/bpfilter/xlate/ipt/helpers.h
+++ b/src/bpfilter/xlate/ipt/helpers.h
@@ -15,7 +15,7 @@
  * @return 0 if @p hook is not enabled, any value otherwise.
  */
 #define ipt_is_hook_enabled(replace, hook)                                     \
-    ((replace)->valid_hooks & (1 << (hook)))
+    ((replace)->valid_hooks & BF_FLAG(hook))
 
 /**
  * Get @p ipt_entry's match at @p offset.

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -474,7 +474,7 @@ static int _bf_ipt_gen_ipt_replace(struct ipt_replace **replace,
          *   sizeof(ipt_entry) + sizeof(ipt_standard_target)
          * Matchers and user-defined chains are not supported. */
 
-        _replace->valid_hooks |= 1 << hook;
+        _replace->valid_hooks |= BF_FLAG(hook);
         _replace->hook_entry[hook] = next_chain_off;
         _replace->underflow[hook] =
             next_chain_off + bf_list_size(&chain->rules) * rule_size;

--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -14,6 +14,99 @@
 
 extern const char *strerrordesc_np(int errnum);
 
+#define _BF_APPLY0(t, s, dummy)
+#define _BF_APPLY1(t, s, a) t(a)
+#define _BF_APPLY2(t, s, a, b) t(a) s t(b)
+#define _BF_APPLY3(t, s, a, b, c)                                              \
+    t(a) s t(b)                                                                \
+    s t(c)
+#define _BF_APPLY4(t, s, a, b, c, d)                                           \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)
+#define _BF_APPLY5(t, s, a, b, c, d, e)                                        \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)
+#define _BF_APPLY6(t, s, a, b, c, d, e, f)                                     \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)                                                                     \
+    s t(f)
+#define _BF_APPLY7(t, s, a, b, c, d, e, f, g)                                  \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)                                                                     \
+    s t(f)                                                                     \
+    s t(g)
+#define _BF_APPLY8(t, s, a, b, c, d, e, f, g, h)                               \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)                                                                     \
+    s t(f)                                                                     \
+    s t(g)                                                                     \
+    s t(h)
+#define _BF_APPLY9(t, s, a, b, c, d, e, f, g, h, i)                            \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)                                                                     \
+    s t(f)                                                                     \
+    s t(g)                                                                     \
+    s t(h)                                                                     \
+    s t(i)
+#define _BF_APPLY10(t, s, a, b, c, d, e, f, g, h, i, j)                        \
+    t(a) s t(b)                                                                \
+    s t(c)                                                                     \
+    s t(d)                                                                     \
+    s t(e)                                                                     \
+    s t(f)                                                                     \
+    s t(g)                                                                     \
+    s t(h)                                                                     \
+    s t(i)                                                                     \
+    s t(j)
+
+#define __BF_NUM_ARGS1(dummy, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0,     \
+                       ...)                                                    \
+    x0
+#define _BF_NUM_ARGS(...)                                                      \
+    __BF_NUM_ARGS1(dummy, ##__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+#define ___BF_APPLY_ALL(t, s, n, ...) _BF_APPLY##n(t, s, __VA_ARGS__)
+#define __BF_APPLY_ALL(t, s, n, ...) ___BF_APPLY_ALL(t, s, n, __VA_ARGS__)
+#define _BF_APPLY_ALL(t, s, ...)                                               \
+    __BF_APPLY_ALL(t, s, _BF_NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
+
+/**
+ * @brief Generate a bitflag from multiple values.
+ *
+ * Enumeration are used extensively to define related values. Thanks to
+ * enumeration's continuous values, they are used as array indexes to convert
+ * them into strings.
+ *
+ * However, they can sometimes be combined, leading to very wordy code, e.g.
+ * `1 << ENUM_VAL_1 | 1 << ENUM_VAL_5`.
+ *
+ * `BF_FLAGS` can be used to replace the wordy code with a simpler macro call,
+ * e.g. `BF_FLAGS(ENUL_VAL_1, ENUM_VAL_5)`. It will automatically create an
+ * integer with the enumeration values as a set bit index in the bitflag.
+ *
+ * @return Bitflag for variadic values.
+ */
+#define BF_FLAGS(...) _BF_APPLY_ALL(BF_FLAG, |, __VA_ARGS__)
+
+/**
+ * @brief Shift 1 by `n` to create a flag.
+ *
+ * @see `BF_FLAGS`
+ *
+ * @return `1 << n` to be used as a flag.
+ */
+#define BF_FLAG(n) (1 << (n))
+
 #define bf_packed __attribute__((packed))
 #define bf_aligned(x) __attribute__((aligned(x)))
 #define bf_unused __attribute__((unused))

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -196,7 +196,7 @@ static int _bf_hookopts_ifindex_parse(struct bf_hookopts *hookopts,
         return bf_err_r(-E2BIG, "ifindex is too big: %lu", ifindex);
 
     hookopts->ifindex = (int)ifindex;
-    hookopts->used_opts |= 1 << BF_HOOKOPTS_IFINDEX;
+    hookopts->used_opts |= BF_FLAG(BF_HOOKOPTS_IFINDEX);
 
     return 0;
 }
@@ -220,7 +220,7 @@ static int _bf_hookopts_cgpath_parse(struct bf_hookopts *hookopts,
                         raw_opt);
     }
 
-    hookopts->used_opts |= 1 << BF_HOOKOPTS_CGPATH;
+    hookopts->used_opts |= BF_FLAG(BF_HOOKOPTS_CGPATH);
 
     return 0;
 }
@@ -245,7 +245,7 @@ static int _bf_hookopts_family_parse(struct bf_hookopts *hookopts,
     else
         return bf_err_r(-ENOTSUP, "unknown netfilter family '%s'", raw_opt);
 
-    hookopts->used_opts |= 1 << BF_HOOKOPTS_FAMILY;
+    hookopts->used_opts |= BF_FLAG(BF_HOOKOPTS_FAMILY);
 
     return 0;
 }
@@ -302,7 +302,7 @@ static int _bf_hookopts_priorities_parse(struct bf_hookopts *hookopts,
 
     hookopts->priorities[0] = (int)priorities[0];
     hookopts->priorities[1] = (int)priorities[1];
-    hookopts->used_opts |= 1 << BF_HOOKOPTS_PRIORITIES;
+    hookopts->used_opts |= BF_FLAG(BF_HOOKOPTS_PRIORITIES);
 
     return 0;
 
@@ -332,25 +332,25 @@ static struct bf_hookopts_ops
     [BF_HOOKOPTS_IFINDEX] = {.name = "ifindex",
                              .type = BF_HOOKOPTS_IFINDEX,
                              .required_by =
-                                 1 << BF_FLAVOR_XDP | 1 << BF_FLAVOR_TC,
+                                 BF_FLAGS(BF_FLAVOR_XDP, BF_FLAVOR_TC),
                              .supported_by = 0,
                              .parse = _bf_hookopts_ifindex_parse,
                              .dump = _bf_hookopts_ifindex_dump},
     [BF_HOOKOPTS_CGPATH] = {.name = "cgpath",
                             .type = BF_HOOKOPTS_CGPATH,
-                            .required_by = 1 << BF_FLAVOR_CGROUP,
+                            .required_by = BF_FLAGS(BF_FLAVOR_CGROUP),
                             .supported_by = 0,
                             .parse = _bf_hookopts_cgpath_parse,
                             .dump = _bf_hookopts_cgpath_dump},
     [BF_HOOKOPTS_FAMILY] = {.name = "family",
                             .type = BF_HOOKOPTS_FAMILY,
-                            .required_by = 1 << BF_FLAVOR_NF,
+                            .required_by = BF_FLAGS(BF_FLAVOR_NF),
                             .supported_by = 0,
                             .parse = _bf_hookopts_family_parse,
                             .dump = _bf_hookopts_family_dump},
     [BF_HOOKOPTS_PRIORITIES] = {.name = "priorities",
                                 .type = BF_HOOKOPTS_PRIORITIES,
-                                .required_by = 1 << BF_FLAVOR_NF,
+                                .required_by = BF_FLAGS(BF_FLAVOR_NF),
                                 .supported_by = 0,
                                 .parse = _bf_hookopts_priorities_parse,
                                 .dump = _bf_hookopts_priorities_dump},
@@ -360,10 +360,10 @@ static_assert(ARRAY_SIZE(_bf_hookopts_ops) == _BF_HOOKOPTS_MAX,
               "missing entries in bf_hookopts_ops array");
 
 #define _bf_hookopts_is_required(type, flavor)                                 \
-    (_bf_hookopts_ops[type].required_by & (1 << (flavor)))
+    (_bf_hookopts_ops[type].required_by & BF_FLAG(flavor))
 
 #define _bf_hookopts_is_supported(type, flavor)                                \
-    ((_bf_hookopts_ops[type].supported_by & (1 << (flavor))) ||                \
+    ((_bf_hookopts_ops[type].supported_by & BF_FLAG(flavor)) ||                \
      _bf_hookopts_is_required((type), (flavor)))
 
 static struct bf_hookopts_ops *_bf_hookopts_get_ops(const char *key)

--- a/src/core/hook.h
+++ b/src/core/hook.h
@@ -238,4 +238,4 @@ int bf_hookopts_validate(const struct bf_hookopts *hookopts, enum bf_hook hook);
  * @return True if the option is used, false otherwise.
  */
 #define bf_hookopts_is_used(hookopts, type)                                    \
-    ((hookopts)->used_opts & (1 << (type)))
+    ((hookopts)->used_opts & BF_FLAG(type))

--- a/tests/unit/bpfilter/opts.c
+++ b/tests/unit/bpfilter/opts.c
@@ -15,5 +15,5 @@ Test(opts, no_nftables)
 
     _bf_opts.fronts = 0xffff;
     assert_success(bf_opts_init(ARRAY_SIZE(opt0), opt0));
-    assert(0 == (_bf_opts.fronts & (1 << BF_FRONT_NFT)));
+    assert(0 == (_bf_opts.fronts & BF_FLAG(BF_FRONT_NFT)));
 }


### PR DESCRIPTION
Create `BF_FLAGS(...)` macros to generate a bitflag values out of a list of integer representing the index of the bits to set.