### PR TITLE
Quality of life improvements following Liz Rice's feedback

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -13,6 +13,8 @@ Commands
 
 Define a new ruleset: replace all the existing chains with the ruleset provided. Replacement is not atomic.
 
+Chains with valid hook options defined are attached to their hook. Chains without hook options are only loaded into the kernel.
+
 **Options**
   - ``--from-str RULESET``: read and apply the ruleset defining from the command line.
   - ``--from-file FILE``: read ``FILE`` and apply the ruleset contained in it.

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -63,9 +63,10 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
         return;
     }
 
+    // Last counter is the error counter, the chain counter is second to last
     counter_node = bf_list_get_head(counters);
-    policy_counter_node = bf_list_get_tail(counters);
-    err_counter_node = bf_list_node_prev(policy_counter_node);
+    err_counter_node = bf_list_get_tail(counters);
+    policy_counter_node = bf_list_node_prev(err_counter_node);
 
     (void)fprintf(stdout, "chain %s %s", chain->name,
                   bf_hook_to_str(chain->hook));

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -315,8 +315,7 @@ static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
         break;
     case BF_MAP_TYPE_PRINTER:
     case BF_MAP_TYPE_SET:
-        bf_warn("bf_map type %s is not yet supported",
-                _bf_map_type_to_str(map->type));
+        // No BTF data available for this map types
         return NULL;
     default:
         bf_err_r(-ENOTSUP, "bf_map type %d is not supported", map->type);

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -301,11 +301,6 @@ struct bf_program
     /// Link objects attaching the program to a hook.
     struct bf_link *link;
 
-    /** Number of counters in the counters map. Not all of them are used by
-     * the program, but this value is common for all the programs of a given
-     * codegen. */
-    size_t num_counters;
-
     /* Bytecode */
     uint32_t functions_location[_BF_FIXUP_FUNC_MAX];
     struct bpf_insn *img;
@@ -431,3 +426,6 @@ int bf_program_get_counter(const struct bf_program *program,
                            uint32_t counter_idx, struct bf_counter *counter);
 int bf_program_set_counters(struct bf_program *program,
                             const struct bf_counter *counters);
+
+size_t bf_program_chain_counter_idx(const struct bf_program *program);
+size_t bf_program_error_counter_idx(const struct bf_program *program);

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -59,7 +59,8 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
 
         // Update the error counter
-        EMIT(program, BPF_MOV32_IMM(BPF_REG_1, program->num_counters - 1));
+        EMIT(program,
+             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
                                   BF_PROG_CTX_OFF(pkt_size)));
         EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
@@ -109,7 +110,8 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
-        EMIT(program, BPF_MOV32_IMM(BPF_REG_1, program->num_counters - 1));
+        EMIT(program,
+             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
                                   BF_PROG_CTX_OFF(pkt_size)));
         EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
@@ -179,7 +181,8 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
-        EMIT(program, BPF_MOV32_IMM(BPF_REG_1, program->num_counters - 1));
+        EMIT(program,
+             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
                                   BF_PROG_CTX_OFF(pkt_size)));
         EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
@@ -277,7 +280,8 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
-        EMIT(program, BPF_MOV32_IMM(BPF_REG_1, program->num_counters - 1));
+        EMIT(program,
+             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
                                   BF_PROG_CTX_OFF(pkt_size)));
         EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);


### PR DESCRIPTION
A few QoL improvements:
- Remove the confusing warning if BTF data for a given map type are not available
- Use consistent counter index for policy and error counter in bpfilter and bfcli
- Clarify the behaviour of `ruleset set` if a chain doesn't have hook options

Thanks to @lizrice !