### PR TITLE
cli,daemon,lib,core,tests: improve cleanup macros naming consistency

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -103,7 +103,7 @@ CheckOptions:
   # specific prefix (.e.g _BF). Other idenfitiers defined by GCC are allowed,
   # such as _start, _end...
   - key: bugprone-reserved-identifier.AllowedIdentifiers
-    value: '^(_)+(start|stop|bf|bfc|BF|BFC|cleanup|GNU)_[a-zA-Z0-9_]+$'
+    value: '^(_)+(start|stop|bf|bfc|BF|BFC|GNU)_[a-zA-Z0-9_]+$'
   - key: misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables
     value: true
   # Unless a *statement* takes 1 line, it should be in braces

--- a/doc/developers/style.rst
+++ b/doc/developers/style.rst
@@ -19,6 +19,16 @@ To format a source file using ClangFormat (from the root of the repository):
 
 ClangFormat is not sufficient to define a consistent code style, as its set of configuration option can't cover every use case. Hence, this document should serve as a reference for the code style ClangFormat can't validate.
 
+
+Memory management
+-----------------
+
+``_cleanup_`` attributes are used extensively in the codebase to simplify resource management. Custom macros are defined to simplify usage of the ``_cleanup`` attribute with the following name prefix:
+
+- ``_free_``: cleanup a dynamically allocated object (e.g. :c:func:`_free_bf_cgen_`).
+- ``_clean_``: cleanup an object with automatic storage duration (e.g. :c:func:`_clean_bf_list`).
+
+
 Comments
 --------
 

