### PR TITLE
Fix unset rule index

### DIFF
--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -461,15 +461,22 @@ int bf_cgen_get_counters(const struct bf_cgen *cgen, bf_list *counters)
 
     bf_assert(cgen && counters);
 
-    for (ssize_t i = BF_COUNTER_POLICY;
-         i < (ssize_t)bf_list_size(&cgen->chain->rules); ++i) {
+    /* Iterate over all the rules, then the policy counter (size(rules)) and
+     * the errors counters (sizeof(rules) + 1)*/
+    for (size_t i = 0; i < bf_list_size(&cgen->chain->rules) + 2; ++i) {
         _free_bf_counter_ struct bf_counter *counter = NULL;
+        ssize_t idx = (ssize_t)i;
+
+        if (i == bf_list_size(&cgen->chain->rules))
+            idx = BF_COUNTER_POLICY;
+        else if (i == bf_list_size(&cgen->chain->rules) + 1)
+            idx = BF_COUNTER_ERRORS;
 
         r = bf_counter_new(&counter, 0, 0);
         if (r)
             return r;
 
-        r = bf_cgen_get_counter(cgen, i, counter);
+        r = bf_cgen_get_counter(cgen, idx, counter);
         if (r)
             return r;
 

--- a/src/core/chain.c
+++ b/src/core/chain.c
@@ -23,7 +23,9 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
                  enum bf_verdict policy, bf_list *sets, bf_list *rules)
 {
     _free_bf_chain_ struct bf_chain *_chain = NULL;
+    size_t ridx = 0;
 
+    bf_assert(chain && name);
     bf_assert(policy < _BF_TERMINAL_VERDICT_MAX);
 
     _chain = malloc(sizeof(*_chain));
@@ -44,6 +46,8 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
     _chain->rules = bf_list_default(bf_rule_free, bf_rule_marsh);
     if (rules)
         _chain->rules = bf_list_move(*rules);
+    bf_list_foreach (&_chain->rules, rule_node)
+        ((struct bf_rule *)bf_list_node_get_data(rule_node))->index = ridx++;
 
     *chain = TAKE_PTR(_chain);
 
@@ -112,7 +116,7 @@ int bf_chain_new_from_marsh(struct bf_chain **chain,
         if (r)
             return r;
 
-        r = bf_list_add_tail(&_chain->rules, rule);
+        r = bf_chain_add_rule(_chain, rule);
         if (r)
             return r;
 

--- a/tests/e2e/e2e.h
+++ b/tests/e2e/e2e.h
@@ -5,9 +5,36 @@
 
 #pragma once
 
+#include <limits.h>
+#include <stddef.h>
+
 #include "core/chain.h"
+#include "core/counter.h"
 #include "core/verdict.h"
 #include "packets.h"
 
+#define BFT_NO_PKTS SIZE_MAX
+#define BFT_NO_BYTES SIZE_MAX
+
+struct bft_counter
+{
+    size_t index;
+    struct bf_counter counter;
+};
+
+#define bft_counter_p(idx, npkts, nbytes)                                      \
+    (struct bft_counter []) {                                                  \
+        {                                                                      \
+            .index = (idx),                                                    \
+            .counter = {                                                       \
+                .packets = (npkts),                                            \
+                .bytes = (nbytes),                                             \
+            },                                                                 \
+        }                                                                      \
+    }
+
+int bft_e2e_test_with_counter(struct bf_chain *chain, enum bf_verdict expect,
+                              const struct bft_prog_run_args *args,
+                              const struct bft_counter *counter);
 int bft_e2e_test(struct bf_chain *chain, enum bf_verdict expect,
                  const struct bft_prog_run_args *args);

--- a/tests/harness/filters.h
+++ b/tests/harness/filters.h
@@ -32,6 +32,31 @@
 
 #define BF_E2E_NAME "bf_e2e"
 
+#define bft_fake_matchers                                                      \
+    (struct bf_matcher *[])                                                    \
+    {                                                                          \
+        bf_matcher_get(                                                        \
+            BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
+            (uint8_t[]) {0x7d, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+        bf_matcher_get(                                                        \
+            BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
+            (uint8_t[]) {0x7e, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+        bf_matcher_get(                                                        \
+            BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
+            (uint8_t[]) {0x7f, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+        NULL,                                                                  \
+    }
+
+#define bft_fake_rules                                                         \
+    (struct bf_rule *[])                                                       \
+    {                                                                          \
+        bf_rule_get(true, BF_VERDICT_ACCEPT, bft_fake_matchers),               \
+        bf_rule_get(false, BF_VERDICT_ACCEPT, bft_fake_matchers),              \
+        bf_rule_get(true, BF_VERDICT_DROP, bft_fake_matchers),                 \
+        bf_rule_get(false, BF_VERDICT_DROP, bft_fake_matchers),                \
+        NULL,                                                                  \
+    }
+
 /**
  * Create a new hook options object.
  *

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -82,6 +82,7 @@ enable_testing()
 
 set(bf_test_srcs
     core/btf.c
+    core/chain.c
     core/flavor.c
     core/front.c
     core/helper.c

--- a/tests/unit/core/chain.c
+++ b/tests/unit/core/chain.c
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "core/chain.c"
+
+#include "harness/filters.h"
+#include "harness/test.h"
+#include "mock.h"
+
+Test(chain, new_free_assert_failure)
+{
+    expect_assert_failure(bf_chain_new(NULL, NOT_NULL, 0, 0, NULL, NULL));
+    expect_assert_failure(bf_chain_new(NOT_NULL, NULL, 0, 0, NULL, NULL));
+    expect_assert_failure(bf_chain_new(NOT_NULL, NOT_NULL, 0, _BF_TERMINAL_VERDICT_MAX + 1, NULL, NULL));
+
+    expect_assert_failure(bf_chain_free(NULL));
+}
+
+Test(chain, new_free)
+{
+    _free_bf_chain_ struct bf_chain *chain = NULL;
+    _clean_bf_list_ bf_list rules = bf_list_default(bf_rule_free, NULL);
+    size_t i;
+
+    assert_success(bf_chain_new(&chain, "name", 0, 0, NULL, NULL));
+    bf_chain_free(&chain);
+    assert_null(chain);
+
+    assert_success(bf_list_add_tail(&rules, bf_rule_get(false, 0, bft_fake_matchers)));
+    assert_success(bf_list_add_tail(&rules, bf_rule_get(false, 0, bft_fake_matchers)));
+
+    i = 0;
+    assert_success(bf_chain_new(&chain, "name", 0, 0, NULL, &rules));
+    bf_list_foreach (&chain->rules, rule_node) {
+        assert_int_equal(i++, ((struct bf_rule *)(bf_list_node_get_data(rule_node)))->index);
+    }
+}
+
+#include "core/dump.h"
+
+Test(chain, marsh_unmarsh)
+{
+    _free_bf_chain_ struct bf_chain *chain0 = NULL;
+    _free_bf_chain_ struct bf_chain *chain1 = NULL;
+    _free_bf_marsh_ struct bf_marsh *marsh = NULL;
+
+    assert_non_null(chain0 = bf_test_chain_get(0, 0, NULL, bft_fake_rules));
+
+    assert_success(bf_chain_marsh(chain0, &marsh));
+    assert_success(bf_chain_new_from_marsh(&chain1, marsh));
+
+    assert_int_equal(bf_list_size(&chain0->rules), bf_list_size(&chain1->rules));
+    assert_int_equal(bf_list_size(&chain0->sets), bf_list_size(&chain1->sets));
+
+    {
+        struct bf_list_node *n0 = bf_list_get_head(&chain0->rules);
+        struct bf_list_node *n1 = bf_list_get_head(&chain1->rules);
+
+        while (n0) {
+            assert_int_equal(((struct bf_rule *)(bf_list_node_get_data(n0)))->index,
+                             ((struct bf_rule *)(bf_list_node_get_data(n1)))->index);
+            n0 = bf_list_node_next(n0);
+            n1 = bf_list_node_next(n1);
+        }
+    }
+}


### PR DESCRIPTION
Set `rule->index` in `bf_chain_new()` and `bf_chain_new_from_marsh()`, otherwise the rules used in a program could have any index (valid or not), leading to counter issues.