### PR TITLE
cli,daemon,doc: Add support for ip6.nexthdr

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -478,7 +478,12 @@ IPv6
       - ``ip6.dnet``
       - ``in``
       - ``{$IP/$MASK[,...]}``
-
+    * - :rspan:`1` Next header
+      - :rspan:`1` ``ip6.nexthdr``
+      - ``eq``
+      - :rspan:`3` ``$NEXT_HEADER``
+      - :rspan:`3` ``$NEXT_HEADER`` can be one of the following strings: ``ah``, ``dst``, ``frag``, ``hop``, ``icmpv6``, ``mh``, ``route``, ``tcp``, ``udp``
+    * - ``not``
 
 TCP
 ###

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -29,6 +29,7 @@
 %s STATE_MATCHER_IP4_NET
 %s STATE_MATCHER_IP6_ADDR
 %s STATE_MATCHER_IP6_NET
+%s STATE_MATCHER_IP6_NEXTHDR
 %s STATE_MATCHER_PORT
 %s STATE_MATCHER_ICMP
 %s STATE_MATCHER_TCP_FLAGS
@@ -146,6 +147,12 @@ ip6\.dnet       { BEGIN(STATE_MATCHER_IP6_NET); yylval.sval = strdup(yytext); re
         yylval.sval = strdup(yytext);
         return MATCHER_IP6_NET;
     }
