### PR TITLE
Use a consistent naming scheme for libbpfilter's symbols

### DIFF
--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -32,7 +32,7 @@ int bfc_ruleset_set(const struct bfc_opts *opts)
     if (r)
         bf_err_r(r, "failed to parse ruleset");
 
-    r = bf_cli_ruleset_set(&ruleset.chains, &ruleset.hookopts);
+    r = bf_ruleset_set(&ruleset.chains, &ruleset.hookopts);
     if (r)
         bf_err_r(r, "failed to set ruleset");
 
@@ -48,7 +48,7 @@ int bfc_ruleset_get(const struct bfc_opts *opts)
     _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
     int r;
 
-    r = bf_cli_ruleset_get(&chains, &hookopts, &counters);
+    r = bf_ruleset_get(&chains, &hookopts, &counters);
     if (r < 0)
         return bf_err_r(r, "failed to request ruleset");
 
@@ -63,5 +63,5 @@ int bfc_ruleset_flush(const struct bfc_opts *opts)
 {
     UNUSED(opts);
 
-    return bf_cli_ruleset_flush();
+    return bf_ruleset_flush();
 }

--- a/src/libbpfilter/bpfilter.h
+++ b/src/libbpfilter/bpfilter.h
@@ -29,7 +29,7 @@ const char *bf_version(void);
  *
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_cli_ruleset_flush(void);
+int bf_ruleset_flush(void);
 
 #define bf_list void
 
@@ -42,7 +42,7 @@ int bf_cli_ruleset_flush(void);
  * @param counters List of bf_counter type to be filled.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters);
+int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters);
 
 /**
  * Load a complete ruleset.
@@ -59,7 +59,7 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters);
  *        NULL.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_cli_ruleset_set(bf_list *chains, bf_list *hookopts);
+int bf_ruleset_set(bf_list *chains, bf_list *hookopts);
 
 /**
  * Set a chain.

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -20,7 +20,7 @@
 #include "core/rule.h"
 #include "libbpfilter/generic.h"
 
-int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
+int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
 {
     _free_bf_request_ struct bf_request *request = NULL;
     _free_bf_response_ struct bf_response *response = NULL;
@@ -127,7 +127,7 @@ int bf_cli_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
     return 0;
 }
 
-int bf_cli_ruleset_flush(void)
+int bf_ruleset_flush(void)
 {
     _free_bf_request_ struct bf_request *request = NULL;
     _free_bf_response_ struct bf_response *response = NULL;
@@ -147,7 +147,7 @@ int bf_cli_ruleset_flush(void)
     return response->type == BF_RES_FAILURE ? response->error : 0;
 }
 
-int bf_cli_ruleset_set(bf_list *chains, bf_list *hookopts)
+int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
 {
     _free_bf_request_ struct bf_request *request = NULL;
     _free_bf_response_ struct bf_response *response = NULL;

--- a/tests/e2e/e2e.c
+++ b/tests/e2e/e2e.c
@@ -103,7 +103,7 @@ static int _bft_e2e_test_with_counter(struct bf_chain *chain,
             break;
         }
 
-        bf_cli_ruleset_flush();
+        bf_ruleset_flush();
 
         if (_bf_tests_meta[flavor].verdicts[expect] != test_ret) {
             print_error("%sERROR: %s: BPF_PROG_RUN returned %d, expecting %d\n",

--- a/tests/harness/prog.c
+++ b/tests/harness/prog.c
@@ -44,7 +44,7 @@ struct bf_test_prog *bf_test_prog_get(struct bf_chain *chain)
         return NULL;
     }
 
-    r = bf_cli_ruleset_set(&chains, &hooks);
+    r = bf_ruleset_set(&chains, &hooks);
     if (r < 0) {
         bf_err_r(r, "failed to create a new chain");
         return NULL;


### PR DESCRIPTION
Before chains can be manipulated by bfcli, libbpfilter's functions were named such as `bf_cli_*` as they were dedicated to the CLI. It's not true another, as they can be used by external programs.

Rename `bf_cli_*` function to `bf_*` instead, so the naming is consistent across the library.