### PR TITLE
Set contact in bfcli and bpfilter help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_FLAGS_RELEASE "")       # No NDEBUG in release mode
 set(CMAKE_CXX_FLAGS_RELEASE "")     # No NDEBUG in release mode
 
+set(BF_CONTACT "Quentin Deslandes <qde@naccy.de>")
+
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "Setting build type to 'release' as none was specified.")
   set(CMAKE_BUILD_TYPE "release" CACHE STRING "Choose the type of build." FORCE)

--- a/src/bfcli/CMakeLists.txt
+++ b/src/bfcli/CMakeLists.txt
@@ -62,6 +62,11 @@ add_executable(bfcli
     ${CMAKE_CURRENT_BINARY_DIR}/generated/bfcli/lexer.c
 )
 
+target_compile_definitions(bfcli
+    PRIVATE
+        BF_CONTACT="${BF_CONTACT}"
+)
+
 target_include_directories(bfcli
     PRIVATE
         ${CMAKE_SOURCE_DIR}/src

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
     int r;
 
     argp_program_version_hook = &_bfc_print_version;
+    argp_program_bug_address = BF_CONTACT;
 
     r = bfc_opts_parse(&opts, argc, argv);
     if (r < 0)

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -49,6 +49,11 @@ add_executable(bpfilter
     ${CMAKE_SOURCE_DIR}/src/external/murmur3.h           ${CMAKE_SOURCE_DIR}/src/external/murmur3.c
 )
 
+target_compile_definitions(bpfilter
+    PRIVATE
+        BF_CONTACT="${BF_CONTACT}"
+)
+
 target_include_directories(bpfilter
     PUBLIC
         ${CMAKE_SOURCE_DIR}/src

--- a/src/bpfilter/main.c
+++ b/src/bpfilter/main.c
@@ -471,6 +471,7 @@ int main(int argc, char *argv[])
     bf_logger_setup();
 
     argp_program_version = "bpfilter version " BF_VERSION;
+    argp_program_bug_address = BF_CONTACT;
 
     r = bf_btf_setup();
     if (r < 0)


### PR DESCRIPTION
Use `argp_program_bug_address` to set the contact address for bfcli and bpfilter.