### PR TITLE
Dynamically compute `YY_READ_BUF_SIZE` to reduce time spent parsing large chains

### DIFF
--- a/src/bfcli/CMakeLists.txt
+++ b/src/bfcli/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(bfcli
 target_compile_definitions(bfcli
     PRIVATE
         BF_CONTACT="${BF_CONTACT}"
+        "YY_READ_BUF_SIZE=(yy_read_buf_size)"
 )
 
 target_include_directories(bfcli

--- a/src/bfcli/helper.c
+++ b/src/bfcli/helper.c
@@ -8,15 +8,41 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <sys/stat.h>
 
 #include "bfcli/lexer.h"
 #include "bfcli/parser.h"
 #include "core/logger.h"
 
+// To speed up parsing very large rulesets, we can increase YY_READ_BUF_SIZE
+int yy_read_buf_size;
+
+#define _BF_LEX_MIN_BUF_POW 14
+#define _BF_LEX_MAX_BUF_POW 20
+
+static int _bf_compute_lexer_buf_size(size_t len)
+{
+    int val = _BF_LEX_MIN_BUF_POW;
+
+    if (len) {
+        val = (int)sizeof(len) * 8 - __builtin_clzl(len);
+        val = bf_min(bf_max(val - 3, _BF_LEX_MIN_BUF_POW), _BF_LEX_MAX_BUF_POW);
+    }
+
+    return 1 << val;
+}
+
 int bfc_parse_file(const char *file, struct bfc_ruleset *ruleset)
 {
     FILE *rules;
+    struct stat stt;
     int r;
+
+    if (stat(file, &stt) == -1)
+        return bf_err_r(errno, "failed to stat file %s:", file);
+
+    yy_read_buf_size = _bf_compute_lexer_buf_size(stt.st_size);
+    bf_dbg("yy_read_buf_size choosen is %d", yy_read_buf_size);
 
     rules = fopen(file, "r");
     if (!rules)
@@ -36,7 +62,12 @@ int bfc_parse_file(const char *file, struct bfc_ruleset *ruleset)
 int bfc_parse_str(const char *str, struct bfc_ruleset *ruleset)
 {
     YY_BUFFER_STATE buffer;
+    unsigned long str_size;
     int r;
+
+    str_size = strlen(str);
+    yy_read_buf_size = _bf_compute_lexer_buf_size(str_size);
+    bf_dbg("yy_read_buf_size choosen is %d", yy_read_buf_size);
 
     buffer = yy_scan_string(str);
 

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -11,6 +11,8 @@
     #include "core/verdict.h"
     #include "core/hook.h"
     #include "core/matcher.h"
+
+    extern int yy_read_buf_size;
 %}
 
 %option noyywrap

--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -194,6 +194,13 @@ extern const char *strerrordesc_np(int errnum);
         _a < _b ? _a : _b;                                                     \
     })
 
+#define bf_max(a, b)                                                           \
+    ({                                                                         \
+        __typeof__(a) _a = (a);                                                \
+        __typeof__(b) _b = (b);                                                \
+        _a > _b ? _a : _b;                                                     \
+    })
+
 /**
  * Free a pointer and set it to NULL.
  *

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -30,6 +30,8 @@ void loadChainLargeSet(::benchmark::State &state)
 BENCHMARK(loadChainLargeSet)
     ->Arg(10000)
     ->Arg(100000)
+    ->Arg(200000)
+    ->Arg(500000)
     ->Iterations(10)
     ->Unit(benchmark::kMillisecond);
 


### PR DESCRIPTION
Fix #257 

We noticed that loading large rulesets in bfcli took a long time, and after tracking it down, the solution to increase the `YY_READ_BUF_SIZE` was found.
Since we can't modify it directly, we use a compiler definition in `src/bfcli/CMakeLists.txt` to make it refer to a global variable that we can manipulate easily.

The current implementation of `compute_buf_size()` is extrapolated through tries and the [graph](https://github.com/facebook/bpfilter/issues/257#issuecomment-2891493844), it's implementation is heuristic and could be improved in the future.
Also we *could* add a lower/upper bound on the buffer size, but I don't know how useful that is.

The `build/bfcli/generated/bfcli/lexer.c` mention that "`YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case`".
But the code it's used in doesn't seems to care if that's not a case, and I didn't face any performance change when increasing this buffer, so I didn't touched it.

Not sure if this was the best approach, but seems pretty good nonetheless.