### PR TITLE
cli,daemon: add support for icmpv6.type and icmpv6.code

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -531,3 +531,55 @@ UDP
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
+
+ICMP
+####
+
+.. flat-table::
+    :header-rows: 1
+    :widths: 2 2 1 4 12
+    :fill-cells:
+
+    * - Matches
+      - Type
+      - Operator
+      - Payload
+      - Notes
+    * - :rspan:`1` Type
+      - :rspan:`1` ``icmp.type``
+      - ``eq``
+      - :rspan:`1` ``$ICMP_TYPE``
+      - :rspan:`1` ``$ICMP_TYPE`` is a valid ICMP message type as a decimal integer.
+    * - ``not``
+    * - :rspan:`1` Code
+      - :rspan:`1` ``icmp.code``
+      - ``eq``
+      - :rspan:`1` ``$ICMP_CODE``
+      - :rspan:`1` ``$ICMP_CODE`` is a valid ICMP message code as a decimal integer.
+    * - ``not``
+
+ICMPv6
+######
+
+.. flat-table::
+    :header-rows: 1
+    :widths: 2 2 1 4 12
+    :fill-cells:
+
+    * - Matches
+      - Type
+      - Operator
+      - Payload
+      - Notes
+    * - :rspan:`1` Type
+      - :rspan:`1` ``icmpv6.type``
+      - ``eq``
+      - :rspan:`1` ``$ICMPV6_TYPE``
+      - :rspan:`1` ``$ICMPV6_TYPE`` is a valid ICMPv6 message type as a decimal integer.
+    * - ``not``
+    * - :rspan:`1` Code
+      - :rspan:`1` ``icmpv6.code``
+      - ``eq``
+      - :rspan:`1` ``$ICMPV6_CODE``
+      - :rspan:`1` ``$ICMPV6_CODE`` is a valid ICMPv6 message code as a decimal integer.
+    * - ``not``

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -131,7 +131,7 @@ udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); retur
     }
 }
 
