### PR TITLE
Sort commit benchmark results according to the Git history order

### DIFF
--- a/doc/benchreport
+++ b/doc/benchreport
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-import dateutil.parser
-import pathlib
-import json
-import git
-import sys
-import os
 import argparse
+import git
+import json
+import pathlib
+import sys
+import time
+from typing import List
 
 VERBOSE: bool = False
 
@@ -24,6 +24,27 @@ def warning(msg: str) -> None:
 
 def error(msg: str) -> None:
     print("\033[1;31m" + msg + "\033[0m")
+
+
+def sort_commits_by_tree_order(repo: git.Repo, commit_hashes: List[str]) -> List[str]:
+    target_hashes = set(commit_hashes)
+    ordered_commits = list(
+        repo.iter_commits(rev="HEAD", topo_order=True, reverse=False)
+    )
+
+    # Build position mapping for target commits
+    commit_positions = {}
+    for idx, commit in enumerate(ordered_commits):
+        commit_hash = commit.hexsha
+        if commit_hash in target_hashes:
+            commit_positions[commit_hash] = idx
+
+    # Sort input hashes by their topological position
+    # Handle missing commits by putting them at the end
+    def sort_key(commit_hash: str) -> int:
+        return commit_positions.get(commit_hash, len(ordered_commits))
+
+    return sorted(commit_hashes, key=sort_key)
 
 
 def main() -> None:
@@ -62,9 +83,7 @@ def main() -> None:
             d = json.load(f)
 
             gitrev = d["context"]["gitrev"]
-            gitdate = d["context"]["gitdate"]
-            benchdate = dateutil.parser.isoparse(d["context"]["date"])
-            commits.append((gitrev, gitdate, benchdate))
+            commits.append(gitrev)
 
             for bench in d["benchmarks"]:
                 benchNames.append(bench["name"])
@@ -81,12 +100,15 @@ def main() -> None:
                     benchmarks["results"][bench["name"]][gitrev]["nInsn"] = nInsn
 
     repo = git.Repo.init(args.sources)
+    commits = sort_commits_by_tree_order(repo, commits)
 
-    for commit, date, _ in sorted(commits, key=lambda tup: tup[2]):
+    for commit in commits:
         try:
             message = repo.commit(commit).message
+            date = repo.commit(commit).committed_date
         except:
             message = "<Not committed yet>"
+            date = int(time.time())
 
         benchmarks["commits"].append(
             {


### PR DESCRIPTION
When generating the benchmark report, we expect the results to be displayed in the order their commit appear in the Git tree.

Update benchreport to sort the benchmarked commits according to the tree order.