### PR TITLE
Only declare `__start_bf_test` and `__stop_bf_test` in the test binaries, not the test harness

### DIFF
--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -846,6 +846,8 @@ Test(meta, dport_range)
 int main(int argc, char *argv[])
 {
     _free_bf_test_suite_ bf_test_suite *suite = NULL;
+    extern bf_test __start_bf_test;
+    extern bf_test __stop_bf_test;
     int failed = 0;
     int r;
 
@@ -853,7 +855,7 @@ int main(int argc, char *argv[])
     if (r)
         return r;
 
-    r = bf_test_discover_test_suite(&suite);
+    r = bf_test_discover_test_suite(&suite, &__start_bf_test, &__stop_bf_test);
     if (r < 0)
         return bf_err_r(r, "test suite discovery failed");
 

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -211,10 +211,7 @@ int bf_test_suite_add_test(bf_test_suite *suite, const char *group_name,
     return 0;
 }
 
-extern bf_test __start_bf_test;
-extern bf_test __stop_bf_test;
-
-int bf_test_discover_test_suite(bf_test_suite **suite)
+int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests, void *sentinel)
 {
     _free_bf_list_ bf_list *symbols = NULL;
     _free_bf_test_suite_ bf_test_suite *_suite = NULL;
@@ -227,7 +224,7 @@ int bf_test_discover_test_suite(bf_test_suite **suite)
     if (r < 0)
         return bf_err_r(r, "failed to create a bf_test_suite object");
 
-    for (test = &__start_bf_test; test < &__stop_bf_test; ++test) {
+    for (test = tests; test < (bf_test *)sentinel; ++test) {
         r = bf_test_suite_add_test(_suite, test->group_name, test);
         if (r)
             return r;

--- a/tests/harness/test.h
+++ b/tests/harness/test.h
@@ -147,14 +147,17 @@ int bf_test_suite_make_cmtests(const bf_test_suite *suite);
 /**
  * Discover the test suite in the current ELF file.
  *
- * Parse the sections in the current ELF file to discover the symbols in the
- * `.bf_test` section and create the associated test suite.
+ * Read all the tests stores in `tests` and add them to the suite.
  *
  * @param suite Discovered test suite. Can't be `NULL`. On success, this
  *        argument will be point to a valid test suite.
+ * @param tests Tests to process. Usually from the `bf_test` section of the
+ *        ELF file. Can't be NULL.
+ * @param sentinel First address after the last test. Used to detect when the
+ *        tests section ends. Can't be NULL.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_test_discover_test_suite(bf_test_suite **suite);
+int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests, void *sentinel);
 
 /**
  * A filter to apply to the tests to run.

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -91,6 +91,8 @@ int main(int argc, char *argv[])
 {
     _free_bf_test_suite_ bf_test_suite *suite = NULL;
     _free_bf_test_opts_ bf_test_opts *opts = NULL;
+    extern bf_test __start_bf_test;
+    extern bf_test __stop_bf_test;
     int failed = 0;
     char *bf_opts[] = {
         argv[0],
@@ -109,7 +111,7 @@ int main(int argc, char *argv[])
     if (r)
         return bf_err_r(r, "failed to enable transient mode for unit tests");
 
-    r = bf_test_discover_test_suite(&suite);
+    r = bf_test_discover_test_suite(&suite, &__start_bf_test, &__stop_bf_test);
     if (r < 0)
         return bf_err_r(r, "test suite discovery failed");
 


### PR DESCRIPTION
`__start_bf_test` and `__end_bf_test` are symbols defined at the beginning and end of the `bf_test` section, used to store the tests definition. Some compiler options (e.g. clang's `start-stop-gc`) will discard the `bf_test` section if it doesn't contain any code, triggering a build failure as the `__start` and `__stop` symbols are not defined.

To prevent this error, the `__start_bf_test` and `__stop_bf_test` symbols are not defined in harness anymore, but in the binary defining the tests, their address is passed to the test discovery function as a parameter.