+}
+
+ip6\.nexthdr    { BEGIN(STATE_MATCHER_IP6_NEXTHDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_IP6_NEXTHDR>{
+    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (ah|dst|frag|hop|icmpv6|mh|route|tcp|udp) { yylval.sval = strdup(yytext); return MATCHER_IP6_NEXTHDR; }
 }
 
 meta\.(s|d)port { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -80,6 +80,7 @@
 %token <sval> MATCHER_IP4_NET
 %token <sval> MATCHER_IP6_ADDR
 %token <sval> MATCHER_IP6_NET
+%token <sval> MATCHER_IP6_NEXTHDR
 %token <sval> MATCHER_PORT MATCHER_PORT_RANGE
 %token <sval> MATCHER_ICMP
 %token <sval> STRING
@@ -605,6 +606,21 @@ matcher         : matcher_type matcher_op MATCHER_META_IFINDEX
 
                     if (bf_matcher_new(&matcher, $1, $2, &set_id, sizeof(set_id)))
                         bf_parse_err("failed to create a new matcher\n");
+
+                    $$ = TAKE_PTR(matcher);
+                }
+                | matcher_type matcher_op MATCHER_IP6_NEXTHDR
+                {
+                    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
+                    enum bf_matcher_ipv6_nh nexthdr;
+
+                    if (bf_matcher_ipv6_nh_from_str($3, &nexthdr))
+                        bf_parse_err("Unknown IPv6 next-header '%s', ignoring\n", $3);
+
+                    if (bf_matcher_new(&matcher, $1, $2, &nexthdr, sizeof(nexthdr)) < 0)
+                        bf_parse_err("failed to create a new matcher\n");
+
+                    free($3);
 
                     $$ = TAKE_PTR(matcher);
                 }

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -61,6 +61,7 @@ bf_target_add_elfstubs(bpfilter
     DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
     STUBS
         "parse_ipv6_eh"
+        "parse_ipv6_nh"
         "update_counters"
 )
 

--- a/src/bpfilter/bpf/parse_ipv6_nh.bpf.c
+++ b/src/bpfilter/bpf/parse_ipv6_nh.bpf.c
@@ -1,0 +1,84 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+#include <linux/in.h>
+#include <linux/ipv6.h>
+
+#include <bpf/bpf_helpers.h>
+#include <stddef.h>
+
+#include "bpfilter/cgen/runtime.h"
+
+#define BF_IPV6_EXT_MAX_CHAIN 6
+
+#define EH_COMMON_OFFSET 1
+#define EH_COMMON_SHIFT 3
+#define EH_AH_OFFSET 2
+#define EH_AH_SHIFT 2
+#define EH_FRAG_OFFSET 8
+#define EH_FRAG_SHIFT 0
+
+/* The following defines are the same of src/bpfilter/cgen/matcher/ip6.c */
+#define BF_IPV6_EH_HOPOPTS(x) ((x) << 0)
+#define BF_IPV6_EH_ROUTING(x) ((x) << 1)
+#define BF_IPV6_EH_FRAGMENT(x) ((x) << 2)
+#define BF_IPV6_EH_AH(x) ((x) << 3)
+#define BF_IPV6_EH_DSTOPTS(x) ((x) << 4)
+#define BF_IPV6_EH_MH(x) ((x) << 5)
+
+__u8 bf_parse_ipv6(struct bf_runtime *ctx)
+{
+    struct ipv6hdr *ip6hdr = ctx->l3_hdr;
+    __u8 next_hdr_type = ip6hdr->nexthdr;
+    ctx->ipv6_eh = 0;
+    ctx->l4_offset = ctx->l3_offset + sizeof(struct ipv6hdr);
+
+    for (int i = 0; i < BF_IPV6_EXT_MAX_CHAIN; ++i) {
+        struct ipv6_opt_hdr _ext;
+        struct ipv6_opt_hdr *ext =
+            bpf_dynptr_slice(&ctx->dynptr, ctx->l4_offset, &_ext, sizeof(_ext));
+
+        if (!ext)
+            break;
+
+        switch (next_hdr_type) {
+        case IPPROTO_HOPOPTS:
+        case IPPROTO_ROUTING:
+        case IPPROTO_DSTOPTS:
+        case IPPROTO_FRAGMENT:
+        case IPPROTO_AH:
+        case IPPROTO_MH:
+            break;
+        default:
+            return next_hdr_type;
+        }
+
+        __u8 offset;
+        __u8 shift;
+        ctx->ipv6_eh |= (BF_IPV6_EH_HOPOPTS(next_hdr_type == IPPROTO_HOPOPTS) |
+                         BF_IPV6_EH_ROUTING(next_hdr_type == IPPROTO_ROUTING) |
+                         BF_IPV6_EH_FRAGMENT(next_hdr_type == IPPROTO_FRAGMENT) |
+                         BF_IPV6_EH_AH(next_hdr_type == IPPROTO_AH) |
+                         BF_IPV6_EH_DSTOPTS(next_hdr_type == IPPROTO_DSTOPTS) |
+                         BF_IPV6_EH_MH(next_hdr_type == IPPROTO_MH));
+
+        if (next_hdr_type == IPPROTO_AH) {
+            offset = EH_AH_OFFSET;
+            shift = EH_AH_SHIFT;
+        } else if (next_hdr_type == IPPROTO_FRAGMENT) {
+            offset = EH_FRAG_OFFSET;
+            shift = EH_FRAG_SHIFT;
+        } else {
+            offset = EH_COMMON_OFFSET;
+            shift = EH_COMMON_SHIFT;
+        }
+
+        ctx->l4_offset += (ext->hdrlen + offset) << shift;
+        next_hdr_type = ext->nexthdr;
+    }
+
+    return next_hdr_type;
+}

--- a/src/bpfilter/cgen/elfstub.h
+++ b/src/bpfilter/cgen/elfstub.h
@@ -92,6 +92,18 @@ enum bf_elfstub_id
      */
     BF_ELFSTUB_PARSE_IPV6_EH,
     /**
+     * Parse IPv6 extension headers filling runtime context for ip6.nexthdr rule.
+     *
+     * `__u8 bf_parse_ipv6(struct bf_runtime *ctx)`
+     *
+     * **Parameters**
+     * - `ctx`: address of the `bf_runtime` context of the program.
+     *
+     * **Return** The L4 protocol on success, or 0 if the program fails creating
+     *            a dynamic pointer slice.
+     */
+    BF_ELFSTUB_PARSE_IPV6_NH,
+    /**
      * Update the counters for a given rule.
      *
      * `__u8 bf_update_counters(struct bf_runtime *ctx, void *map, __u64 key)`

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -195,6 +195,8 @@ struct bf_program
 
     /// Link objects attaching the program to a hook.
     struct bf_link *link;
+    /// Program with ip6.nexthdr rules
+    bool ipv6_nexthdr;
 
     /* Bytecode */
     uint32_t elfstubs_location[_BF_ELFSTUB_MAX];

--- a/src/bpfilter/cgen/runtime.h
+++ b/src/bpfilter/cgen/runtime.h
@@ -127,6 +127,9 @@ struct bf_runtime
     /** Total size of the packet. */
     __u64 pkt_size;
 
+    /** IPv6 extension header mask */
+    __u8 bf_aligned(8) ipv6_eh;
+
     /** Offset of the layer 3 protocol header. */
     __u32 bf_aligned(8) l3_offset;
 

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -270,7 +270,9 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
         // Process EH
         EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
         EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
-        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_PARSE_IPV6_EH);
+        EMIT_FIXUP_ELFSTUB(program, program->ipv6_nexthdr ?
+                                    BF_ELFSTUB_PARSE_IPV6_NH :
+                                    BF_ELFSTUB_PARSE_IPV6_EH);
         EMIT(program, BPF_MOV64_REG(BPF_REG_8, BPF_REG_0));
 
         ehjmp = bf_jmpctx_get(program, BPF_JMP_A(0));

--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -147,6 +147,7 @@ static const char *_bf_matcher_type_strs[] = {
     [BF_MATCHER_IP6_SNET] = "ip6.snet",
     [BF_MATCHER_IP6_DADDR] = "ip6.daddr",
     [BF_MATCHER_IP6_DNET] = "ip6.dnet",
+    [BF_MATCHER_IP6_NEXTHDR] = "ip6.nexthdr",
     [BF_MATCHER_TCP_SPORT] = "tcp.sport",
     [BF_MATCHER_TCP_DPORT] = "tcp.dport",
     [BF_MATCHER_TCP_FLAGS] = "tcp.flags",
@@ -222,6 +223,8 @@ static const char *_bf_matcher_tcp_flags_strs[] = {
     [BF_MATCHER_TCP_FLAG_ECE] = "ECE", [BF_MATCHER_TCP_FLAG_CWR] = "CWR",
 };
 
+static_assert(ARRAY_SIZE(_bf_matcher_tcp_flags_strs) == _BF_MATCHER_TCP_FLAG_MAX);
+
 const char *bf_matcher_tcp_flag_to_str(enum bf_matcher_tcp_flag flag)
 {
     bf_assert(0 <= flag && flag < _BF_MATCHER_TCP_FLAG_MAX);
@@ -238,6 +241,45 @@ int bf_matcher_tcp_flag_from_str(const char *str,
     for (size_t i = 0; i < _BF_MATCHER_TCP_FLAG_MAX; ++i) {
         if (bf_streq(_bf_matcher_tcp_flags_strs[i], str)) {
             *flag = i;
+            return 0;
+        }
+    }
+
+    return -EINVAL;
+}
+
+static const char *_bf_matcher_ipv6_nh_strs[] = {
+    [BF_IPV6_NH_HOP] = "hop",
+    [BF_IPV6_NH_TCP] = "tcp",
+    [BF_IPV6_NH_UDP] = "udp",
+    [BF_IPV6_NH_ROUTING] = "route",
+    [BF_IPV6_NH_FRAGMENT] = "frag",
+    [BF_IPV6_NH_AH] = "ah",
+    [BF_IPV6_NH_ICMPV6] = "icmpv6",
+    [BF_IPV6_NH_DSTOPTS] = "dst",
+    [BF_IPV6_NH_MH] = "mh",
+};
+
+static_assert(ARRAY_SIZE(_bf_matcher_ipv6_nh_strs) == _BF_MATCHER_IPV6_NH_MAX);
+
+const char *bf_matcher_ipv6_nh_to_str(enum bf_matcher_ipv6_nh nexthdr)
+{
+    bf_assert(0 <= nexthdr && nexthdr < _BF_MATCHER_IPV6_NH_MAX);
+
+    return _bf_matcher_ipv6_nh_strs[nexthdr];
+}
+
+int bf_matcher_ipv6_nh_from_str(const char *str,
+                                enum bf_matcher_ipv6_nh *nexthdr)
+{
+    bf_assert(str && nexthdr);
+
+    for (size_t i = 0; i < _BF_MATCHER_IPV6_NH_MAX; ++i) {
+        /* sparse array */
+        if (!_bf_matcher_ipv6_nh_strs[i])
+            continue;
+        if (bf_streq(_bf_matcher_ipv6_nh_strs[i], str)) {
+            *nexthdr = i;
             return 0;
         }
     }

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <linux/in.h>
+#include <linux/in6.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -73,6 +75,8 @@ enum bf_matcher_type
     BF_MATCHER_IP6_DADDR,
     /// Matches IPv6 destination network.
     BF_MATCHER_IP6_DNET,
+    /// Matches IPv6 next header
+    BF_MATCHER_IP6_NEXTHDR,
     /// Matches against the TCP source port
     BF_MATCHER_TCP_SPORT,
     /// Matches against the TCP destination port
@@ -117,6 +121,23 @@ struct bf_matcher_ip6_addr
     uint8_t addr[16];
     /// 128-bits IPv6 mask.
     uint8_t mask[16];
+};
+
+/**
+ * Define the IPv6 next headers.
+ */
+enum bf_matcher_ipv6_nh
+{
+    BF_IPV6_NH_HOP = IPPROTO_HOPOPTS,
+    BF_IPV6_NH_TCP = IPPROTO_TCP,
+    BF_IPV6_NH_UDP = IPPROTO_UDP,
+    BF_IPV6_NH_ROUTING = IPPROTO_ROUTING,
+    BF_IPV6_NH_FRAGMENT = IPPROTO_FRAGMENT,
+    BF_IPV6_NH_AH = IPPROTO_AH,
+    BF_IPV6_NH_ICMPV6 = IPPROTO_ICMPV6,
+    BF_IPV6_NH_DSTOPTS = IPPROTO_DSTOPTS,
+    BF_IPV6_NH_MH = IPPROTO_MH,
+    _BF_MATCHER_IPV6_NH_MAX,
 };
 
 /**
@@ -279,3 +300,21 @@ const char *bf_matcher_tcp_flag_to_str(enum bf_matcher_tcp_flag flag);
  */
 int bf_matcher_tcp_flag_from_str(const char *str,
                                  enum bf_matcher_tcp_flag *flag);
+
+/**
+ * Convert a IPv6 next-header to a string.
+ *
+ * @param nexthdr IPv6 next-header to convert.
+ * @return String representation of the IPv6 next-header.
+ */
+const char *bf_matcher_ipv6_nh_to_str(enum bf_matcher_ipv6_nh nexthdr);
+
+/**
+ * Convert a string to the corresponding IPv6 next-header.
+ *
+ * @param str String containing the name of the IPv6 next-header.
+ * @param nexthdr IPv6 next-header value, if the parsing succeeds.
+ * @return 0 on success, or negative errno value on failure.
+ */
+int bf_matcher_ipv6_nh_from_str(const char *str,
+                                enum bf_matcher_ipv6_nh *nexthdr);

--- a/tests/e2e/cli.sh
+++ b/tests/e2e/cli.sh
@@ -422,12 +422,23 @@ suite_icmpv6_chain_set() {
     log "[SUITE] icmpv6: chain set"
     expect_success "can parse icmpv6 type and code by TC chain" \
 	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_TC_INGRESS\{ifindex=${NS_IFINDEX}\} ACCEPT rule icmpv6.type eq 128 icmpv6.code eq 0 counter DROP\"
-    expect_success "can parse icmpv6 type and code by TC chain" \
-	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule icmp.type eq 8 icmp.code eq 0 counter DROP\"
+    expect_success "can parse icmpv6 type and code by XDP chain" \
+	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule icmpv6.type eq 8 icmp.code eq 0 counter DROP\"
     expect_success "flushing the ruleset" \
         ${FROM_NS} ${BFCLI} ruleset flush
 }
 with_daemon suite_icmpv6_chain_set
+
+suite_ipv6_nexthdr_chain_set() {
+    log "[SUITE] ipv6 next-header: chain set"
+    expect_success "can parse ipv6 next-header by TC chain" \
+	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_TC_INGRESS\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip6.nexthdr eq hop counter DROP\"
+    expect_success "can parse ipv6 next-header by XDP chain" \
+	    ${FROM_NS} ${BFCLI} ruleset set --from-str \"chain xdp BF_HOOK_XDP\{ifindex=${NS_IFINDEX}\} ACCEPT rule ip6.nexthdr not tcp counter DROP\"
+    expect_success "flushing the ruleset" \
+        ${FROM_NS} ${BFCLI} ruleset flush
+}
+with_daemon suite_ipv6_nexthdr_chain_set
 
 suite_chain_set() {
     log "[SUITE] chain: set"

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -36,6 +36,15 @@ packets = [
         / ICMPv6EchoRequest(),
     },
     {
+        "name": "pkt_local_ip6_hop",
+        "family": "NFPROTO_IPV6",
+        "packet": Ether(src=0x01, dst=0x02)
+        / IPv6(src="::1", dst="::2")
+        / IPv6ExtHdrHopByHop()
+        / IPv6ExtHdrRouting()
+        / IPv6ExtHdrHopByHop(),
+    },
+    {
         "name": "pkt_remote_ip6_tcp",
         "family": "NFPROTO_IPV6",
         "packet": Ether(src=0x01, dst=0x02)

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -102,6 +102,12 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         counter
         ACCEPT
     rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        CONTINUE
+    rule
         meta.probability eq 50%
         counter
         CONTINUE
@@ -119,6 +125,12 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         CONTINUE
     rule
         ip6.dnet in {fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/64}
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
         counter
         CONTINUE
 
@@ -231,6 +243,12 @@ chain mytciprog BF_HOOK_TC_INGRESS{ifindex=2} ACCEPT
         CONTINUE
     rule
         ip6.dnet in {fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/64}
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
         counter
         CONTINUE
 
@@ -353,6 +371,12 @@ chain mycgroupingressprog BF_HOOK_CGROUP_INGRESS{cgpath=/sys/fs/cgroup/user.slic
         ip6.dnet in {fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/64}
         counter
         CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        CONTINUE
 
 # Create a Netfilter chain
 chain mynfprog BF_HOOK_NF_LOCAL_IN{family=inet4,priorities=1-2} ACCEPT
@@ -471,5 +495,11 @@ chain mynfprog BF_HOOK_NF_LOCAL_IN{family=inet4,priorities=1-2} ACCEPT
         CONTINUE
     rule
         ip6.dnet in {fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/64}
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
         counter
         CONTINUE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -139,6 +139,7 @@ bf_target_add_elfstubs(unit_bin
     DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
     STUBS
         "parse_ipv6_eh"
+        "parse_ipv6_nh"
         "update_counters"
 )
 


### PR DESCRIPTION
Issue #216

I have done initial work to support extra headers in IPv6. To fully parse the data inside these headers, a second kernel query is required (which I have not implemented yet). The extra header is valid only if the L3 protocol is IPv6.

Then I have added support for IPv6 next header filtering, included e2e tests and updated the documentation accordingly.

Please let me know if everything looks good or if there are any suggestions or nits.

Thank you!
