### PR TITLE
Add a benchmark for chain loading time

### DIFF
--- a/doc/benchmarks.html.template
+++ b/doc/benchmarks.html.template
@@ -17,6 +17,56 @@
 
         const data = {{ DATA }}
 
+        function formatTimeDuration(value, fixed = 2, unit = null) {
+            const coeff = {
+                "ns": 1,
+                "μs": 1000,
+                "ms": 1000*1000,
+                "s": 1000*1000*1000
+            };
+
+            // Specific unit requested, use it
+            if (unit !== null) {
+                return {
+                    value: value / coeff[unit],
+                    str: parseFloat(value / coeff[unit]).toFixed(2),
+                    unit: unit,
+                    raw: value
+                };
+            }
+
+            // No unit requested, find the best one
+            if (value < 1000) {
+                return {
+                    value: value,
+                    str: parseFloat(value).toFixed(2),
+                    unit: "ns",
+                    raw: value
+                };
+            } else if (value < 1000000) {
+                return {
+                    value: value / coeff["μs"],
+                    str: parseFloat(value / coeff["μs"]).toFixed(2),
+                    unit: "μs",
+                    raw: value
+                };
+            } else if (value < 1000000000) {
+                return {
+                    value: value / coeff["ms"],
+                    str: parseFloat(value / coeff["ms"]).toFixed(2),
+                    unit: "ms",
+                    raw: value
+                };
+            } else {
+                return {
+                    value: value / coeff["s"],
+                    str: parseFloat(value / coeff["s"]).toFixed(2),
+                    unit: "s",
+                    raw: value
+                };
+            }
+        }
+
         function render() {
             for (const benchName of data.benchNames) {
                 makeTable(benchName, data.commits, data.results[benchName])
@@ -29,10 +79,10 @@
 
             const newCommit = commits[commits.length - 1];
             const newResults = results[newCommit.sha];
-            const newTime = newResults.time;
+            const newTime = formatTimeDuration(newResults.time);
             const newInsns = newResults.nInsn;
 
-            let newHtml = `<td class="text-end font-monospace">${parseFloat(newResults.time).toFixed(2)}</td>`;
+            let newHtml = `<td class="text-end font-monospace">${newTime.str} ${newTime.unit}</td>`;
             newHtml += `<td class="text-end font-monospace">${newResults.nInsn}</td>`;
 
             let diffHtml = '';
@@ -43,20 +93,18 @@
                 const oldCommit = commits.length > 1 ? commits[commits.length - 2] : null;
                 const oldResults = results[oldCommit.sha];
 
-                const oldTime = oldResults.time;
+                const oldTime = formatTimeDuration(oldResults.time, 2, newTime.unit);
                 const oldInsns = oldResults.nInsn;
-                const absTime = newTime - oldTime;
+                const absTime = formatTimeDuration(newTime.raw - oldTime.raw, 2, newTime.unit);
                 const absInsns = newInsns - oldInsns;
-                const diffTime = (absTime / oldTime) * 100;
+                const diffTime = (absTime.raw / oldTime.raw) * 100;
                 const diffInsns = (absInsns / oldInsns) * 100;
 
                 const timeDiffClass = diffTime > 0 ? "text-danger" : "text-success";
                 const nInsnsDiffClass = diffInsns > 0 ? "text-danger" : "text-success";
-                diffHtml += `<td class="text-end font-monospace ${timeDiffClass}">${(diffTime < 0 ? "" : "+") + parseFloat(diffTime).toFixed(2)}% (${(absTime < 0 ? "" : "+") + parseFloat(absTime).toFixed(2)})</td>`;
-                diffHtml += `<td class="text-end font-monospace ${nInsnsDiffClass}">${(diffInsns < 0 ? "" : "+") + parseFloat(diffInsns).toFixed(2)}% (${(absInsns < 0 ? "" : "+") + parseFloat(absInsns)})</td>`;
+                diffHtml += `<td class="text-end font-monospace ${timeDiffClass}">${(diffTime < 0 ? "" : "+") + parseFloat(diffTime).toFixed(2)}% (${absTime.raw < 0 ? "" : "+"}${absTime.str} ${absTime.unit})</td>`;
 
-                oldHtml += `<td class="text-end font-monospace">${parseFloat(oldResults.time).toFixed(2)}</td>`;
-                oldHtml += `<td class="text-end font-monospace">${oldResults.nInsn}</td>`;
+                oldHtml += `<td class="text-end font-monospace">${oldTime.str} ${oldTime.unit}</td>`;
             } else {
                 diffHtml += '<td class="text-end font-monospace">n/a</td><td class="font-monospace">n/a</td>';
                 oldHtml += '<td class="text-end font-monospace">n/a</td><td class="font-monospace">n/a</td>';
@@ -101,6 +149,9 @@
                 labels.push(commit.sha);
             }
 
+            const maxValue = Math.max(...durations);
+            const bestUnit = formatTimeDuration(maxValue).unit;
+
             const afterTitle = (tooltipItems) => {
                 const commit = commits.find((e) => e.sha == tooltipItems[0].label);
                 return commit.message;
@@ -139,16 +190,14 @@
                             callbacks: {
                                 afterTitle: afterTitle,
                                 label: function (context) {
-                                    let label = '';
-
-                                    if (context.dataset.yAxisID == "duration")
-                                        label = parseFloat(context.parsed.y).toFixed(2) + " ns"
-                                    else if (context.dataset.yAxisID == "instructions")
-                                        label = parseInt(context.parsed.y) + " instructions"
-                                    else
-                                        label = context.parsed.y;
-
-                                    return label;
+                                    if (context.dataset.yAxisID == "duration") {
+                                        duration = formatTimeDuration(context.parsed.y, 2, bestUnit);
+                                        return `${duration.str} ${duration.unit}`;
+                                    } else if (context.dataset.yAxisID == "instructions") {
+                                        return parseInt(context.parsed.y) + " instructions";
+                                    } else {
+                                        return context.parsed.y;
+                                    }
                                 }
                             }
                         }
@@ -161,8 +210,14 @@
                             min: 0,
                             title: {
                                 display: true,
-                                text: 'ns'
+                                text: "Duration"
                             },
+                            ticks: {
+                                callback: function (value) {
+                                    duration = formatTimeDuration(value, 2, bestUnit);
+                                    return `${duration.str} ${duration.unit}`;
+                                }
+                            }
                         },
                         instructions: {
                             id: '# insn',

--- a/doc/benchmarks.html.template
+++ b/doc/benchmarks.html.template
@@ -83,7 +83,7 @@
             const newInsns = newResults.nInsn;
 
             let newHtml = `<td class="text-end font-monospace">${newTime.str} ${newTime.unit}</td>`;
-            newHtml += `<td class="text-end font-monospace">${newResults.nInsn}</td>`;
+            newHtml += `<td class="text-end font-monospace">${newInsns ? newInsns : "n/a"}</td>`;
 
             let diffHtml = '';
             let oldHtml = '';
@@ -104,7 +104,15 @@
                 const nInsnsDiffClass = diffInsns > 0 ? "text-danger" : "text-success";
                 diffHtml += `<td class="text-end font-monospace ${timeDiffClass}">${(diffTime < 0 ? "" : "+") + parseFloat(diffTime).toFixed(2)}% (${absTime.raw < 0 ? "" : "+"}${absTime.str} ${absTime.unit})</td>`;
 
+                if (diffInsns === 0)
+                    diffHtml += `<td class="text-end font-monospace">no change</td>`;
+                else if (isNaN(diffInsns))
+                    diffHtml += `<td class="text-end font-monospace">n/a</td>`;
+                else
+                    diffHtml += `<td class="text-end font-monospace ${nInsnsDiffClass}">${(diffInsns < 0 ? "" : "+") + parseFloat(diffInsns).toFixed(2)}% (${(absInsns < 0 ? "" : "+") + parseFloat(absInsns)})</td>`;
+
                 oldHtml += `<td class="text-end font-monospace">${oldTime.str} ${oldTime.unit}</td>`;
+                oldHtml += `<td class="text-end font-monospace">${oldInsns ? oldInsns : "n/a"}</td>`;
             } else {
                 diffHtml += '<td class="text-end font-monospace">n/a</td><td class="font-monospace">n/a</td>';
                 oldHtml += '<td class="text-end font-monospace">n/a</td><td class="font-monospace">n/a</td>';
@@ -143,7 +151,10 @@
                     nInsns.push(null);
                 } else {
                     durations.push(result.time);
-                    nInsns.push(result.nInsn);
+
+                    // nInsn doesn't exist if the benchmark doesn't report it
+                    if (result.nInsn !== undefined)
+                         nInsns.push(result.nInsn);
                 }
 
                 labels.push(commit.sha);
