### PR TITLE
Prevent wrapped functions from being inlined during unit tests

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -140,6 +140,7 @@ set_source_files_properties(${bf_test_srcs} ${core_srcs} ${bpfilter_srcs} ${lib_
 target_compile_options(unit_bin
     PRIVATE
         -include ${CMAKE_CURRENT_SOURCE_DIR}/assert_override.h
+        -fno-inline-small-functions     # Prevent inlining that would be -Wl,wrap (e.g. bf_ctx_token())
 )
 
 target_include_directories(unit_bin


### PR DESCRIPTION
Unit tests use `-Wl,wrap` flag to wrap functions to mock (e.g. `bf_ctx_token()`). However, when GCC inlines small functions, some of those wrapped functions might be inlined, preventing the wrapping and mocking of it.

Build unit tests with `-fno-inline-small-functions` to prevent inlining of small functions.