### PR TITLE
Add missing copyright header to doc/benchmarks.html.template

### DIFF
--- a/doc/benchmarks.html.template
+++ b/doc/benchmarks.html.template
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Meta Platforms, Inc. and affiliates. -->
+
 <!DOCTYPE html>
 <html lang="en">
 


### PR DESCRIPTION
Let's get Meta's copyright bot off my back.