@@ -228,6 +239,8 @@
                                 display: true,
                                 text: '# insn'
                             },
+                            // Only display the nInsns axis if we have values
+                            display: nInsns.length != 0
                         },
                         x: {
                             title: {

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -74,8 +74,11 @@ def main() -> None:
                 benchmarks["results"][bench["name"]][gitrev] = {
                     "iters": bench["iterations"],
                     "time": bench["real_time"] * TIME_MULTI[bench["time_unit"]],
-                    "nInsn": bench.get("nInsn", 0),
                 }
+
+                nInsn = bench.get("nInsn", None)
+                if nInsn:
+                    benchmarks["results"][bench["name"]][gitrev]["nInsn"] = nInsn
 
     repo = git.Repo.init(args.sources)
 

--- a/doc/benchreport
+++ b/doc/benchreport
@@ -10,6 +10,8 @@ import argparse
 
 VERBOSE: bool = False
 
+TIME_MULTI: dict = {"ns": 1, "us": 1000, "ms": 1000 * 1000, "s": 1000 * 1000 * 1000}
+
 
 def log(msg: str) -> None:
     if VERBOSE:
@@ -71,13 +73,9 @@ def main() -> None:
 
                 benchmarks["results"][bench["name"]][gitrev] = {
                     "iters": bench["iterations"],
-                    "time": bench["real_time"],
+                    "time": bench["real_time"] * TIME_MULTI[bench["time_unit"]],
                     "nInsn": bench.get("nInsn", 0),
                 }
-
-                if bench["time_unit"] != "ns":
-                    error("Only ns time unit is supported")
-                    sys.exit(-1)
 
     repo = git.Repo.init(args.sources)
 

--- a/tools/benchmarks/benchmark.hpp
+++ b/tools/benchmarks/benchmark.hpp
@@ -200,6 +200,7 @@ public:
 
     Chain &operator<<(const ::std::string &rule);
     Chain &repeat(const ::std::string &rule, ::std::size_t count);
+    void insertRuleIPv4Set(unsigned int nIps);
     int apply();
     [[nodiscard]] Program getProgram() const;
 

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -16,6 +16,23 @@
 namespace
 {
 
+void loadChainLargeSet(::benchmark::State &state)
+{
+    ::bf::Chain chain(::bf::config.bfcli);
+
+    chain.insertRuleIPv4Set(state.range(0));
+
+    for (auto _: state) {
+        chain.apply();
+    }
+}
+
+BENCHMARK(loadChainLargeSet)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Iterations(10)
+    ->Unit(benchmark::kMillisecond);
+
 void firstRuleDropCounter(::benchmark::State &state)
 {
     ::bf::Chain chain(::bf::config.bfcli);

--- a/tools/perfrec
+++ b/tools/perfrec
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import tempfile
+import shutil
+from subprocess import Popen, run
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="perfrec",
+        description="perf wrapper to collect bpfilter/bfcli performance data and format them properly",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default="perf.data",
+        help="Path to the perf output file",
+    )
+    parser.add_argument(
+        "--target",
+        "-t",
+        choices=["firefox"],
+        default=None,
+        help="Target tool to format the data for (optional)",
+    )
+    args, remaining_args = parser.parse_known_args()
+
+    tmp_output = tempfile.NamedTemporaryFile()
+
+    process = Popen(
+        [
+            "perf",
+            "record",
+            "--output",
+            tmp_output.name,
+            "-g",
+            "-F",
+            "max",
+            *remaining_args,
+        ]
+    )
+
+    process.wait()
+
+    if args.target == "firefox":
+        with open(args.output, "w") as f:
+            run(["perf", "script", "-i", tmp_output.name, "-F", "+pid"], stdout=f)
+    else:
+        shutil.copyfile(tmp_output.name, args.output)
+
+    sudo = os.getenv("SUDO_USER")
+    if sudo:
+        print(
+            f"perfrecord started with 'sudo', changing output file ownership to '{sudo}'"
+        )
+        os.chown(args.output, int(os.getenv("SUDO_UID")), int(os.getenv("SUDO_GID")))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
It seems bfcli is slow to parse and load rulesets with a large set (this might be applicable to large rulesets in general, but I assume fixing one would fix the other).

This change introduces a benchmark for bfcli big set parsing and loading duration.