### PR TITLE
Disable ASLR during benchmarks

### DIFF
--- a/tools/benchmarks/benchmark.hpp
+++ b/tools/benchmarks/benchmark.hpp
@@ -91,6 +91,7 @@ public:
 
 extern Config config;
 
+int disableASLR(char **argv);
 int setup(std::span<char *> args);
 void restorePermissions(::std::string outfile);
 

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -101,6 +101,9 @@ int main(int argc, char *argv[])
         return -EPERM;
     }
 
+    if (::bf::disableASLR(argv) < 0)
+        return -1;
+
     if (::bf::setup(std::span<char *>(argv, argc)) < 0)
         return -1;
 


### PR DESCRIPTION
Disable ASLR when running the benchmark to avoid unreproducible noise. See https://google.github.io/benchmark/reducing_variance.html