-icmp\.(code|type) { BEGIN(STATE_MATCHER_ICMP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+icmp(v6)?\.(code|type) { BEGIN(STATE_MATCHER_ICMP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_ICMP>{
     (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     (\!)?[0-9]+ {

--- a/src/bpfilter/cgen/matcher/icmp.c
+++ b/src/bpfilter/cgen/matcher/icmp.c
@@ -5,6 +5,7 @@
 
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
+#include <linux/icmpv6.h>
 
 #include <errno.h>
 
@@ -12,12 +13,10 @@
 #include "core/matcher.h"
 
 static int _bf_matcher_generate_icmp_fields(struct bf_program *program,
-                                            const struct bf_matcher *matcher)
+                                            const struct bf_matcher *matcher,
+                                            const size_t offset)
 {
     const uint8_t value = matcher->payload[0];
-    size_t offset = matcher->type == BF_MATCHER_ICMP_TYPE ?
-                        offsetof(struct icmphdr, type) :
-                        offsetof(struct icmphdr, code);
 
     EMIT(program, BPF_LDX_MEM(BPF_B, BPF_REG_1, BPF_REG_6, offset));
 
@@ -38,20 +37,49 @@ static int _bf_matcher_generate_icmp_fields(struct bf_program *program,
     return 0;
 }
 
+static int _bf_matcher_generate_icmp6_fields(struct bf_program *program,
+                                            const struct bf_matcher *matcher)
+{
+    size_t offset = matcher->type == BF_MATCHER_ICMPV6_TYPE ?
+                        offsetof(struct icmp6hdr, icmp6_type) :
+                        offsetof(struct icmp6hdr, icmp6_code);
+
+    EMIT_FIXUP_JMP_NEXT_RULE(
+        program, BPF_JMP_IMM(BPF_JNE, BPF_REG_8, IPPROTO_ICMPV6, 0));
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_6, BPF_REG_10, BF_PROG_CTX_OFF(l4_hdr)));
+
+    return _bf_matcher_generate_icmp_fields(program, matcher, offset);
+}
+
+static int _bf_matcher_generate_icmp4_fields(struct bf_program *program,
+                                            const struct bf_matcher *matcher)
+{
+    size_t offset = matcher->type == BF_MATCHER_ICMP_TYPE ?
+                        offsetof(struct icmphdr, type) :
+                        offsetof(struct icmphdr, code);
+
+    EMIT_FIXUP_JMP_NEXT_RULE(
+        program, BPF_JMP_IMM(BPF_JNE, BPF_REG_8, IPPROTO_ICMP, 0));
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_6, BPF_REG_10, BF_PROG_CTX_OFF(l4_hdr)));
+
+    return _bf_matcher_generate_icmp_fields(program, matcher, offset);
+}
+
 int bf_matcher_generate_icmp(struct bf_program *program,
                              const struct bf_matcher *matcher)
 {
     int r;
 
-    EMIT_FIXUP_JMP_NEXT_RULE(program,
-                             BPF_JMP_IMM(BPF_JNE, BPF_REG_8, IPPROTO_ICMP, 0));
-    EMIT(program,
-         BPF_LDX_MEM(BPF_DW, BPF_REG_6, BPF_REG_10, BF_PROG_CTX_OFF(l4_hdr)));
-
     switch (matcher->type) {
     case BF_MATCHER_ICMP_TYPE:
     case BF_MATCHER_ICMP_CODE:
-        r = _bf_matcher_generate_icmp_fields(program, matcher);
+        r = _bf_matcher_generate_icmp4_fields(program, matcher);
+        break;
+    case BF_MATCHER_ICMPV6_TYPE:
+    case BF_MATCHER_ICMPV6_CODE:
+        r = _bf_matcher_generate_icmp6_fields(program, matcher);
         break;
     default:
         return bf_err_r(-EINVAL, "unknown matcher type %d", matcher->type);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -595,6 +595,8 @@ static int _bf_program_generate_rule(struct bf_program *program,
             break;
         case BF_MATCHER_ICMP_TYPE:
         case BF_MATCHER_ICMP_CODE:
+        case BF_MATCHER_ICMPV6_TYPE:
+        case BF_MATCHER_ICMPV6_CODE:
             r = bf_matcher_generate_icmp(program, matcher);
             if (r)
                 return r;

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -151,6 +151,8 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_SET_SRCIP6] = "set.srcip6",
     [BF_MATCHER_ICMP_TYPE] = "icmp.type",
     [BF_MATCHER_ICMP_CODE] = "icmp.code",
+    [BF_MATCHER_ICMPV6_TYPE] = "icmpv6.type",
+    [BF_MATCHER_ICMPV6_CODE] = "icmpv6.code",
 };
 
 static_assert(ARRAY_SIZE(_bf_matcher_type_strs) == _BF_MATCHER_TYPE_MAX,

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -81,6 +81,10 @@ enum bf_matcher_type
     BF_MATCHER_ICMP_TYPE,
     /// Matches against the ICMP code
     BF_MATCHER_ICMP_CODE,
+    /// Matches against the ICMPv6 type
+    BF_MATCHER_ICMPV6_TYPE,
+    /// Matches against the ICMPv6 code
+    BF_MATCHER_ICMPV6_CODE,
     _BF_MATCHER_TYPE_MAX,
 };
 

--- a/tests/e2e/cli.sh
+++ b/tests/e2e/cli.sh
@@ -396,6 +396,17 @@ suite_icmp_XDP() {
 }
 with_daemon suite_icmp_XDP
 
+suite_icmpv6_chain_set() {
+    log "[SUITE] icmpv6: chain set"
+    expect_success "can parse icmpv6 type and code by TC chain" \
+	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_TC_INGRESS\{ifindex=${NS_IFINDEX}\} ACCEPT rule icmpv6.type eq 128 icmpv6.code eq 0 counter DROP\"
+    expect_success "can parse icmpv6 type and code by TC chain" \
+	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule icmp.type eq 8 icmp.code eq 0 counter DROP\"
+    expect_success "flushing the ruleset" \
+        ${FROM_NS} ${BFCLI} ruleset flush
+}
+with_daemon suite_icmpv6_chain_set
+
 suite_chain_set() {
     log "[SUITE] chain: set"
     expect_failure "no chain defined in --from-str" \

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -6,7 +6,7 @@ import pathlib
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP as IPv4
 from scapy.layers.inet import TCP, UDP, ICMP
-from scapy.layers.inet6 import IPv6
+from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest
 
 packets = [
     {
@@ -22,6 +22,13 @@ packets = [
         "packet": Ether(src=0x01, dst=0x02)
         / IPv6(src="::1", dst="::2")
         / UDP(sport=31337, dport=31415),
+    },
+    {
+        "name": "pkt_local_ip6_icmp",
+        "family": "NFPROTO_IPV6",
+        "packet": Ether(src=0x01, dst=0x02)
+        / IPv6(src="::1", dst="::2")
+        / ICMPv6EchoRequest(),
     },
     {
         "name": "pkt_remote_ip6_tcp",

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -899,7 +899,7 @@ Test(meta, dport_range)
     bft_e2e_test(over_range, BF_VERDICT_ACCEPT, pkt_local_ip6_udp);
 }
 
-Test(icmp, type_code)
+Test(icmp, type_code_v4)
 {
     _free_bf_chain_ struct bf_chain *type_accept = bf_test_chain_get(
         BF_HOOK_XDP,
@@ -1027,6 +1027,136 @@ Test(icmp, type_code)
         }
     );
     bft_e2e_test(combo_drop, BF_VERDICT_DROP, pkt_local_ip4_icmp);
+}
+
+Test(icmpv6, type_code_v6)
+{
+    _free_bf_chain_ struct bf_chain *type_accept = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Echo Reply
+                            0x81,
+                        },
+                        1
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(type_accept, BF_VERDICT_ACCEPT, pkt_local_ip6_icmp);
+
+    _free_bf_chain_ struct bf_chain *type_drop = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Echo Request
+                            0x80,
+                        },
+                        1
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(type_drop, BF_VERDICT_DROP, pkt_local_ip6_icmp);
+
+    _free_bf_chain_ struct bf_chain *code_accept = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Code
+                            0x1,
+                        },
+                        1
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(code_accept, BF_VERDICT_ACCEPT, pkt_local_ip6_icmp);
+
+    _free_bf_chain_ struct bf_chain *code_drop = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Code
+                            0x0,
+                        },
+                        1
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(code_drop, BF_VERDICT_DROP, pkt_local_ip6_icmp);
+
+    _free_bf_chain_ struct bf_chain *combo_drop = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Type
+                            0x80,
+                        },
+                        1
+                    ),
+                    bf_matcher_get(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_EQ,
+                        (uint8_t[]) {
+                            // Code
+                            0x0,
+                        },
+                        1
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+    bft_e2e_test(combo_drop, BF_VERDICT_DROP, pkt_local_ip6_icmp);
 }
 
 int main(int argc, char *argv[])

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -91,6 +91,16 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         udp.dport 30-39
         counter
         ACCEPT
+    rule
+        icmp.type eq 8
+        icmp.code eq 0
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq 128
+        icmpv6.code eq 0
+        counter
+        ACCEPT
 
 # Create a TC chain
 chain mytciprog BF_HOOK_TC_INGRESS{ifindex=2} ACCEPT
@@ -175,6 +185,16 @@ chain mytciprog BF_HOOK_TC_INGRESS{ifindex=2} ACCEPT
         tcp.dport 10-19
         udp.sport 20-29
         udp.dport 30-39
+        counter
+        ACCEPT
+    rule
+        icmp.type eq 8
+        icmp.code eq 0
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq 128
+        icmpv6.code eq 0
         counter
         ACCEPT
 
@@ -271,6 +291,16 @@ chain mycgroupingressprog BF_HOOK_CGROUP_INGRESS{cgpath=/sys/fs/cgroup/user.slic
         udp.dport 30-39
         counter
         ACCEPT
+    rule
+        icmp.type eq 8
+        icmp.code eq 0
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq 128
+        icmpv6.code eq 0
+        counter
+        ACCEPT
 
 # Create a Netfilter chain
 chain mynfprog BF_HOOK_NF_LOCAL_IN{family=inet4,priorities=1-2} ACCEPT
@@ -363,5 +393,15 @@ chain mynfprog BF_HOOK_NF_LOCAL_IN{family=inet4,priorities=1-2} ACCEPT
         tcp.dport 10-19
         udp.sport 20-29
         udp.dport 30-39
+        counter
+        ACCEPT
+    rule
+        icmp.type eq 8
+        icmp.code eq 0
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq 128
+        icmpv6.code eq 0
         counter
         ACCEPT


### PR DESCRIPTION
Issue #214 

bfcli and bpfilter now support ICMPv6 type and code.
e2e tests have been added. cli tests were excluded as they currently appear not to support IPv6.
Minimal update of ruleset file.