--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -72,7 +72,7 @@ The example below will create an empty chain with a default ``ACCEPT`` policy.
 
     Test(policy, accept_no_rule)
     {
-        _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+        _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
             BF_HOOK_XDP,
             BF_VERDICT_ACCEPT,
             NULL,

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -100,7 +100,7 @@ int bfc_chain_set(const struct bfc_opts *opts)
 
 int bfc_chain_get(const struct bfc_opts *opts)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
     _clean_bf_list_ bf_list counters = bf_list_default(bf_counter_free, NULL);
     int r;

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -118,10 +118,10 @@ chains          : chain { UNUSED($1); }
 
 chain           : CHAIN STRING hook hookopts verdict rules
                 {
-                    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+                    _free_bf_chain_ struct bf_chain *chain = NULL;
                     _cleanup_free_ const char *name = $2;
                     _free_bf_hookopts_ struct bf_hookopts *hookopts = $4;
-                    _cleanup_bf_list_ bf_list *rules = $6;
+                    _free_bf_list_ bf_list *rules = $6;
                     int r;
 
                     if ($5 >= _BF_TERMINAL_VERDICT_MAX)
@@ -204,7 +204,7 @@ rules           : %empty { $$ = NULL; }
                 ;
 rule            : RULE matchers counter verdict
                 {
-                    _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+                    _free_bf_rule_ struct bf_rule *rule = NULL;
 
                     if (bf_rule_new(&rule) < 0)
                         bf_parse_err("failed to create a new bf_rule\n");
@@ -228,7 +228,7 @@ rule            : RULE matchers counter verdict
 
 matchers        : matcher
                 {
-                    _cleanup_bf_list_ bf_list *list = NULL;
+                    _free_bf_list_ bf_list *list = NULL;
 
                     if (bf_list_new(&list, (bf_list_ops[]){{.free = (bf_list_ops_free)bf_matcher_free, .marsh = (bf_list_ops_marsh)bf_matcher_marsh}}) < 0)
                         bf_parse_err("failed to allocate a new bf_list for bf_matcher\n");
@@ -250,7 +250,7 @@ matchers        : matcher
                 ;
 matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     unsigned long lifindex;
                     uint32_t ifindex;
 
@@ -273,7 +273,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_META_L3_PROTO
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint16_t proto;
 
                     if (bf_streq($3, "ipv4"))
@@ -292,7 +292,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_META_L4_PROTO
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint8_t proto;
 
                     if (bf_streq($3, "icmp"))
@@ -315,7 +315,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_IP_PROTO
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint8_t proto;
 
                     if (bf_streq($3, "icmp"))
@@ -332,7 +332,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_IPADDR
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     struct bf_matcher_ip4_addr addr;
                     char *mask;
                     int r;
@@ -367,8 +367,8 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_IP_ADDR_SET
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
-                    _cleanup_bf_set_ struct bf_set *set = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_set_ struct bf_set *set = NULL;
                     uint32_t set_id = bf_list_size(&ruleset->sets);
                     int r;
 
@@ -422,7 +422,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_IP6_ADDR
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     struct bf_matcher_ip6_addr addr = {};
                     char *mask_str;
                     int mask = 128;
@@ -459,7 +459,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_PORT
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     long raw_val;
                     uint16_t port;
 
@@ -478,7 +478,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_PORT_RANGE
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     long raw_val;
                     char *end_port_str;
                     uint16_t ports[2];
@@ -506,7 +506,7 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
                 }
                 | matcher_type matcher_op MATCHER_TCP_FLAGS
                 {
-                    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     uint8_t flags = 0;
                     char *flags_str;
                     char *saveptr;

--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -66,9 +66,9 @@ int bf_cgen_new(struct bf_cgen **cgen, enum bf_front front,
 
 int bf_cgen_new_from_marsh(struct bf_cgen **cgen, const struct bf_marsh *marsh)
 {
-    _cleanup_bf_cgen_ struct bf_cgen *_cgen = NULL;
-    _cleanup_bf_program_ struct bf_program *program = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_cgen_ struct bf_cgen *_cgen = NULL;
+    _free_bf_program_ struct bf_program *program = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     struct bf_marsh *marsh_elem = NULL;
     enum bf_front front;
     int r;
@@ -141,7 +141,7 @@ void bf_cgen_free(struct bf_cgen **cgen)
 
 int bf_cgen_marsh(const struct bf_cgen *cgen, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(cgen);
@@ -157,7 +157,7 @@ int bf_cgen_marsh(const struct bf_cgen *cgen, struct bf_marsh **marsh)
 
     {
         // Serialize cgen.chain
-        _cleanup_bf_marsh_ struct bf_marsh *chain_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *chain_elem = NULL;
 
         r = bf_chain_marsh(cgen->chain, &chain_elem);
         if (r < 0)
@@ -169,7 +169,7 @@ int bf_cgen_marsh(const struct bf_cgen *cgen, struct bf_marsh **marsh)
     }
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *prog_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *prog_elem = NULL;
 
         if (cgen->program) {
             r = bf_program_marsh(cgen->program, &prog_elem);
@@ -243,7 +243,7 @@ int bf_cgen_get_counter(const struct bf_cgen *cgen,
 int bf_cgen_set(struct bf_cgen *cgen, const struct bf_ns *ns,
                 struct bf_hookopts **hookopts)
 {
-    _cleanup_bf_program_ struct bf_program *prog = NULL;
+    _free_bf_program_ struct bf_program *prog = NULL;
     _cleanup_close_ int pindir_fd = -1;
     int r;
 
@@ -293,7 +293,7 @@ int bf_cgen_set(struct bf_cgen *cgen, const struct bf_ns *ns,
 
 int bf_cgen_load(struct bf_cgen *cgen)
 {
-    _cleanup_bf_program_ struct bf_program *prog = NULL;
+    _free_bf_program_ struct bf_program *prog = NULL;
     _cleanup_close_ int pindir_fd = -1;
     int r;
 
@@ -373,7 +373,7 @@ int bf_cgen_attach(struct bf_cgen *cgen, const struct bf_ns *ns,
 
 int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain)
 {
-    _cleanup_bf_program_ struct bf_program *new_prog = NULL;
+    _free_bf_program_ struct bf_program *new_prog = NULL;
     _cleanup_close_ int pindir_fd = -1;
     struct bf_program *old_prog;
     int r;
@@ -463,7 +463,7 @@ int bf_cgen_get_counters(const struct bf_cgen *cgen, bf_list *counters)
 
     for (ssize_t i = BF_COUNTER_POLICY;
          i < (ssize_t)bf_list_size(&cgen->chain->rules); ++i) {
-        _cleanup_bf_counter_ struct bf_counter *counter = NULL;
+        _free_bf_counter_ struct bf_counter *counter = NULL;
 
         r = bf_counter_new(&counter, 0, 0);
         if (r)

--- a/src/bpfilter/cgen/cgen.h
+++ b/src/bpfilter/cgen/cgen.h
@@ -18,7 +18,7 @@ struct bf_program;
 struct bf_ns;
 struct bf_hookopts;
 
-#define _cleanup_bf_cgen_ __attribute__((cleanup(bf_cgen_free)))
+#define _free_bf_cgen_ __attribute__((cleanup(bf_cgen_free)))
 
 /**
  * Convenience macro to initialize a list of @ref bf_cgen .

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -67,7 +67,7 @@ static int _bf_cgroup_gen_inline_prologue(struct bf_program *program)
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1, offset));
 
     {
-        _cleanup_bf_swich_ struct bf_swich swich =
+        _clean_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BPF_REG_2);
 
         EMIT_SWICH_OPTION(&swich, AF_INET,

--- a/src/bpfilter/cgen/fixup.h
+++ b/src/bpfilter/cgen/fixup.h
@@ -64,7 +64,7 @@ struct bf_fixup
     union bf_fixup_attr attr;
 };
 
-#define _cleanup_bf_fixup_ __attribute__((cleanup(bf_fixup_free)))
+#define _free_bf_fixup_ __attribute__((cleanup(bf_fixup_free)))
 
 int bf_fixup_new(struct bf_fixup **fixup, enum bf_fixup_type type,
                  size_t insn_offset, const union bf_fixup_attr *attr);

--- a/src/bpfilter/cgen/jmp.c
+++ b/src/bpfilter/cgen/jmp.c
@@ -16,11 +16,13 @@
 
 void bf_jmpctx_cleanup(struct bf_jmpctx *ctx)
 {
-    struct bpf_insn *insn = &ctx->program->img[ctx->insn_idx];
-    size_t off = ctx->program->img_size - ctx->insn_idx - 1U;
+    if (ctx->program) {
+        struct bpf_insn *insn = &ctx->program->img[ctx->insn_idx];
+        size_t off = ctx->program->img_size - ctx->insn_idx - 1U;
 
-    if (off > SHRT_MAX)
-        bf_warn("jump offset overflow: %ld", off);
+        if (off > SHRT_MAX)
+            bf_warn("jump offset overflow: %ld", off);
 
-    insn->off = (int16_t)off;
+        insn->off = (int16_t)off;
+    }
 }

--- a/src/bpfilter/cgen/jmp.h
+++ b/src/bpfilter/cgen/jmp.h
@@ -18,7 +18,7 @@
  * @code{.c}
  *  // Within a function body
  *  {
- *      _cleanup_bf_jmpctx_ struct bf_jmpctx ctx =
+ *      _clean_bf_jmpctx_ struct bf_jmpctx ctx =
  *          bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_2, 0, 0));
  *
  *      EMIT(program,
@@ -28,7 +28,7 @@
  *  }
  * @endcode
  *
- * @c ctx is a variable local to the scope, marked with @c _cleanup_bf_jmpctx_ .
+ * @c ctx is a variable local to the scope, marked with @c _clean_bf_jmpctx_ .
  * The second argument to @c bf_jmpctx_get is the jump instruction to emit, with
  * the correct condition. When the scope is exited, the jump instruction is
  * automatically updated to point to the first instruction outside of the scope.
@@ -43,7 +43,9 @@ struct bf_program;
 /**
  * Cleanup attribute for a @ref bf_jmpctx variable.
  */
-#define _cleanup_bf_jmpctx_ __attribute__((cleanup(bf_jmpctx_cleanup)))
+#define _clean_bf_jmpctx_ __attribute__((cleanup(bf_jmpctx_cleanup)))
+
+#define bf_jmpctx_default() {.program = NULL}
 
 /**
  * Create a new @ref bf_jmpctx variable.

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -58,7 +58,7 @@ static int _bf_matcher_generate_meta_l4_proto(struct bf_program *program,
 static int _bf_matcher_generate_meta_port(struct bf_program *program,
                                           const struct bf_matcher *matcher)
 {
-    _cleanup_bf_swich_ struct bf_swich swich;
+    _clean_bf_swich_ struct bf_swich swich;
     uint16_t *port = (uint16_t *)&matcher->payload;
     int r;
 

--- a/src/bpfilter/cgen/matcher/set.c
+++ b/src/bpfilter/cgen/matcher/set.c
@@ -29,7 +29,7 @@
 int _bf_matcher_generate_set_ip6port(struct bf_program *program,
                                      const struct bf_matcher *matcher)
 {
-    _cleanup_bf_swich_ struct bf_swich swich;
+    _clean_bf_swich_ struct bf_swich swich;
     uint32_t set_id;
     int r;
 

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -75,7 +75,7 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
     EMIT(program, BPF_LDX_MEM(BPF_B, BPF_REG_3, BPF_REG_2, offset));
 
     {
-        _cleanup_bf_swich_ struct bf_swich swich =
+        _clean_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BPF_REG_3);
 
         EMIT_SWICH_OPTION(&swich, AF_INET,

--- a/src/bpfilter/cgen/printer.c
+++ b/src/bpfilter/cgen/printer.c
@@ -52,8 +52,7 @@ struct bf_printer
     bf_list msgs;
 };
 
-#define _cleanup_bf_printer_msg_                                               \
-    __attribute__((__cleanup__(_bf_printer_msg_free)))
+#define _free_bf_printer_msg_ __attribute__((__cleanup__(_bf_printer_msg_free)))
 
 static void _bf_printer_msg_free(struct bf_printer_msg **msg);
 
@@ -66,7 +65,7 @@ static void _bf_printer_msg_free(struct bf_printer_msg **msg);
  */
 static int _bf_printer_msg_new(struct bf_printer_msg **msg)
 {
-    _cleanup_bf_printer_msg_ struct bf_printer_msg *_msg = NULL;
+    _free_bf_printer_msg_ struct bf_printer_msg *_msg = NULL;
 
     bf_assert(msg);
 
@@ -91,7 +90,7 @@ static int _bf_printer_msg_new(struct bf_printer_msg **msg)
 static int _bf_printer_msg_new_from_marsh(struct bf_printer_msg **msg,
                                           const struct bf_marsh *marsh)
 {
-    _cleanup_bf_printer_msg_ struct bf_printer_msg *_msg = NULL;
+    _free_bf_printer_msg_ struct bf_printer_msg *_msg = NULL;
     struct bf_marsh *child = NULL;
     int r;
 
@@ -153,7 +152,7 @@ static void _bf_printer_msg_free(struct bf_printer_msg **msg)
 static int _bf_printer_msg_marsh(const struct bf_printer_msg *msg,
                                  struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(msg);
@@ -203,7 +202,7 @@ size_t bf_printer_msg_len(const struct bf_printer_msg *msg)
 
 int bf_printer_new(struct bf_printer **printer)
 {
-    _cleanup_bf_printer_ struct bf_printer *_printer;
+    _free_bf_printer_ struct bf_printer *_printer = NULL;
 
     bf_assert(printer);
 
@@ -221,7 +220,7 @@ int bf_printer_new(struct bf_printer **printer)
 int bf_printer_new_from_marsh(struct bf_printer **printer,
                               const struct bf_marsh *marsh)
 {
-    _cleanup_bf_printer_ struct bf_printer *_printer = NULL;
+    _free_bf_printer_ struct bf_printer *_printer = NULL;
     struct bf_marsh *child = NULL;
     int r;
 
@@ -233,7 +232,7 @@ int bf_printer_new_from_marsh(struct bf_printer **printer,
         return bf_err_r(r, "failed to allocate a new bf_printer object");
 
     while ((child = bf_marsh_next_child(marsh, child))) {
-        _cleanup_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
+        _free_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
 
         r = _bf_printer_msg_new_from_marsh(&msg, child);
         if (r)
@@ -319,7 +318,7 @@ static size_t _bf_printer_total_size(const struct bf_printer *printer)
 const struct bf_printer_msg *bf_printer_add_msg(struct bf_printer *printer,
                                                 const char *str)
 {
-    _cleanup_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
+    _free_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
     int r;
 
     bf_assert(printer);

--- a/src/bpfilter/cgen/printer.h
+++ b/src/bpfilter/cgen/printer.h
@@ -50,7 +50,7 @@ struct bf_marsh;
 struct bf_printer;
 struct bf_printer_msg;
 
-#define _cleanup_bf_printer_ __attribute__((__cleanup__(bf_printer_free)))
+#define _free_bf_printer_ __attribute__((__cleanup__(bf_printer_free)))
 
 /**
  * Emit BPF instructions to print a log message.

--- a/src/bpfilter/cgen/prog/link.c
+++ b/src/bpfilter/cgen/prog/link.c
@@ -99,7 +99,7 @@ void bf_link_free(struct bf_link **link)
 
 int bf_link_marsh(const struct bf_link *link, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(link && marsh);
@@ -114,7 +114,7 @@ int bf_link_marsh(const struct bf_link *link, struct bf_marsh **marsh)
 
     // Serialize link.hookopts
     if (link->hookopts) {
-        _cleanup_bf_marsh_ struct bf_marsh *hookopts_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *hookopts_elem = NULL;
 
         r = bf_hookopts_marsh(link->hookopts, &hookopts_elem);
         if (r < 0)

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -26,7 +26,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
                enum bf_map_bpf_type bpf_type, size_t key_size,
                size_t value_size, size_t n_elems)
 {
-    _cleanup_bf_map_ struct bf_map *_map = NULL;
+    _free_bf_map_ struct bf_map *_map = NULL;
 
     bf_assert(map && name);
     bf_assert(name[0] != '\0');
@@ -53,7 +53,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
 int bf_map_new_from_marsh(struct bf_map **map, int dir_fd,
                           const struct bf_marsh *marsh)
 {
-    _cleanup_bf_map_ struct bf_map *_map = NULL;
+    _free_bf_map_ struct bf_map *_map = NULL;
     struct bf_marsh *elem = NULL;
     int r;
 
@@ -115,7 +115,7 @@ void bf_map_free(struct bf_map **map)
 
 int bf_map_marsh(const struct bf_map *map, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(map);
@@ -208,7 +208,7 @@ _bf_map_bpf_type_to_kernel_type(enum bf_map_bpf_type bpf_type)
     return _kernel_types[bpf_type];
 }
 
-#define _cleanup_bf_btf_ __attribute__((__cleanup__(_bf_btf_free)))
+#define _free_bf_btf_ __attribute__((__cleanup__(_bf_btf_free)))
 
 struct bf_btf
 {
@@ -222,7 +222,7 @@ static void _bf_btf_free(struct bf_btf **btf);
 
 static int _bf_btf_new(struct bf_btf **btf)
 {
-    _cleanup_bf_btf_ struct bf_btf *_btf = NULL;
+    _free_bf_btf_ struct bf_btf *_btf = NULL;
 
     bf_assert(btf);
 
@@ -293,7 +293,7 @@ static int _bf_btf_load(struct bf_btf *btf)
  */
 static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
 {
-    _cleanup_bf_btf_ struct bf_btf *btf = NULL;
+    _free_bf_btf_ struct bf_btf *btf = NULL;
     struct btf *kbtf;
     int r;
 
@@ -336,7 +336,7 @@ int bf_map_create(struct bf_map *map, uint32_t flags)
 {
     int token_fd;
     union bpf_attr attr = {};
-    _cleanup_bf_btf_ struct bf_btf *btf = NULL;
+    _free_bf_btf_ struct bf_btf *btf = NULL;
     int r;
 
     bf_assert(map);

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -46,7 +46,7 @@ struct bf_map
 
 struct bf_marsh;
 
-#define _cleanup_bf_map_ __attribute__((__cleanup__(bf_map_free)))
+#define _free_bf_map_ __attribute__((__cleanup__(bf_map_free)))
 
 /**
  * Convenience macro to initialize a list of @ref bf_map .

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -78,7 +78,7 @@ static const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
 
 int bf_program_new(struct bf_program **program, const struct bf_chain *chain)
 {
-    _cleanup_bf_program_ struct bf_program *_program = NULL;
+    _free_bf_program_ struct bf_program *_program = NULL;
     char name[BPF_OBJ_NAME_LEN];
     uint32_t set_idx = 0;
     int r;
@@ -111,7 +111,7 @@ int bf_program_new(struct bf_program **program, const struct bf_chain *chain)
     _program->sets = bf_map_list();
     bf_list_foreach (&chain->sets, set_node) {
         struct bf_set *set = bf_list_node_get_data(set_node);
-        _cleanup_bf_map_ struct bf_map *map = NULL;
+        _free_bf_map_ struct bf_map *map = NULL;
 
         (void)snprintf(name, BPF_OBJ_NAME_LEN, "set_%04x", (uint8_t)set_idx++);
         r = bf_map_new(&map, name, BF_MAP_TYPE_SET, BF_MAP_BPF_TYPE_HASH,
@@ -168,7 +168,7 @@ void bf_program_free(struct bf_program **program)
 
 int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(program);
@@ -180,7 +180,7 @@ int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 
     {
         // Serialize bf_program.counters
-        _cleanup_bf_marsh_ struct bf_marsh *counters_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *counters_elem = NULL;
 
         r = bf_map_marsh(program->cmap, &counters_elem);
         if (r < 0)
@@ -193,7 +193,7 @@ int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 
     {
         // Serialize bf_program.pmap
-        _cleanup_bf_marsh_ struct bf_marsh *pmap_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *pmap_elem = NULL;
 
         r = bf_map_marsh(program->pmap, &pmap_elem);
         if (r < 0)
@@ -206,7 +206,7 @@ int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 
     {
         // Serialize bf_program.sets
-        _cleanup_bf_marsh_ struct bf_marsh *sets_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *sets_elem = NULL;
 
         r = bf_list_marsh(&program->sets, &sets_elem);
         if (r < 0)
@@ -222,7 +222,7 @@ int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 
     {
         // Serialize bf_program.links
-        _cleanup_bf_marsh_ struct bf_marsh *links_elem = NULL;
+        _free_bf_marsh_ struct bf_marsh *links_elem = NULL;
 
         r = bf_link_marsh(program->link, &links_elem);
         if (r)
@@ -238,7 +238,7 @@ int bf_program_marsh(const struct bf_program *program, struct bf_marsh **marsh)
 
     {
         // Serialise bf_program.printer
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_printer_marsh(program->printer, &child);
         if (r)
@@ -265,7 +265,7 @@ int bf_program_unmarsh(const struct bf_marsh *marsh,
                        struct bf_program **program,
                        const struct bf_chain *chain, int dir_fd)
 {
-    _cleanup_bf_program_ struct bf_program *_program = NULL;
+    _free_bf_program_ struct bf_program *_program = NULL;
     struct bf_marsh *child = NULL;
     int r;
 
@@ -303,7 +303,7 @@ int bf_program_unmarsh(const struct bf_marsh *marsh,
         struct bf_marsh *set_elem = NULL;
 
         while ((set_elem = bf_marsh_next_child(child, set_elem))) {
-            _cleanup_bf_map_ struct bf_map *map = NULL;
+            _free_bf_map_ struct bf_map *map = NULL;
 
             r = bf_map_new_from_marsh(&map, dir_fd, set_elem);
             if (r < 0)
@@ -662,7 +662,7 @@ static int _bf_program_generate_update_counters(struct bf_program *program)
 
     // If the counters doesn't exist, return from the function
     {
-        _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
+        _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
@@ -773,7 +773,7 @@ int bf_program_emit_kfunc_call(struct bf_program *program, const char *name)
 int bf_program_emit_fixup(struct bf_program *program, enum bf_fixup_type type,
                           struct bpf_insn insn, const union bf_fixup_attr *attr)
 {
-    _cleanup_bf_fixup_ struct bf_fixup *fixup = NULL;
+    _free_bf_fixup_ struct bf_fixup *fixup = NULL;
     int r;
 
     bf_assert(program);
@@ -806,7 +806,7 @@ int bf_program_emit_fixup(struct bf_program *program, enum bf_fixup_type type,
 int bf_program_emit_fixup_call(struct bf_program *program,
                                enum bf_fixup_func function)
 {
-    _cleanup_bf_fixup_ struct bf_fixup *fixup = NULL;
+    _free_bf_fixup_ struct bf_fixup *fixup = NULL;
     int r;
 
     bf_assert(program);

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -333,7 +333,7 @@ struct bf_program
     } runtime;
 };
 
-#define _cleanup_bf_program_ __attribute__((__cleanup__(bf_program_free)))
+#define _free_bf_program_ __attribute__((__cleanup__(bf_program_free)))
 
 int bf_program_new(struct bf_program **program, const struct bf_chain *chain);
 void bf_program_free(struct bf_program **program);

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -55,7 +55,7 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
 
     // If the function call failed, quit the program
     {
-        _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
+        _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
 
         // Update the error counter
@@ -105,7 +105,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
 
     // If the function call failed, quit the program
     {
-        _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
+        _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
@@ -140,7 +140,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
 
 int bf_stub_parse_l3_hdr(struct bf_program *program)
 {
-    _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+    _clean_bf_jmpctx_ struct bf_jmpctx _ = bf_jmpctx_default();
     int r;
 
     bf_assert(program);
@@ -149,7 +149,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
      * ID stored in r7. If the protocol is not supported, we store 0 into r7
      * and we skip the instructions below. */
     {
-        _cleanup_bf_swich_ struct bf_swich swich =
+        _clean_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BPF_REG_7);
 
         EMIT_SWICH_OPTION(&swich, htobe16(ETH_P_IP),
@@ -175,7 +175,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
 
     // If the function call failed, quit the program
     {
-        _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
+        _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
@@ -201,7 +201,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
      * function and would jump over the block below, so there is no need to
      * worry about them here. */
     {
-        _cleanup_bf_swich_ struct bf_swich swich =
+        _clean_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BPF_REG_7);
 
         EMIT_SWICH_OPTION(&swich, htobe16(ETH_P_IP),
@@ -235,7 +235,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
 
 int bf_stub_parse_l4_hdr(struct bf_program *program)
 {
-    _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+    _clean_bf_jmpctx_ struct bf_jmpctx _ = bf_jmpctx_default();
     int r;
 
     bf_assert(program);
@@ -243,7 +243,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
     /* Parse the L4 protocol and handle unuspported protocol, similarly to
      * bf_stub_parse_l3_hdr() above. */
     {
-        _cleanup_bf_swich_ struct bf_swich swich =
+        _clean_bf_swich_ struct bf_swich swich =
             bf_swich_get(program, BPF_REG_8);
 
         EMIT_SWICH_OPTION(&swich, IPPROTO_TCP,
@@ -273,7 +273,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
 
     // If the function call failed, quit the program
     {
-        _cleanup_bf_jmpctx_ struct bf_jmpctx _ =
+        _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter

--- a/src/bpfilter/cgen/swich.c
+++ b/src/bpfilter/cgen/swich.c
@@ -23,8 +23,7 @@
 #include "external/filter.h"
 
 /// Cleanup attribute for a @ref bf_swich_option variable.
-#define _cleanup_bf_swich_option_                                              \
-    __attribute__((cleanup(_bf_swich_option_free)))
+#define _free_bf_swich_option_ __attribute__((cleanup(_bf_swich_option_free)))
 
 /**
  * @struct bf_swich_option
@@ -59,7 +58,7 @@ static void _bf_swich_option_free(struct bf_swich_option **option);
 static int _bf_swich_option_new(struct bf_swich_option **option, uint32_t imm,
                                 const struct bpf_insn *insns, size_t insns_len)
 {
-    _cleanup_bf_swich_option_ struct bf_swich_option *_option = NULL;
+    _free_bf_swich_option_ struct bf_swich_option *_option = NULL;
 
     bf_assert(option);
     bf_assert(insns);
@@ -125,7 +124,7 @@ void bf_swich_cleanup(struct bf_swich *swich)
 int bf_swich_add_option(struct bf_swich *swich, uint32_t imm,
                         const struct bpf_insn *insns, size_t insns_len)
 {
-    _cleanup_bf_swich_option_ struct bf_swich_option *option = NULL;
+    _free_bf_swich_option_ struct bf_swich_option *option = NULL;
     int r;
 
     bf_assert(swich);
@@ -147,7 +146,7 @@ int bf_swich_add_option(struct bf_swich *swich, uint32_t imm,
 int bf_swich_set_default(struct bf_swich *swich, const struct bpf_insn *insns,
                          size_t insns_len)
 {
-    _cleanup_bf_swich_option_ struct bf_swich_option *option = NULL;
+    _free_bf_swich_option_ struct bf_swich_option *option = NULL;
     int r;
 
     bf_assert(swich);

--- a/src/bpfilter/cgen/swich.h
+++ b/src/bpfilter/cgen/swich.h
@@ -50,7 +50,7 @@
 struct bf_program;
 
 /// Cleanup attribute for a @ref bf_swich variable.
-#define _cleanup_bf_swich_ __attribute__((cleanup(bf_swich_cleanup)))
+#define _clean_bf_swich_ __attribute__((cleanup(bf_swich_cleanup)))
 
 /**
  * Create, initialize, and return a new @ref bf_swich object.

--- a/src/bpfilter/ctx.c
+++ b/src/bpfilter/ctx.c
@@ -26,7 +26,7 @@
 #include "core/marsh.h"
 #include "core/ns.h"
 
-#define _cleanup_bf_ctx_ __attribute__((cleanup(_bf_ctx_free)))
+#define _free_bf_ctx_ __attribute__((cleanup(_bf_ctx_free)))
 
 /**
  * @struct bf_ctx
@@ -87,7 +87,7 @@ static int _bf_ctx_gen_token(void)
  */
 static int _bf_ctx_new(struct bf_ctx **ctx)
 {
-    _cleanup_bf_ctx_ struct bf_ctx *_ctx = NULL;
+    _free_bf_ctx_ struct bf_ctx *_ctx = NULL;
     int r;
 
     bf_assert(ctx);
@@ -138,7 +138,7 @@ static int _bf_ctx_new(struct bf_ctx **ctx)
 static int _bf_ctx_new_from_marsh(struct bf_ctx **ctx,
                                   const struct bf_marsh *marsh)
 {
-    _cleanup_bf_ctx_ struct bf_ctx *_ctx = NULL;
+    _free_bf_ctx_ struct bf_ctx *_ctx = NULL;
     struct bf_marsh *child = NULL;
     struct bf_marsh *elem = NULL;
     int r;
@@ -153,7 +153,7 @@ static int _bf_ctx_new_from_marsh(struct bf_ctx **ctx,
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
     while ((elem = bf_marsh_next_child(child, elem))) {
-        _cleanup_bf_cgen_ struct bf_cgen *cgen = NULL;
+        _free_bf_cgen_ struct bf_cgen *cgen = NULL;
 
         r = bf_cgen_new_from_marsh(&cgen, elem);
         if (r < 0)
@@ -258,7 +258,7 @@ static void _bf_ctx_dump(const struct bf_ctx *ctx, prefix_t *prefix)
  */
 static int _bf_ctx_marsh(const struct bf_ctx *ctx, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(ctx && marsh);
@@ -268,7 +268,7 @@ static int _bf_ctx_marsh(const struct bf_ctx *ctx, struct bf_marsh **marsh)
         return bf_err_r(r, "failed to create marsh for context");
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_list_marsh(&ctx->cgens, &child);
         if (r < 0)
@@ -365,7 +365,7 @@ static int _bf_ctx_delete_cgen(struct bf_ctx *ctx, struct bf_cgen *cgen,
 
 int bf_ctx_setup(void)
 {
-    _cleanup_bf_ctx_ struct bf_ctx *_ctx = NULL;
+    _free_bf_ctx_ struct bf_ctx *_ctx = NULL;
     int r;
 
     bf_assert(!_ctx);
@@ -391,7 +391,7 @@ void bf_ctx_teardown(bool clear)
 
 int bf_ctx_save(struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(marsh);
@@ -407,7 +407,7 @@ int bf_ctx_save(struct bf_marsh **marsh)
 
 int bf_ctx_load(const struct bf_marsh *marsh)
 {
-    _cleanup_bf_ctx_ struct bf_ctx *ctx = NULL;
+    _free_bf_ctx_ struct bf_ctx *ctx = NULL;
     int r;
 
     bf_assert(marsh);

--- a/src/bpfilter/main.c
+++ b/src/bpfilter/main.c
@@ -413,9 +413,9 @@ static int _bf_run(void)
 
     while (!_bf_stop_received) {
         _cleanup_close_ int client_fd = -1;
-        _cleanup_bf_request_ struct bf_request *request = NULL;
-        _cleanup_bf_response_ struct bf_response *response = NULL;
-        _clean_bf_ns_ struct bf_ns ns;
+        _free_bf_request_ struct bf_request *request = NULL;
+        _free_bf_response_ struct bf_response *response = NULL;
+        _clean_bf_ns_ struct bf_ns ns = bf_ns_default();
 
         client_fd = accept(fd, NULL, NULL);
         if (client_fd < 0) {

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -62,10 +62,10 @@ int _bf_cli_ruleset_flush(const struct bf_request *request,
 static int _bf_cli_ruleset_get(const struct bf_request *request,
                                struct bf_response **response)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *hookopts_marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *counters_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *hookopts_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *counters_marsh = NULL;
     _clean_bf_list_ bf_list cgens = bf_list_default(NULL, NULL);
     _clean_bf_list_ bf_list chains = bf_list_default(NULL, bf_chain_marsh);
     _clean_bf_list_ bf_list hookopts = bf_list_default(NULL, bf_hookopts_marsh);
@@ -85,7 +85,7 @@ static int _bf_cli_ruleset_get(const struct bf_request *request,
 
     bf_list_foreach (&cgens, cgen_node) {
         struct bf_cgen *cgen = bf_list_node_get_data(cgen_node);
-        _cleanup_bf_list_ bf_list *cgen_counters = NULL;
+        _free_bf_list_ bf_list *cgen_counters = NULL;
 
         r = bf_list_add_tail(&chains, cgen->chain);
         if (r)
@@ -124,7 +124,7 @@ static int _bf_cli_ruleset_get(const struct bf_request *request,
     r = bf_marsh_new(&hookopts_marsh, NULL, 0);
     bf_list_foreach (&hookopts, hookopts_node) {
         struct bf_hookopts *hookopts = bf_list_node_get_data(hookopts_node);
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         if (hookopts) {
             r = bf_hookopts_marsh(bf_list_node_get_data(hookopts_node), &child);
@@ -178,8 +178,8 @@ int _bf_cli_ruleset_set(const struct bf_request *request,
     bf_ctx_flush(BF_FRONT_CLI);
 
     while ((list_elem = bf_marsh_next_child(marsh, list_elem))) {
-        _cleanup_bf_cgen_ struct bf_cgen *cgen = NULL;
-        _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+        _free_bf_cgen_ struct bf_cgen *cgen = NULL;
+        _free_bf_chain_ struct bf_chain *chain = NULL;
         _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
         struct bf_marsh *child = NULL;
 
@@ -234,8 +234,8 @@ int _bf_cli_chain_set(const struct bf_request *request,
 {
     struct bf_cgen *old_cgen;
     struct bf_marsh *marsh, *child = NULL;
-    _cleanup_bf_cgen_ struct bf_cgen *new_cgen = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_cgen_ struct bf_cgen *new_cgen = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
     int r;
 
@@ -293,7 +293,7 @@ int _bf_cli_chain_set(const struct bf_request *request,
 static int _bf_cli_chain_get(const struct bf_request *request,
                              struct bf_response **response)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     _clean_bf_list_ bf_list counters =
         bf_list_default(bf_counter_free, bf_counter_marsh);
     struct bf_cgen *cgen;
@@ -325,7 +325,7 @@ static int _bf_cli_chain_get(const struct bf_request *request,
         return bf_err_r(r, "failed to get new marsh");
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_chain_marsh(cgen->chain, &child);
         if (r)
@@ -337,7 +337,7 @@ static int _bf_cli_chain_get(const struct bf_request *request,
     }
 
     if (cgen->program->link->hookopts) {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_hookopts_marsh(cgen->program->link->hookopts, &child);
         if (r)
@@ -353,7 +353,7 @@ static int _bf_cli_chain_get(const struct bf_request *request,
     }
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_cgen_get_counters(cgen, &counters);
         if (r)
@@ -376,8 +376,8 @@ int _bf_cli_chain_load(const struct bf_request *request,
                        struct bf_response **response)
 {
     struct bf_marsh *marsh, *child = NULL;
-    _cleanup_bf_cgen_ struct bf_cgen *cgen = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_cgen_ struct bf_cgen *cgen = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     int r;
 
     bf_assert(request && response);
@@ -427,7 +427,7 @@ int _bf_cli_chain_attach(const struct bf_request *request,
                          struct bf_response **response)
 {
     struct bf_marsh *marsh, *child = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     struct bf_cgen *cgen = NULL;
     const char *name;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
@@ -477,7 +477,7 @@ int _bf_cli_chain_update(const struct bf_request *request,
                          struct bf_response **response)
 {
     struct bf_marsh *marsh, *child = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     struct bf_cgen *cgen = NULL;
     int r;
 

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -178,7 +178,7 @@ static int _bf_verdict_to_ipt_target(enum bf_verdict verdict,
 static int _bf_ipt_entry_to_rule(const struct ipt_entry *entry,
                                  struct bf_rule **rule)
 {
-    _cleanup_bf_rule_ struct bf_rule *_rule = NULL;
+    _free_bf_rule_ struct bf_rule *_rule = NULL;
     int r;
 
     bf_assert(entry && rule);
@@ -305,7 +305,7 @@ static int _bf_ipt_entries_to_chain(struct bf_chain **chain, int ipt_hook,
                                     struct ipt_entry *first,
                                     struct ipt_entry *last)
 {
-    _cleanup_bf_chain_ struct bf_chain *_chain = NULL;
+    _free_bf_chain_ struct bf_chain *_chain = NULL;
     enum bf_verdict policy;
     int r;
 
@@ -322,7 +322,7 @@ static int _bf_ipt_entries_to_chain(struct bf_chain **chain, int ipt_hook,
         return r;
 
     while (first < last) {
-        _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+        _free_bf_rule_ struct bf_rule *rule = NULL;
 
         r = _bf_ipt_entry_to_rule(first, &rule);
         if (r)
@@ -367,7 +367,7 @@ struct bf_ipt_gen_ruleset_entry
 static int _bf_ipt_gen_get_ruleset(struct bf_ipt_gen_ruleset_entry *ruleset,
                                    size_t *nrules, bf_list *dummy_chains)
 {
-    _clean_bf_list_ bf_list cgens;
+    _clean_bf_list_ bf_list cgens = bf_list_default(NULL, NULL);
     size_t _nrules = 0;
     int r;
 
@@ -394,7 +394,7 @@ static int _bf_ipt_gen_get_ruleset(struct bf_ipt_gen_ruleset_entry *ruleset,
      * ipt_replace structure. */
     for (enum nf_inet_hooks hook = NF_INET_LOCAL_IN; hook <= NF_INET_LOCAL_OUT;
          ++hook) {
-        _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+        _free_bf_chain_ struct bf_chain *chain = NULL;
 
         if (ruleset[hook].cgen)
             continue;
@@ -568,7 +568,7 @@ _bf_ipt_xlate_ruleset_set(struct ipt_replace *ipt,
     bf_assert(ipt && chains);
 
     for (int i = 0; i < NF_INET_NUMHOOKS; ++i) {
-        _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+        _free_bf_chain_ struct bf_chain *chain = NULL;
 
         if (!ipt_is_hook_enabled(ipt, i)) {
             bf_dbg("iptables hook %d is not enabled, skipping", i);
@@ -632,8 +632,8 @@ static int _bf_ipt_ruleset_set(const struct bf_request *req)
     }
 
     for (int i = 0; i < NF_INET_NUMHOOKS; i++) {
-        _cleanup_bf_cgen_ struct bf_cgen *cgen = cur_cgens[i];
-        _cleanup_bf_chain_ struct bf_chain *chain = TAKE_PTR(chains[i]);
+        _free_bf_cgen_ struct bf_cgen *cgen = cur_cgens[i];
+        _free_bf_chain_ struct bf_chain *chain = TAKE_PTR(chains[i]);
 
         _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
 

--- a/src/bpfilter/xlate/nft/nfgroup.c
+++ b/src/bpfilter/xlate/nft/nfgroup.c
@@ -30,7 +30,7 @@ int bf_nfgroup_new(struct bf_nfgroup **group)
 {
     bf_assert(group);
 
-    _cleanup_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
+    _free_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
 
     _group = calloc(1, sizeof(*_group));
     if (!_group)
@@ -54,7 +54,7 @@ int bf_nfgroup_new_from_stream(struct bf_nfgroup **group, struct nlmsghdr *nlh,
     /* nlmsg_ok() takes an int. length should not be larger than INT_MAX, but
      * we check anyway to be safe. */
 
-    _cleanup_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
+    _free_bf_nfgroup_ struct bf_nfgroup *_group = NULL;
     int len = (int)length;
     int r;
 
@@ -63,7 +63,7 @@ int bf_nfgroup_new_from_stream(struct bf_nfgroup **group, struct nlmsghdr *nlh,
         return r;
 
     while (nlmsg_ok(nlh, len)) {
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         if (nlh->nlmsg_type == NFNL_MSG_BATCH_BEGIN ||
             nlh->nlmsg_type == NFNL_MSG_BATCH_END) {
@@ -141,7 +141,7 @@ int bf_nfgroup_add_new_message(struct bf_nfgroup *group, struct bf_nfmsg **msg,
 {
     bf_assert(group);
 
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
     int r;
 
     r = bf_nfmsg_new(&_msg, command, seqnr);
@@ -166,8 +166,8 @@ int bf_nfgroup_to_response(const struct bf_nfgroup *group,
     bf_assert(group);
     bf_assert(resp);
 
-    _cleanup_bf_response_ struct bf_response *_resp = NULL;
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *done = NULL;
+    _free_bf_response_ struct bf_response *_resp = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *done = NULL;
     size_t size = bf_nfgroup_size(group);
     bool is_multipart = bf_list_size(&group->messages) != 1;
     void *payload;

--- a/src/bpfilter/xlate/nft/nfgroup.h
+++ b/src/bpfilter/xlate/nft/nfgroup.h
@@ -33,7 +33,7 @@ struct bf_nfmsg;
 /**
  * Cleanup function for @ref bf_nfgroup.
  */
-#define _cleanup_bf_nfgroup_ __attribute__((__cleanup__(bf_nfgroup_free)))
+#define _free_bf_nfgroup_ __attribute__((__cleanup__(bf_nfgroup_free)))
 
 /**
  * Create a new Netlink messages group.

--- a/src/bpfilter/xlate/nft/nfmsg.c
+++ b/src/bpfilter/xlate/nft/nfmsg.c
@@ -124,7 +124,7 @@ int bf_nfmsg_new(struct bf_nfmsg **msg, uint8_t command, uint32_t seqnr)
 {
     bf_assert(msg);
 
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
     struct nlmsghdr *nlh;
     struct nfgenmsg extra_hdr = {
         .nfgen_family = AF_INET,
@@ -159,7 +159,7 @@ int bf_nfmsg_new_done(struct bf_nfmsg **msg)
 {
     bf_assert(msg);
 
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
     struct nlmsghdr *nlh;
     struct nfgenmsg extra_hdr = {
         .nfgen_family = AF_INET,
@@ -194,7 +194,7 @@ int bf_nfmsg_new_from_nlmsghdr(struct bf_nfmsg **msg, struct nlmsghdr *nlh)
     bf_assert(msg);
     bf_assert(nlh);
 
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *_msg = NULL;
 
     if (nlh->nlmsg_type >> 8 != NFNL_SUBSYS_NFTABLES) {
         return bf_err_r(-EINVAL, "invalid Netlink message type: %u",

--- a/src/bpfilter/xlate/nft/nfmsg.h
+++ b/src/bpfilter/xlate/nft/nfmsg.h
@@ -73,7 +73,7 @@ extern const bf_nfpolicy *bf_nf_verdict_policy;
 /**
  * Cleanup attribute for a @ref bf_nfmsg variable.
  */
-#define _cleanup_bf_nfmsg_ __attribute__((__cleanup__(bf_nfmsg_free)))
+#define _free_bf_nfmsg_ __attribute__((__cleanup__(bf_nfmsg_free)))
 
 /**
  * Create a new Netfilter Netlink message.
@@ -433,7 +433,7 @@ bf_nfattr *bf_nfattr_next(bf_nfattr *attr, size_t *remaining);
 /**
  * Cleanup attribute for a @ref bf_nfnest variable.
  */
-#define _cleanup_bf_nfnest_ __attribute__((__cleanup__(bf_nfnest_cleanup)))
+#define _clean_bf_nfnest_ __attribute__((__cleanup__(bf_nfnest_cleanup)))
 
 /**
  * Convenience macro to create a new nested attribute context or jump to

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -22,7 +22,7 @@
 int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
                  enum bf_verdict policy, bf_list *sets, bf_list *rules)
 {
-    _cleanup_bf_chain_ struct bf_chain *_chain = NULL;
+    _free_bf_chain_ struct bf_chain *_chain = NULL;
 
     bf_assert(policy < _BF_TERMINAL_VERDICT_MAX);
 
@@ -53,7 +53,7 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
 int bf_chain_new_from_marsh(struct bf_chain **chain,
                             const struct bf_marsh *marsh)
 {
-    _cleanup_bf_chain_ struct bf_chain *_chain = NULL;
+    _free_bf_chain_ struct bf_chain *_chain = NULL;
     struct bf_marsh *child = NULL;
     struct bf_marsh *list_elem;
     enum bf_hook hook;
@@ -88,7 +88,7 @@ int bf_chain_new_from_marsh(struct bf_chain **chain,
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
     while ((list_elem = bf_marsh_next_child(child, list_elem))) {
-        _cleanup_bf_set_ struct bf_set *set = NULL;
+        _free_bf_set_ struct bf_set *set = NULL;
 
         r = bf_set_new_from_marsh(&set, list_elem);
         if (r)
@@ -106,7 +106,7 @@ int bf_chain_new_from_marsh(struct bf_chain **chain,
     if (!(child = bf_marsh_next_child(marsh, child)))
         return -EINVAL;
     while ((list_elem = bf_marsh_next_child(child, list_elem))) {
-        _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+        _free_bf_rule_ struct bf_rule *rule = NULL;
 
         r = bf_rule_unmarsh(list_elem, &rule);
         if (r)
@@ -139,7 +139,7 @@ void bf_chain_free(struct bf_chain **chain)
 
 int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(chain && marsh);
@@ -162,7 +162,7 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
 
     {
         // Serialize bf_chain.sets
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_list_marsh(&chain->sets, &child);
         if (r < 0)
@@ -175,7 +175,7 @@ int bf_chain_marsh(const struct bf_chain *chain, struct bf_marsh **marsh)
 
     {
         // Serialize bf_chain.rules
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_list_marsh(&chain->rules, &child);
         if (r < 0)

--- a/src/core/chain.h
+++ b/src/core/chain.h
@@ -14,7 +14,7 @@ struct bf_hookopts;
 struct bf_marsh;
 struct bf_rule;
 
-#define _cleanup_bf_chain_ __attribute__((cleanup(bf_chain_free)))
+#define _free_bf_chain_ __attribute__((cleanup(bf_chain_free)))
 
 struct bf_chain
 {

--- a/src/core/counter.c
+++ b/src/core/counter.c
@@ -34,7 +34,7 @@ int bf_counter_new(struct bf_counter **counter, uint64_t packets,
 int bf_counter_new_from_marsh(struct bf_counter **counter,
                               const struct bf_marsh *marsh)
 {
-    _cleanup_bf_counter_ struct bf_counter *_counter = NULL;
+    _free_bf_counter_ struct bf_counter *_counter = NULL;
     struct bf_marsh *elem = NULL;
 
     bf_assert(counter && marsh);
@@ -68,7 +68,7 @@ void bf_counter_free(struct bf_counter **counter)
 
 int bf_counter_marsh(const struct bf_counter *counter, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(counter && marsh);

--- a/src/core/counter.h
+++ b/src/core/counter.h
@@ -26,7 +26,7 @@ struct bf_counter
     uint64_t bytes;
 } bf_packed;
 
-#define _cleanup_bf_counter_ __attribute__((__cleanup__(bf_counter_free)))
+#define _free_bf_counter_ __attribute__((__cleanup__(bf_counter_free)))
 
 /**
  * Free a @ref bf_counter structure.

--- a/src/core/hook.c
+++ b/src/core/hook.c
@@ -453,7 +453,7 @@ void bf_hookopts_free(struct bf_hookopts **hookopts)
 int bf_hookopts_marsh(const struct bf_hookopts *hookopts,
                       struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r = 0;
 
     bf_assert(hookopts && marsh);

--- a/src/core/io.c
+++ b/src/core/io.c
@@ -90,7 +90,7 @@ int bf_send_request(int fd, const struct bf_request *request)
 int bf_recv_request(int fd, struct bf_request **request)
 {
     struct bf_request req;
-    _cleanup_bf_request_ struct bf_request *_request = NULL;
+    _free_bf_request_ struct bf_request *_request = NULL;
     ssize_t r;
 
     bf_assert(request);
@@ -157,7 +157,7 @@ int bf_send_response(int fd, struct bf_response *response)
 int bf_recv_response(int fd, struct bf_response **response)
 {
     struct bf_response res;
-    _cleanup_bf_response_ struct bf_response *_response = NULL;
+    _free_bf_response_ struct bf_response *_response = NULL;
     ssize_t r;
 
     bf_assert(response);

--- a/src/core/list.c
+++ b/src/core/list.c
@@ -54,7 +54,7 @@ static void bf_list_node_free(bf_list_node **node,
 
 int bf_list_new(bf_list **list, const bf_list_ops *ops)
 {
-    _cleanup_bf_list_ bf_list *_list = NULL;
+    _free_bf_list_ bf_list *_list = NULL;
 
     bf_assert(list);
 
@@ -109,7 +109,7 @@ void bf_list_clean(bf_list *list)
 
 int bf_list_marsh(const bf_list *list, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(list && marsh);
@@ -120,7 +120,7 @@ int bf_list_marsh(const bf_list *list, struct bf_marsh **marsh)
 
     if (list->ops.marsh) {
         bf_list_foreach (list, node) {
-            _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+            _free_bf_marsh_ struct bf_marsh *child = NULL;
 
             r = list->ops.marsh(bf_list_node_get_data(node), &child);
             if (r < 0)

--- a/src/core/list.h
+++ b/src/core/list.h
@@ -81,7 +81,7 @@ typedef struct
     bf_list_ops ops;
 } bf_list;
 
-#define _cleanup_bf_list_ __attribute__((cleanup(bf_list_free)))
+#define _free_bf_list_ __attribute__((cleanup(bf_list_free)))
 #define _clean_bf_list_ __attribute__((cleanup(bf_list_clean)))
 
 /**

--- a/src/core/marsh.c
+++ b/src/core/marsh.c
@@ -43,7 +43,7 @@ void bf_marsh_free(struct bf_marsh **marsh)
 
 int bf_marsh_add_child_obj(struct bf_marsh **marsh, const struct bf_marsh *obj)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *new = NULL;
+    _free_bf_marsh_ struct bf_marsh *new = NULL;
     size_t new_data_len;
 
     bf_assert(marsh && *marsh);
@@ -68,7 +68,7 @@ int bf_marsh_add_child_obj(struct bf_marsh **marsh, const struct bf_marsh *obj)
 int bf_marsh_add_child_raw(struct bf_marsh **marsh, const void *data,
                            size_t data_len)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+    _free_bf_marsh_ struct bf_marsh *child = NULL;
     int r;
 
     bf_assert(marsh && *marsh);

--- a/src/core/marsh.h
+++ b/src/core/marsh.h
@@ -24,7 +24,7 @@ struct bf_marsh
     char data[];
 } bf_packed;
 
-#define _cleanup_bf_marsh_ __attribute__((__cleanup__(bf_marsh_free)))
+#define _free_bf_marsh_ __attribute__((__cleanup__(bf_marsh_free)))
 
 /**
  * Returns true if a marsh object is empty (only contains a header).

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -18,7 +18,7 @@ int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
                    enum bf_matcher_op op, const void *payload,
                    size_t payload_len)
 {
-    _cleanup_bf_matcher_ struct bf_matcher *_matcher = NULL;
+    _free_bf_matcher_ struct bf_matcher *_matcher = NULL;
 
     bf_assert(matcher);
     bf_assert((payload && payload_len) || (!payload && !payload_len));
@@ -87,7 +87,7 @@ void bf_matcher_free(struct bf_matcher **matcher)
 
 int bf_matcher_marsh(const struct bf_matcher *matcher, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(matcher);

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -32,7 +32,7 @@ struct bf_matcher;
 struct bf_marsh;
 
 /// Automatically destroy @ref bf_matcher objects going out of the scope.
-#define _cleanup_bf_matcher_ __attribute__((__cleanup__(bf_matcher_free)))
+#define _free_bf_matcher_ __attribute__((__cleanup__(bf_matcher_free)))
 
 /**
  * Matcher type.

--- a/src/core/request.c
+++ b/src/core/request.c
@@ -16,7 +16,7 @@
 int bf_request_new(struct bf_request **request, const void *data,
                    size_t data_len)
 {
-    _cleanup_bf_request_ struct bf_request *_request = NULL;
+    _free_bf_request_ struct bf_request *_request = NULL;
 
     bf_assert(request);
     bf_assert(!(!!data ^ !!data_len));
@@ -37,7 +37,7 @@ int bf_request_new(struct bf_request **request, const void *data,
 
 int bf_request_copy(struct bf_request **dest, const struct bf_request *src)
 {
-    _cleanup_bf_request_ struct bf_request *_request = NULL;
+    _free_bf_request_ struct bf_request *_request = NULL;
 
     bf_assert(dest);
     bf_assert(src);

--- a/src/core/request.h
+++ b/src/core/request.h
@@ -12,7 +12,7 @@
 
 struct bf_ns;
 
-#define _cleanup_bf_request_ __attribute__((cleanup(bf_request_free)))
+#define _free_bf_request_ __attribute__((cleanup(bf_request_free)))
 
 /**
  * @enum bf_request_cmd

--- a/src/core/response.c
+++ b/src/core/response.c
@@ -28,7 +28,7 @@ int bf_response_new_raw(struct bf_response **response, size_t data_len)
 int bf_response_new_success(struct bf_response **response, const char *data,
                             size_t data_len)
 {
-    _cleanup_bf_response_ struct bf_response *_response = NULL;
+    _free_bf_response_ struct bf_response *_response = NULL;
 
     bf_assert(response);
     bf_assert(!(!!data ^ !!data_len));
@@ -48,7 +48,7 @@ int bf_response_new_success(struct bf_response **response, const char *data,
 
 int bf_response_new_failure(struct bf_response **response, int error)
 {
-    _cleanup_bf_response_ struct bf_response *_response = NULL;
+    _free_bf_response_ struct bf_response *_response = NULL;
 
     bf_assert(response);
 
@@ -72,7 +72,7 @@ void bf_response_free(struct bf_response **response)
 
 int bf_response_copy(struct bf_response **dest, const struct bf_response *src)
 {
-    _cleanup_bf_response_ struct bf_response *_response = NULL;
+    _free_bf_response_ struct bf_response *_response = NULL;
 
     bf_assert(dest);
     bf_assert(src);

--- a/src/core/response.h
+++ b/src/core/response.h
@@ -9,7 +9,7 @@
 
 #include "core/helper.h"
 
-#define _cleanup_bf_response_ __attribute__((cleanup(bf_response_free)))
+#define _free_bf_response_ __attribute__((cleanup(bf_response_free)))
 
 /**
  * @enum bf_response_type

--- a/src/core/rule.c
+++ b/src/core/rule.c
@@ -52,7 +52,7 @@ void bf_rule_free(struct bf_rule **rule)
 
 int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     int r;
 
     bf_assert(rule);
@@ -67,7 +67,7 @@ int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
         return r;
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_list_marsh(&rule->matchers, &child);
         if (r < 0)
@@ -92,7 +92,7 @@ int bf_rule_marsh(const struct bf_rule *rule, struct bf_marsh **marsh)
 
 int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
 {
-    _cleanup_bf_rule_ struct bf_rule *_rule = NULL;
+    _free_bf_rule_ struct bf_rule *_rule = NULL;
     struct bf_marsh *rule_elem = NULL;
     int r;
 
@@ -114,7 +114,7 @@ int bf_rule_unmarsh(const struct bf_marsh *marsh, struct bf_rule **rule)
         struct bf_marsh *matcher_elem = NULL;
 
         while ((matcher_elem = bf_marsh_next_child(rule_elem, matcher_elem))) {
-            _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+            _free_bf_matcher_ struct bf_matcher *matcher = NULL;
 
             r = bf_matcher_new_from_marsh(&matcher, matcher_elem);
             if (r)
@@ -179,7 +179,7 @@ int bf_rule_add_matcher(struct bf_rule *rule, enum bf_matcher_type type,
                         enum bf_matcher_op op, const void *payload,
                         size_t payload_len)
 {
-    _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
     int r;
 
     bf_assert(rule);

--- a/src/core/rule.h
+++ b/src/core/rule.h
@@ -16,7 +16,7 @@
 
 struct bf_marsh;
 
-#define _cleanup_bf_rule_ __attribute__((__cleanup__(bf_rule_free)))
+#define _free_bf_rule_ __attribute__((__cleanup__(bf_rule_free)))
 
 /**
  * Convenience macro to initialize a list of @ref bf_rule .

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -49,7 +49,7 @@ int bf_set_new(struct bf_set **set, enum bf_set_type type)
 
 int bf_set_new_from_marsh(struct bf_set **set, const struct bf_marsh *marsh)
 {
-    _cleanup_bf_set_ struct bf_set *_set = NULL;
+    _free_bf_set_ struct bf_set *_set = NULL;
     struct bf_marsh *child;
     enum bf_set_type type;
     int r;
@@ -99,7 +99,7 @@ void bf_set_free(struct bf_set **set)
 
 int bf_set_marsh(const struct bf_set *set, struct bf_marsh **marsh)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
     _cleanup_free_ uint8_t *data = NULL;
     size_t elem_idx = 0;
     int r;

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -32,7 +32,7 @@
 
 struct bf_marsh;
 
-#define _cleanup_bf_set_ __attribute__((__cleanup__(bf_set_free)))
+#define _free_bf_set_ __attribute__((__cleanup__(bf_set_free)))
 
 /**
  * Convenience macro to initialize a list of @ref bf_set .

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -22,8 +22,8 @@
 
 int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     _clean_bf_list_ bf_list _chains = bf_list_default_from(*chains);
     _clean_bf_list_ bf_list _hookopts = bf_list_default_from(*hookopts);
     _clean_bf_list_ bf_list _counters = bf_list_default_from(*counters);
@@ -54,7 +54,7 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
         return -EINVAL;
     for (struct bf_marsh *schild = bf_marsh_next_child(child, NULL); schild;
          schild = bf_marsh_next_child(child, schild)) {
-        _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+        _free_bf_chain_ struct bf_chain *chain = NULL;
 
         r = bf_chain_new_from_marsh(&chain, schild);
         if (r)
@@ -90,7 +90,7 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
         return -EINVAL;
     for (struct bf_marsh *schild = bf_marsh_next_child(child, NULL); schild;
          schild = bf_marsh_next_child(child, schild)) {
-        _cleanup_bf_list_ bf_list *nested = NULL;
+        _free_bf_list_ bf_list *nested = NULL;
 
         r = bf_list_new(
             &nested, &bf_list_ops_default(bf_counter_free, bf_counter_marsh));
@@ -100,7 +100,7 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
         for (struct bf_marsh *counter_marsh = bf_marsh_next_child(schild, NULL);
              counter_marsh;
              counter_marsh = bf_marsh_next_child(schild, counter_marsh)) {
-            _cleanup_bf_counter_ struct bf_counter *counter = NULL;
+            _free_bf_counter_ struct bf_counter *counter = NULL;
 
             r = bf_counter_new_from_marsh(&counter, counter_marsh);
             if (r)
@@ -129,8 +129,8 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
 
 int bf_cli_ruleset_flush(void)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     r = bf_request_new(&request, NULL, 0);
@@ -149,9 +149,9 @@ int bf_cli_ruleset_flush(void)
 
 int bf_cli_ruleset_set(bf_list *chains, bf_list *hookopts)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     struct bf_list_node *chain_node = bf_list_get_head(chains);
     struct bf_list_node *hookopts_node = bf_list_get_head(hookopts);
     int r;
@@ -164,9 +164,9 @@ int bf_cli_ruleset_set(bf_list *chains, bf_list *hookopts)
         return r;
 
     while (chain_node && hookopts_node) {
-        _cleanup_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *hook_marsh = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *_marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *hook_marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *_marsh = NULL;
         struct bf_chain *chain = bf_list_node_get_data(chain_node);
         struct bf_hookopts *hookopts = bf_list_node_get_data(hookopts_node);
 
@@ -220,11 +220,11 @@ int bf_cli_ruleset_set(bf_list *chains, bf_list *hookopts)
 
 int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *hook_marsh = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *chain_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *hook_marsh = NULL;
     int r;
 
     r = bf_marsh_new(&marsh, NULL, 0);
@@ -270,13 +270,13 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
 int bf_chain_get(const char *name, struct bf_chain **chain,
                  struct bf_hookopts **hookopts, bf_list *counters)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_chain_ struct bf_chain *_chain = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_chain_ struct bf_chain *_chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *_hookopts = NULL;
     _clean_bf_list_ bf_list _counters = bf_list_default_from(*counters);
     struct bf_marsh *marsh, *child = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *req_marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *req_marsh = NULL;
     int r;
 
     r = bf_marsh_new(&req_marsh, NULL, 0);
@@ -327,7 +327,7 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
     for (struct bf_marsh *counter_marsh = bf_marsh_next_child(child, NULL);
          counter_marsh;
          counter_marsh = bf_marsh_next_child(child, counter_marsh)) {
-        _cleanup_bf_counter_ struct bf_counter *counter = NULL;
+        _free_bf_counter_ struct bf_counter *counter = NULL;
 
         r = bf_counter_new_from_marsh(&counter, counter_marsh);
         if (r)
@@ -349,9 +349,9 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
 
 int bf_chain_load(struct bf_chain *chain)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     int r;
 
     r = bf_marsh_new(&marsh, NULL, 0);
@@ -359,7 +359,7 @@ int bf_chain_load(struct bf_chain *chain)
         return r;
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_chain_marsh(chain, &child);
         if (r)
@@ -386,9 +386,9 @@ int bf_chain_load(struct bf_chain *chain)
 
 int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     int r;
 
     r = bf_marsh_new(&marsh, NULL, 0);
@@ -400,7 +400,7 @@ int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
         return r;
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+        _free_bf_marsh_ struct bf_marsh *child = NULL;
 
         r = bf_hookopts_marsh(hookopts, &child);
         if (r)
@@ -427,10 +427,10 @@ int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
 
 int bf_chain_update(const struct bf_chain *chain)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *child = NULL;
     int r;
 
     r = bf_marsh_new(&marsh, NULL, 0);
@@ -461,9 +461,9 @@ int bf_chain_update(const struct bf_chain *chain)
 
 int bf_chain_flush(const char *name)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     int r;
 
     r = bf_marsh_new(&marsh, NULL, 0);

--- a/src/libbpfilter/ipt.c
+++ b/src/libbpfilter/ipt.c
@@ -47,8 +47,8 @@
 
 int bf_ipt_replace(struct ipt_replace *ipt_replace)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     bf_assert(ipt_replace);
@@ -79,8 +79,8 @@ int bf_ipt_replace(struct ipt_replace *ipt_replace)
 
 int bf_ipt_add_counters(struct xt_counters_info *counters)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     bf_assert(counters);
@@ -111,8 +111,8 @@ int bf_ipt_add_counters(struct xt_counters_info *counters)
 
 int bf_ipt_get_info(struct ipt_getinfo *info)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     bf_assert(info);
@@ -144,8 +144,8 @@ int bf_ipt_get_info(struct ipt_getinfo *info)
 
 int bf_ipt_get_entries(struct ipt_get_entries *entries)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     bf_assert(entries);

--- a/src/libbpfilter/nft.c
+++ b/src/libbpfilter/nft.c
@@ -16,8 +16,8 @@
 
 int bf_nft_send(const void *data, size_t len)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     if (!data || !len)
@@ -39,8 +39,8 @@ int bf_nft_send(const void *data, size_t len)
 int bf_nft_sendrecv(const struct nlmsghdr *req, size_t req_len,
                     struct nlmsghdr *res, size_t *res_len)
 {
-    _cleanup_bf_request_ struct bf_request *request = NULL;
-    _cleanup_bf_response_ struct bf_response *response = NULL;
+    _free_bf_request_ struct bf_request *request = NULL;
+    _free_bf_response_ struct bf_response *response = NULL;
     int r;
 
     if (!req || !req_len || !res || !res_len)

--- a/tests/e2e/e2e.c
+++ b/tests/e2e/e2e.c
@@ -52,7 +52,7 @@ static struct {
 int bft_e2e_test(struct bf_chain *chain, enum bf_verdict expect,
                  const struct bft_prog_run_args *args)
 {
-    _cleanup_bf_test_daemon_ struct bf_test_daemon daemon = bft_daemon_default();
+    _clean_bf_test_daemon_ struct bf_test_daemon daemon = bft_daemon_default();
     bool success = true, daemon_failure = false;
     int retval[_BF_FLAVOR_MAX] = {};
     int r;

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -13,7 +13,7 @@
 
 Test(policy, accept_no_rule)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -27,7 +27,7 @@ Test(policy, accept_no_rule)
 
 Test(ip4, daddr_eq_mask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -57,7 +57,7 @@ Test(ip4, daddr_eq_mask_match)
 
 Test(ip6, saddr_eq_nomask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -89,7 +89,7 @@ Test(ip6, saddr_eq_nomask_match)
 
 Test(ip6, saddr_eq_nomask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -121,7 +121,7 @@ Test(ip6, saddr_eq_nomask_nomatch)
 
 Test(ip6, saddr_ne_nomask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -153,7 +153,7 @@ Test(ip6, saddr_ne_nomask_match)
 
 Test(ip6, saddr_ne_nomask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -185,7 +185,7 @@ Test(ip6, saddr_ne_nomask_nomatch)
 
 Test(ip6, saddr_eq_8mask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -217,7 +217,7 @@ Test(ip6, saddr_eq_8mask_match)
 
 Test(ip6, saddr_eq_8mask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -249,7 +249,7 @@ Test(ip6, saddr_eq_8mask_nomatch)
 
 Test(ip6, saddr_ne_8mask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -281,7 +281,7 @@ Test(ip6, saddr_ne_8mask_match)
 
 Test(ip6, saddr_ne_8mask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -313,7 +313,7 @@ Test(ip6, saddr_ne_8mask_nomatch)
 
 Test(ip6, saddr_eq_120mask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -343,7 +343,7 @@ Test(ip6, saddr_eq_120mask_match)
 
 Test(ip6, saddr_eq_120mask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -375,7 +375,7 @@ Test(ip6, saddr_eq_120mask_nomatch)
 
 Test(ip6, saddr_ne_120mask_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -407,7 +407,7 @@ Test(ip6, saddr_ne_120mask_nomatch)
 
 Test(ip6, saddr_ne_120mask_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -439,7 +439,7 @@ Test(ip6, saddr_ne_120mask_match)
 
 struct bf_set *make_ip6port_set(size_t nelems, uint8_t *matching_elem)
 {
-    _cleanup_bf_set_ struct bf_set *set = NULL;
+    _free_bf_set_ struct bf_set *set = NULL;
     int r;
 
     r = bf_set_new(&set, BF_SET_SRCIP6PORT);
@@ -474,7 +474,7 @@ struct bf_set *make_ip6port_set(size_t nelems, uint8_t *matching_elem)
 
 Test(ip6, port_200kset_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
@@ -501,7 +501,7 @@ Test(ip6, port_200kset_match)
 
 Test(ip6, port_200kset_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
@@ -528,7 +528,7 @@ Test(ip6, port_200kset_nomatch)
 
 struct bf_set *make_ip6_set(size_t nelems, uint8_t *matching_elem)
 {
-    _cleanup_bf_set_ struct bf_set *set = NULL;
+    _free_bf_set_ struct bf_set *set = NULL;
     int r;
 
     r = bf_set_new(&set, BF_SET_SRCIP6);
@@ -563,7 +563,7 @@ struct bf_set *make_ip6_set(size_t nelems, uint8_t *matching_elem)
 
 Test(ip6, addrport_200kset_match)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
@@ -590,7 +590,7 @@ Test(ip6, addrport_200kset_match)
 
 Test(ip6, addrport_200kset_nomatch)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         (struct bf_set *[]) {
@@ -617,7 +617,7 @@ Test(ip6, addrport_200kset_nomatch)
 
 Test(tcp, dport_range)
 {
-    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -641,7 +641,7 @@ Test(tcp, dport_range)
     );
     bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_tcp);
 
-    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -665,7 +665,7 @@ Test(tcp, dport_range)
     );
     bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
 
-    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -692,7 +692,7 @@ Test(tcp, dport_range)
 
 Test(udp, dport_range)
 {
-    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -716,7 +716,7 @@ Test(udp, dport_range)
     );
     bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_udp);
 
-    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -740,7 +740,7 @@ Test(udp, dport_range)
     );
     bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
 
-    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -767,7 +767,7 @@ Test(udp, dport_range)
 
 Test(meta, dport_range)
 {
-    _cleanup_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *in_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -792,7 +792,7 @@ Test(meta, dport_range)
     bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_tcp);
     bft_e2e_test(in_range, BF_VERDICT_DROP, pkt_local_ip6_udp);
 
-    _cleanup_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *under_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,
@@ -817,7 +817,7 @@ Test(meta, dport_range)
     bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_tcp);
     bft_e2e_test(under_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
 
-    _cleanup_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
+    _free_bf_chain_ struct bf_chain *over_range = bf_test_chain_get(
         BF_HOOK_XDP,
         BF_VERDICT_ACCEPT,
         NULL,

--- a/tests/harness/daemon.h
+++ b/tests/harness/daemon.h
@@ -36,7 +36,7 @@ enum bf_test_daemon_option
     _BF_TEST_DAEMON_LAST = BF_TEST_DAEMON_NO_NFTABLES,
 };
 
-#define _cleanup_bf_test_daemon_                                               \
+#define _clean_bf_test_daemon_                                                 \
     __attribute__((__cleanup__(bf_test_daemon_clean)))
 
 #define bft_daemon_default()                                                   \

--- a/tests/harness/filters.c
+++ b/tests/harness/filters.c
@@ -50,7 +50,7 @@ struct bf_hookopts *bft_hookopts_get(const char *raw_opt, ...)
 
 struct bf_set *bf_test_set_get(enum bf_set_type type, uint8_t *data[])
 {
-    _cleanup_bf_set_ struct bf_set *set = NULL;
+    _free_bf_set_ struct bf_set *set = NULL;
     int r;
 
     r = bf_set_new(&set, type);
@@ -90,7 +90,7 @@ struct bf_matcher *bf_matcher_get(enum bf_matcher_type type,
 struct bf_rule *bf_rule_get(bool counters, enum bf_verdict verdict,
                             struct bf_matcher **matchers)
 {
-    _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+    _free_bf_rule_ struct bf_rule *rule = NULL;
     int r;
 
     r = bf_rule_new(&rule);
@@ -124,7 +124,7 @@ err_free_matchers:
 struct bf_chain *bf_test_chain_get(enum bf_hook hook, enum bf_verdict policy,
                                    struct bf_set **sets, struct bf_rule **rules)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = NULL;
+    _free_bf_chain_ struct bf_chain *chain = NULL;
     _clean_bf_list_ bf_list sets_list = bf_set_list();
     _clean_bf_list_ bf_list rules_list = bf_rule_list();
     int r;

--- a/tests/harness/process.c
+++ b/tests/harness/process.c
@@ -214,7 +214,8 @@ int bf_test_process_stop(struct bf_test_process *process)
 
 int bf_run(const char *cmd, char **args, size_t nargs)
 {
-    _cleanup_bf_test_process_ struct bf_test_process process;
+    _clean_bf_test_process_ struct bf_test_process process =
+        bft_process_default();
     int r;
 
     r = bf_test_process_init(&process, cmd, args, nargs);

--- a/tests/harness/process.h
+++ b/tests/harness/process.h
@@ -49,7 +49,7 @@ struct bf_test_process
     int err_fd;
 };
 
-#define _cleanup_bf_test_process_                                              \
+#define _clean_bf_test_process_                                                \
     __attribute__((__cleanup__(bf_test_process_clean)))
 
 #define bft_process_default()                                                  \

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -216,7 +216,7 @@ extern bf_test __stop_bf_test;
 
 int bf_test_discover_test_suite(bf_test_suite **suite)
 {
-    _cleanup_bf_list_ bf_list *symbols = NULL;
+    _free_bf_list_ bf_list *symbols = NULL;
     _free_bf_test_suite_ bf_test_suite *_suite = NULL;
     bf_test *test;
     int r;

--- a/tests/unit/bpfilter/cgen/cgen.c
+++ b/tests/unit/bpfilter/cgen/cgen.c
@@ -22,16 +22,16 @@ Test(cgen, create_delete_assert)
 Test(cgen, create_delete)
 {
     // Rely on the cleanup attribute.
-    _cleanup_bf_cgen_ struct bf_cgen *cgen0 = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain0 = bf_test_chain_quick();
+    _free_bf_cgen_ struct bf_cgen *cgen0 = NULL;
+    _free_bf_chain_ struct bf_chain *chain0 = bf_test_chain_quick();
 
     assert_success(bf_cgen_new(&cgen0, BF_FRONT_CLI, &chain0));
     assert_non_null(cgen0);
     assert_null(chain0);
 
     // Codegen has the cleanup attribute, but call free() before
-    _cleanup_bf_cgen_ struct bf_cgen *cgen1 = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain1 = bf_test_chain_quick();
+    _free_bf_cgen_ struct bf_cgen *cgen1 = NULL;
+    _free_bf_chain_ struct bf_chain *chain1 = bf_test_chain_quick();
 
     assert_success(bf_cgen_new(&cgen1, BF_FRONT_CLI, &chain1));
     assert_non_null(cgen1);
@@ -42,7 +42,7 @@ Test(cgen, create_delete)
 
     // Free the codegen manually
     struct bf_cgen *cgen2;
-    _cleanup_bf_chain_ struct bf_chain *chain2 = bf_test_chain_quick();
+    _free_bf_chain_ struct bf_chain *chain2 = bf_test_chain_quick();
 
     assert_success(bf_cgen_new(&cgen2, BF_FRONT_CLI, &chain2));
     assert_non_null(cgen2);
@@ -57,7 +57,7 @@ Test(cgen, create_delete_no_malloc)
 {
     _clean_bf_test_mock_ bf_test_mock mock;
     struct bf_cgen *cgen;
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
 
     mock = bf_test_mock_get(malloc, NULL);
     assert_error(bf_cgen_new(&cgen, BF_FRONT_CLI, &chain));
@@ -73,9 +73,9 @@ Test(cgen, marsh_unmarsh_assert)
 
 Test(cgen, marsh_unmarsh)
 {
-    _cleanup_bf_cgen_ struct bf_cgen *cgen0 = NULL;
-    _cleanup_bf_cgen_ struct bf_cgen *cgen1 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_cgen_ struct bf_cgen *cgen0 = NULL;
+    _free_bf_cgen_ struct bf_cgen *cgen1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
     /* Create a codegen without any program, other bf_program_unmarsh()
      * will try to open the pinned BPF objects.

--- a/tests/unit/bpfilter/cgen/jmp.c
+++ b/tests/unit/bpfilter/cgen/jmp.c
@@ -35,8 +35,8 @@ static int emit_in_ctx(struct bf_program *program, struct bf_jmpctx *ctx,
 
 Test(jmp, create_and_close)
 {
-    _cleanup_bf_program_ struct bf_program *program = NULL;
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain(BF_HOOK_XDP, BF_VERDICT_ACCEPT);
+    _free_bf_program_ struct bf_program *program = NULL;
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain(BF_HOOK_XDP, BF_VERDICT_ACCEPT);
 
     assert_success(bf_program_new(&program, chain));
 
@@ -61,7 +61,7 @@ Test(jmp, create_and_close)
         size_t idx;
 
         {
-            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            _clean_bf_jmpctx_ struct bf_jmpctx _;
             assert_int_equal(emit_in_ctx(program, &_, 0), 0);
             idx = _.insn_idx;
         }
@@ -69,7 +69,7 @@ Test(jmp, create_and_close)
         assert_int_equal(program->img[idx].off, 0);
 
         {
-            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            _clean_bf_jmpctx_ struct bf_jmpctx _;
             assert_int_equal(emit_in_ctx(program, &_, 1), 0);
             idx = _.insn_idx;
         }
@@ -77,7 +77,7 @@ Test(jmp, create_and_close)
         assert_int_equal(program->img[idx].off, 1);
 
         {
-            _cleanup_bf_jmpctx_ struct bf_jmpctx _;
+            _clean_bf_jmpctx_ struct bf_jmpctx _;
             assert_int_equal(emit_in_ctx(program, &_, 2), 0);
             idx = _.insn_idx;
         }

--- a/tests/unit/bpfilter/cgen/printer.c
+++ b/tests/unit/bpfilter/cgen/printer.c
@@ -15,7 +15,7 @@ Test(printer, msg_lifetime)
 
     {
         // Automatic cleanup
-        _cleanup_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
+        _free_bf_printer_msg_ struct bf_printer_msg *msg = NULL;
 
         assert_int_equal(_bf_printer_msg_new(&msg), 0);
     }
@@ -53,9 +53,9 @@ Test(printer, msg_marsh_unmarsh)
     expect_assert_failure(_bf_printer_msg_marsh(NOT_NULL, NULL));
     expect_assert_failure(_bf_printer_msg_marsh(NULL, NULL));
 
-    _cleanup_bf_printer_msg_ struct bf_printer_msg *msg0 = NULL;
-    _cleanup_bf_printer_msg_ struct bf_printer_msg *msg1 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_printer_msg_ struct bf_printer_msg *msg0 = NULL;
+    _free_bf_printer_msg_ struct bf_printer_msg *msg1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
     assert_int_equal(_bf_printer_msg_new(&msg0), 0);
     msg0->offset = 17;
@@ -77,7 +77,7 @@ Test(printer, printer_lifetime)
 
     {
         // Automatic cleanup
-        _cleanup_bf_printer_ struct bf_printer *printer = NULL;
+        _free_bf_printer_ struct bf_printer *printer = NULL;
 
         assert_int_equal(bf_printer_new(&printer), 0);
     }
@@ -119,12 +119,12 @@ Test(printer, printer_marsh_unmarsh)
     expect_assert_failure(bf_printer_add_msg(NOT_NULL, NULL));
     expect_assert_failure(bf_printer_add_msg(NULL, NULL));
 
-    _cleanup_bf_printer_ struct bf_printer *printer0 = NULL;
-    _cleanup_bf_printer_ struct bf_printer *printer1 = NULL;
+    _free_bf_printer_ struct bf_printer *printer0 = NULL;
+    _free_bf_printer_ struct bf_printer *printer1 = NULL;
     const struct bf_printer_msg *msg0;
     const struct bf_printer_msg *msg1;
     const struct bf_printer_msg *msg2;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
     // Insert messages into the printer, and ensure inserting 2 times the
     // same message will only create 1 message.

--- a/tests/unit/bpfilter/cgen/prog/map.c
+++ b/tests/unit/bpfilter/cgen/prog/map.c
@@ -23,13 +23,13 @@ Test(map, create_delete_assert)
 Test(map, create_delete)
 {
     // Rely on the cleanup attribute
-    _cleanup_bf_map_ struct bf_map *map0 = NULL;
+    _free_bf_map_ struct bf_map *map0 = NULL;
 
     assert_success(bf_map_new(&map0, "012345", BF_MAP_TYPE_SET, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map0);
 
     // Use the cleanup attribute, but free manually
-    _cleanup_bf_map_ struct bf_map *map1 = NULL;
+    _free_bf_map_ struct bf_map *map1 = NULL;
 
     assert_success(bf_map_new(&map1, "012345", BF_MAP_TYPE_SET, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     assert_non_null(map1);
@@ -58,9 +58,9 @@ Test(map, marsh_unmarsh_assert)
 
 Test(map, marsh_unmarsh)
 {
-    _cleanup_bf_map_ struct bf_map *map0 = NULL;
-    _cleanup_bf_map_ struct bf_map *map1 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_map_ struct bf_map *map0 = NULL;
+    _free_bf_map_ struct bf_map *map1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(bf_bpf_obj_get, 0);
 
     assert_success(bf_map_new(&map0, "012345", BF_MAP_TYPE_SET, BF_MAP_BPF_TYPE_ARRAY, 1, 2, 3));
@@ -87,7 +87,7 @@ Test(map, dump_assert)
 
 Test(map, dump)
 {
-    _cleanup_bf_map_ struct bf_map *map = NULL;
+    _free_bf_map_ struct bf_map *map = NULL;
 
     assert_success(bf_map_new(&map, "012345", BF_MAP_TYPE_SET, BF_MAP_BPF_TYPE_ARRAY, 1, 1, 1));
     bf_map_dump(map, EMPTY_PREFIX);
@@ -108,13 +108,13 @@ Test(map, btf_create_delete_assert)
 Test(map, btf_create_delete)
 {
     // Rely on the cleanup attribute
-    _cleanup_bf_btf_ struct bf_btf *btf0 = NULL;
+    _free_bf_btf_ struct bf_btf *btf0 = NULL;
 
     assert_success(_bf_btf_new(&btf0));
     assert_non_null(btf0);
 
     // Use the cleanup attribute, but free manually
-    _cleanup_bf_btf_ struct bf_btf *btf1 = NULL;
+    _free_bf_btf_ struct bf_btf *btf1 = NULL;
 
     assert_success(_bf_btf_new(&btf1));
     assert_non_null(btf1);
@@ -140,7 +140,7 @@ Test(map, map_create_assert)
 
 Test(map, map_create)
 {
-    _cleanup_bf_map_ struct bf_map *map = NULL;
+    _free_bf_map_ struct bf_map *map = NULL;
     _clean_bf_test_mock_ bf_test_mock _0 = bf_test_mock_get(bf_bpf, 16);
     _clean_bf_test_mock_ bf_test_mock _1 = bf_test_mock_get(bf_ctx_token, -1);
 
@@ -156,7 +156,7 @@ Test(map, map_create)
 
 Test(map, map_create_failure)
 {
-    _cleanup_bf_map_ struct bf_map *map = NULL;
+    _free_bf_map_ struct bf_map *map = NULL;
     _clean_bf_test_mock_ bf_test_mock _0 = bf_test_mock_get(bf_bpf, -1);
     _clean_bf_test_mock_ bf_test_mock _1 = bf_test_mock_get(bf_ctx_token, -1);
 

--- a/tests/unit/bpfilter/cgen/program.c
+++ b/tests/unit/bpfilter/cgen/program.c
@@ -11,14 +11,14 @@
 
 Test(program, emit_fixup_call)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
 
     expect_assert_failure(bf_program_emit_fixup_call(
         NULL, BF_FIXUP_FUNC_UPDATE_COUNTERS));
 
     {
         // Instructions buffer should grow
-        _cleanup_bf_program_ struct bf_program *program = NULL;
+        _free_bf_program_ struct bf_program *program = NULL;
         size_t start_cap;
 
         assert_success(bf_program_new(&program, chain));

--- a/tests/unit/bpfilter/cgen/swich.c
+++ b/tests/unit/bpfilter/cgen/swich.c
@@ -23,7 +23,7 @@ Test(swich, new_and_free_option)
 
     {
         // Auto cleanup
-        _cleanup_bf_swich_option_ struct bf_swich_option *option = NULL;
+        _free_bf_swich_option_ struct bf_swich_option *option = NULL;
 
         assert_int_equal(
             0, _bf_swich_option_new(&option, 0, (struct bpf_insn[]) {}, 0));
@@ -44,7 +44,7 @@ Test(swich, new_and_free_option)
 
 Test(swich, init_and_cleanup)
 {
-    _cleanup_bf_swich_ struct bf_swich swich;
+    _clean_bf_swich_ struct bf_swich swich;
 
     expect_assert_failure(bf_swich_init(NULL, NOT_NULL, 0));
     expect_assert_failure(bf_swich_init(NOT_NULL, NULL, 0));
@@ -57,7 +57,7 @@ Test(swich, init_and_cleanup)
 
 Test(swich, generate_swich)
 {
-    _cleanup_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
     struct bpf_insn insns[] = {
         BPF_EXIT_INSN(),
         BPF_EXIT_INSN(),
@@ -66,8 +66,8 @@ Test(swich, generate_swich)
 
     {
         // No default option
-        _cleanup_bf_program_ struct bf_program *program = NULL;
-        _cleanup_bf_swich_ struct bf_swich swich;
+        _free_bf_program_ struct bf_program *program = NULL;
+        _clean_bf_swich_ struct bf_swich swich;
 
         assert_success(bf_program_new(&program, chain));
         assert_success(bf_swich_init(&swich, program, 0));
@@ -82,8 +82,8 @@ Test(swich, generate_swich)
 
     {
         // With default option (2 times)
-        _cleanup_bf_program_ struct bf_program *program = NULL;
-        _cleanup_bf_swich_ struct bf_swich swich;
+        _free_bf_program_ struct bf_program *program = NULL;
+        _clean_bf_swich_ struct bf_swich swich;
 
         assert_success(bf_program_new(&program, chain));
         assert_success(bf_swich_init(&swich, program, 0));

--- a/tests/unit/bpfilter/ctx.c
+++ b/tests/unit/bpfilter/ctx.c
@@ -20,13 +20,13 @@ Test(ctx, create_delete_assert)
 Test(ctx, create_delete)
 {
     // Rely on the cleanup attrubte
-    _cleanup_bf_ctx_ struct bf_ctx *ctx0 = NULL;
+    _free_bf_ctx_ struct bf_ctx *ctx0 = NULL;
 
     assert_success(_bf_ctx_new(&ctx0));
     assert_non_null(ctx0);
 
     // Use the cleanup attribute, but free manually
-    _cleanup_bf_ctx_ struct bf_ctx *ctx1 = NULL;
+    _free_bf_ctx_ struct bf_ctx *ctx1 = NULL;
 
     assert_success(_bf_ctx_new(&ctx1));
     assert_non_null(ctx1);
@@ -48,10 +48,10 @@ Test(ctx, create_delete)
 Test(ctx, set_get_chain)
 {
     // Rely on the cleanup attrubte
-    _cleanup_bf_ctx_ struct bf_ctx *ctx = NULL;
-    _cleanup_bf_cgen_ struct bf_cgen *cgen0 = bf_test_cgen_quick();
-    _cleanup_bf_cgen_ struct bf_cgen *cgen1 = bf_test_cgen_quick();
-    _cleanup_bf_cgen_ struct bf_cgen *cgen2 = bf_test_cgen_quick();
+    _free_bf_ctx_ struct bf_ctx *ctx = NULL;
+    _free_bf_cgen_ struct bf_cgen *cgen0 = bf_test_cgen_quick();
+    _free_bf_cgen_ struct bf_cgen *cgen1 = bf_test_cgen_quick();
+    _free_bf_cgen_ struct bf_cgen *cgen2 = bf_test_cgen_quick();
 
     // Change the name of cgen2
     freep(&cgen2->chain->name);

--- a/tests/unit/bpfilter/xlate/nft/nfgroup.c
+++ b/tests/unit/bpfilter/xlate/nft/nfgroup.c
@@ -26,7 +26,7 @@ Test(nfgroup, new_and_free)
     }
 
     {
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
 
         assert_int_equal(bf_nfgroup_new(&gp), 0);
         assert_non_null(gp);
@@ -35,7 +35,7 @@ Test(nfgroup, new_and_free)
     {
         // calloc failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(calloc, NULL);
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
 
         assert_int_equal(bf_nfgroup_new(&gp), -ENOMEM);
     }
@@ -50,7 +50,7 @@ Test(nfgroup, new_from_stream)
 
     {
         // 1 Netlink message
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
         size_t nlh_len = 0;
         _cleanup_free_ struct nlmsghdr *nlh = bf_test_get_nlmsghdr(1, &nlh_len);
 
@@ -60,7 +60,7 @@ Test(nfgroup, new_from_stream)
 
     {
         // 2 Netlink messages
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
         size_t nlh_len = 0;
         _cleanup_free_ struct nlmsghdr *nlh = bf_test_get_nlmsghdr(2, &nlh_len);
 
@@ -77,7 +77,7 @@ Test(nfgroup, helpers)
 
     for (int i = 0; i < 10; ++i) {
         size_t len;
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp =
+        _free_bf_nfgroup_ struct bf_nfgroup *gp =
             bf_test_get_nfgroup(i, &len);
 
         assert_int_equal(bf_nfgroup_is_empty(gp), i == 0);
@@ -94,7 +94,7 @@ Test(nfgroup, add_new_message)
     expect_assert_failure(bf_nfgroup_add_new_message(NULL, NOT_NULL, 0, 0));
 
     {
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
 
         assert_int_equal(bf_nfgroup_new(&gp), 0);
 
@@ -108,7 +108,7 @@ Test(nfgroup, add_new_message)
     }
 
     {
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
 
         assert_int_equal(bf_nfgroup_new(&gp), 0);
 
@@ -128,8 +128,8 @@ Test(nfgroup, to_response)
     {
         // Group without any message
 
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
-        _cleanup_bf_response_ struct bf_response *res = NULL;
+        _free_bf_nfgroup_ struct bf_nfgroup *gp = NULL;
+        _free_bf_response_ struct bf_response *res = NULL;
 
         assert_int_equal(bf_nfgroup_new(&gp), 0);
         assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
@@ -142,9 +142,9 @@ Test(nfgroup, to_response)
         // Group without multiple messages
 
         size_t len;
-        _cleanup_bf_nfgroup_ struct bf_nfgroup *gp =
+        _free_bf_nfgroup_ struct bf_nfgroup *gp =
             bf_test_get_nfgroup(10, &len);
-        _cleanup_bf_response_ struct bf_response *res = NULL;
+        _free_bf_response_ struct bf_response *res = NULL;
 
         assert_int_equal(bf_nfgroup_to_response(gp, &res), 0);
         assert_non_null(res);

--- a/tests/unit/bpfilter/xlate/nft/nfmsg.c
+++ b/tests/unit/bpfilter/xlate/nft/nfmsg.c
@@ -20,7 +20,7 @@ Test(nfmsg, new_and_free)
     expect_assert_failure(bf_nfmsg_seqnr(NULL));
 
     {
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_success(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
         assert_non_null(msg);
@@ -45,7 +45,7 @@ Test(nfmsg, new_and_free)
     {
         // calloc failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(calloc, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
@@ -53,7 +53,7 @@ Test(nfmsg, new_and_free)
     {
         // nlmsg_put failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_alloc, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
@@ -61,7 +61,7 @@ Test(nfmsg, new_and_free)
     {
         // nlmsg_put failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_put, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
@@ -69,7 +69,7 @@ Test(nfmsg, new_and_free)
     {
         // nlmsg_append failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_append, -1);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new(&msg, NFT_MSG_GETRULE, 17));
     }
@@ -80,7 +80,7 @@ Test(nfmsg, new_done)
     expect_assert_failure(bf_nfmsg_new_done(NULL));
 
     {
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_success(bf_nfmsg_new_done(&msg));
         assert_non_null(msg);
@@ -89,7 +89,7 @@ Test(nfmsg, new_done)
     {
         // calloc failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(calloc, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new_done(&msg));
     }
@@ -97,7 +97,7 @@ Test(nfmsg, new_done)
     {
         // nlmsg_put failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_alloc, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new_done(&msg));
     }
@@ -105,7 +105,7 @@ Test(nfmsg, new_done)
     {
         // nlmsg_put failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_put, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new_done(&msg));
     }
@@ -113,7 +113,7 @@ Test(nfmsg, new_done)
     {
         // nlmsg_append failure
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_append, -1);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
         assert_error(bf_nfmsg_new_done(&msg));
     }
@@ -126,8 +126,8 @@ Test(nfmsg, new_from_nlmsghdr)
 
     {
         // Create a bf_nfmsg from a nlmsghdr
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
         assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
         assert_int_equal(0,
@@ -139,8 +139,8 @@ Test(nfmsg, new_from_nlmsghdr)
 
     {
         // Invalid message type
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
         assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
         bf_nfmsg_hdr(msg0)->nlmsg_type = 0;
@@ -149,24 +149,24 @@ Test(nfmsg, new_from_nlmsghdr)
 
     {
         // calloc failed
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
 
         assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
 
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(calloc, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
         assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
 
     {
         // nlmsg_convert failed
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg0 = NULL;
 
         assert_success(bf_nfmsg_new(&msg0, NFT_MSG_GETRULE, 17));
 
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(nlmsg_convert, NULL);
-        _cleanup_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
+        _free_bf_nfmsg_ struct bf_nfmsg *msg1 = NULL;
 
         assert_error(bf_nfmsg_new_from_nlmsghdr(&msg1, bf_nfmsg_hdr(msg0)));
     }
@@ -174,7 +174,7 @@ Test(nfmsg, new_from_nlmsghdr)
 
 Test(nfmsg, write_attributes)
 {
-    _cleanup_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
+    _free_bf_nfmsg_ struct bf_nfmsg *msg = NULL;
 
     const bf_nfpolicy test_policy[] = {
         [0] = {.type = NLA_U8},     [1] = {.type = NLA_U16},
@@ -196,7 +196,7 @@ Test(nfmsg, write_attributes)
     assert_success(bf_nfmsg_push_u64(msg, 3, 3));
     assert_success(bf_nfmsg_push_str(msg, 4, "4"));
     {
-        _cleanup_bf_nfnest_ struct bf_nfnest nest;
+        _clean_bf_nfnest_ struct bf_nfnest nest;
 
         assert_success(bf_nfmsg_nest_init(&nest, msg, 5));
         assert_success(bf_nfmsg_push_u8(msg, 0, 0));

--- a/tests/unit/core/list.c
+++ b/tests/unit/core/list.c
@@ -187,12 +187,12 @@ Test(list, serialize_deserialize)
     // bf_list_marsh() will be tested with actual data by the various
     // xxx_marsh() functions.
 
-    _cleanup_bf_list_ bf_list *l0 = NULL;
-    _cleanup_bf_list_ bf_list *l1 = NULL;
-    _cleanup_bf_list_ bf_list *l2 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *m0 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *m1 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *m2 = NULL;
+    _free_bf_list_ bf_list *l0 = NULL;
+    _free_bf_list_ bf_list *l1 = NULL;
+    _free_bf_list_ bf_list *l2 = NULL;
+    _free_bf_marsh_ struct bf_marsh *m0 = NULL;
+    _free_bf_marsh_ struct bf_marsh *m1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *m2 = NULL;
     struct bf_marsh *child = NULL;
     bf_list_ops free_ops = bf_list_ops_default(freep, dummy_marsh);
     bf_list_ops free_nomarsh_ops = bf_list_ops_default(freep, NULL);
@@ -366,7 +366,7 @@ Test(list, prev_next_node_access)
     expect_assert_failure(bf_list_node_prev(NULL));
 
     {
-        _cleanup_bf_list_ bf_list *l = NULL;
+        _free_bf_list_ bf_list *l = NULL;
 
         new_and_fill(&l, 0, NULL, bf_list_add_head);
 
@@ -375,7 +375,7 @@ Test(list, prev_next_node_access)
     }
 
     {
-        _cleanup_bf_list_ bf_list *l = NULL;
+        _free_bf_list_ bf_list *l = NULL;
 
         new_and_fill(&l, 1, NULL, bf_list_add_head);
 
@@ -385,7 +385,7 @@ Test(list, prev_next_node_access)
     }
 
     {
-        _cleanup_bf_list_ bf_list *l = NULL;
+        _free_bf_list_ bf_list *l = NULL;
 
         new_and_fill(&l, 2, NULL, bf_list_add_head);
 
@@ -402,7 +402,7 @@ Test(list, node_take_data)
     bf_list_ops free_ops = bf_list_ops_default(freep, NULL);
 
     {
-        _cleanup_bf_list_ bf_list *l = NULL;
+        _free_bf_list_ bf_list *l = NULL;
 
         new_and_fill(&l, 5, &free_ops, dummy_filler_tail);
 

--- a/tests/unit/core/marsh.c
+++ b/tests/unit/core/marsh.c
@@ -12,12 +12,12 @@ Test(marsh, new)
 {
     {
         // Call bf_marsh_free() with NULL marsh.
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     }
 
     {
         // Create a new empty marsh.
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
         assert_int_equal(0, marsh->data_len);
@@ -27,7 +27,7 @@ Test(marsh, new)
     {
         // Create a new marsh with data but size 0.
         int a = 3;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, &a, 0));
         assert_int_equal(0, marsh->data_len);
@@ -37,7 +37,7 @@ Test(marsh, new)
     {
         // Create a new marsh with data.
         int a = 3;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, &a, sizeof(a)));
         assert_int_equal(sizeof(a), marsh->data_len);
@@ -53,7 +53,7 @@ Test(marsh, new_failure)
     expect_assert_failure(bf_marsh_new(NOT_NULL, NULL, 1));
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_get(malloc, NULL);
 
         assert_true(bf_marsh_new(NOT_NULL, NULL, 0) < 0);
@@ -62,9 +62,9 @@ Test(marsh, new_failure)
 
 Test(marsh, add_child_obj)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *child0 = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *child1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *child0 = NULL;
+    _free_bf_marsh_ struct bf_marsh *child1 = NULL;
 
     assert_success(bf_marsh_new(&marsh, NULL, 0));
     assert_success(bf_marsh_new(&child0, NULL, 0));
@@ -83,7 +83,7 @@ Test(marsh, add_child_obj)
 
 Test(marsh, add_child_raw)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
     struct bf_marsh *child0;
     struct bf_marsh *child1;
     struct bf_marsh *child2;
@@ -123,7 +123,7 @@ Test(marsh, next_child)
 {
     {
         // Empty marsh.
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
         assert_null(bf_marsh_next_child(marsh, NULL));
@@ -131,7 +131,7 @@ Test(marsh, next_child)
 
     {
         // Access all childs
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child;
         const char *str = "hello, world";
 
@@ -146,7 +146,7 @@ Test(marsh, next_child)
 
     {
         // Modify childs
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child0;
         struct bf_marsh *child1;
         const char *str = "hello, world";
@@ -179,7 +179,7 @@ Test(marsh, child_assert_failure)
     {
         // bf_marsh_add_child_obj() will call assert() on *marsh, so we need to
         // have a valid marsh.
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
         expect_assert_failure(bf_marsh_add_child_obj(&marsh, NULL));
@@ -188,7 +188,7 @@ Test(marsh, child_assert_failure)
     {
         // bf_marsh_add_child_raw() will call assert() on *marsh, so we need to
         // have a valid marsh.
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
         expect_assert_failure(bf_marsh_add_child_raw(&marsh, NULL, 1));
@@ -198,7 +198,7 @@ Test(marsh, child_assert_failure)
 Test(marsh, child_is_valid)
 {
     {
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child0;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
@@ -223,7 +223,7 @@ Test(marsh, child_is_valid)
     }
 
     {
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         struct bf_marsh *child0;
 
         assert_success(bf_marsh_new(&marsh, NULL, 0));
@@ -236,8 +236,8 @@ Test(marsh, child_is_valid)
 
 Test(marsh, add_child_obj_failure)
 {
-    _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
-    _cleanup_bf_marsh_ struct bf_marsh *child = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+    _free_bf_marsh_ struct bf_marsh *child = NULL;
 
     assert_success(bf_marsh_new(&marsh, NULL, 0));
     assert_success(bf_marsh_new(&child, NULL, 0));

--- a/tests/unit/core/matcher.c
+++ b/tests/unit/core/matcher.c
@@ -19,7 +19,7 @@ Test(matcher, new_and_free)
 
     // New, free, new again, then cleanup
     {
-        _cleanup_bf_matcher_ struct bf_matcher *matcher = NULL;
+        _free_bf_matcher_ struct bf_matcher *matcher = NULL;
 
         assert_success(bf_matcher_new(&matcher, 0, 0, NULL, 0));
         bf_matcher_free(&matcher);
@@ -58,9 +58,9 @@ Test(matcher, marsh_unmarsh)
 
     // All good
     {
-        _cleanup_bf_matcher_ struct bf_matcher *matcher0 = NULL;
-        _cleanup_bf_matcher_ struct bf_matcher *matcher1 = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_matcher_ struct bf_matcher *matcher0 = NULL;
+        _free_bf_matcher_ struct bf_matcher *matcher1 = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_int_equal(
             0, bf_matcher_new(&matcher0, 1, 2, payload, sizeof(payload)));
@@ -70,8 +70,8 @@ Test(matcher, marsh_unmarsh)
 
     // Failed serialisation
     {
-        _cleanup_bf_matcher_ struct bf_matcher *matcher0 = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_matcher_ struct bf_matcher *matcher0 = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_int_equal(
             0, bf_matcher_new(&matcher0, 1, 2, payload, sizeof(payload)));
@@ -82,8 +82,8 @@ Test(matcher, marsh_unmarsh)
 
     // Failed deserialisation
     {
-        _cleanup_bf_matcher_ struct bf_matcher *matcher0 = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_matcher_ struct bf_matcher *matcher0 = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
         // No cleanup, it's not supposed to be allocated
         struct bf_matcher *matcher1 = NULL;
 

--- a/tests/unit/core/rule.c
+++ b/tests/unit/core/rule.c
@@ -17,7 +17,7 @@ Test(rule, new_and_free)
 
     // New, free, new again, then cleanup
     {
-        _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+        _free_bf_rule_ struct bf_rule *rule = NULL;
 
         assert_success(bf_rule_new(&rule));
         bf_rule_free(&rule);
@@ -45,9 +45,9 @@ Test(rule, marsh_unmarsh)
 
     // All good
     {
-        _cleanup_bf_rule_ struct bf_rule *rule0 = bf_test_get_rule(10);
-        _cleanup_bf_rule_ struct bf_rule *rule1 = NULL;
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_rule_ struct bf_rule *rule0 = bf_test_get_rule(10);
+        _free_bf_rule_ struct bf_rule *rule1 = NULL;
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_non_null(rule0);
         assert_int_equal(0, bf_rule_marsh(rule0, &marsh));
@@ -62,8 +62,8 @@ Test(rule, marsh_unmarsh)
 
     // Failed serialisation
     {
-        _cleanup_bf_rule_ struct bf_rule *rule = bf_test_get_rule(10);
-        _cleanup_bf_marsh_ struct bf_marsh *marsh = NULL;
+        _free_bf_rule_ struct bf_rule *rule = bf_test_get_rule(10);
+        _free_bf_marsh_ struct bf_marsh *marsh = NULL;
 
         assert_non_null(rule);
 

--- a/tests/unit/fake.c
+++ b/tests/unit/fake.c
@@ -102,7 +102,7 @@ struct nlmsghdr *bf_test_get_nlmsghdr(size_t nmsg, size_t *len)
 
 struct bf_nfgroup *bf_test_get_nfgroup(size_t nmsg, size_t *len)
 {
-    _cleanup_bf_nfgroup_ struct bf_nfgroup *group = NULL;
+    _free_bf_nfgroup_ struct bf_nfgroup *group = NULL;
     _cleanup_free_ struct nlmsghdr *nlh = NULL;
 
     nlh = bf_test_get_nlmsghdr(nmsg, len);
@@ -115,7 +115,7 @@ struct bf_nfgroup *bf_test_get_nfgroup(size_t nmsg, size_t *len)
 
 struct bf_rule *bf_test_get_rule(size_t nmatchers)
 {
-    _cleanup_bf_rule_ struct bf_rule *rule = NULL;
+    _free_bf_rule_ struct bf_rule *rule = NULL;
 
     assert_int_equal(0, bf_rule_new(&rule));
 


### PR DESCRIPTION
Originally, the cleanup macros were named as `_cleanup_$STRUCT_NAME_` to free the dynamically allocated structures, and `_clean_$STRUCT_NAME_` for the stack-allocate ones. Eventually, `_free_$STRUCT_NAME_` has been used for the dynamically allocated objects, leaving 3 different macro naming scheme in the codebase for 2 use cases.

Rename all the `_cleanup_*` macros into `_free_*` for consistency. Ensure the `_clean_*` macros always refer to allocated objects, so the cleanup doesn't access uninitialized data.