### PR TITLE
Process IPv6 extension headers

### DIFF
--- a/.github/fedora-40.Dockerfile
+++ b/.github/fedora-40.Dockerfile
@@ -6,6 +6,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     gawk \
     bpftool \
     bison \
+    clang \
     clang-tools-extra \
     cmake \
     doxygen \
@@ -30,5 +31,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     python3-GitPython \
     python3-linuxdoc \
     python3-scapy \
-    python3-sphinx && \
+    python3-sphinx \
+    sed \
+    xxd && \
     dnf clean all -y

--- a/.github/fedora-41.Dockerfile
+++ b/.github/fedora-41.Dockerfile
@@ -6,6 +6,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     gawk \
     bpftool \
     bison \
+    clang \
     clang-tools-extra \
     cmake \
     doxygen \
@@ -30,5 +31,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     python3-GitPython \
     python3-linuxdoc \
     python3-scapy \
-    python3-sphinx && \
+    python3-sphinx \
+    sed \
+    xxd && \
     dnf clean all -y

--- a/.github/fedora-42.Dockerfile
+++ b/.github/fedora-42.Dockerfile
@@ -6,6 +6,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     gawk \
     bpftool \
     bison \
+    clang \
     clang-tools-extra \
     cmake \
     doxygen \
@@ -30,5 +31,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     python3-GitPython \
     python3-linuxdoc \
     python3-scapy \
-    python3-sphinx && \
+    python3-sphinx \
+    sed \
+    xxd && \
     dnf clean all -y

--- a/.github/ubuntu-24.04.Dockerfile
+++ b/.github/ubuntu-24.04.Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     autoconf \
     automake \
     bison \
+    clang \
     clang-tidy \
     clang-format \
     cmake \
@@ -31,7 +32,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-git \
     python3-pip \
     python3-scapy \
-    python3-sphinx && \
+    python3-sphinx \
+    sed \
+    xxd && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --break-system-packages linuxdoc

--- a/.github/ubuntu-24.10.Dockerfile
+++ b/.github/ubuntu-24.10.Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     autoconf \
     automake \
     bison \
+    clang \
     clang-tidy \
     clang-format \
     cmake \
@@ -32,7 +33,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pip \
     python3-scapy \
     python3-setuptools \
-    python3-sphinx && \
+    python3-sphinx \
+    sed \
+    xxd && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --break-system-packages linuxdoc

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo dnf install -y bpfilter bpfilter-devel
 
 ```shell
 # Essential build requirements
-sudo dnf install -y cmake gcc libbpf-devel libnl3-devel bison flex
+sudo dnf install -y clang cmake gcc libbpf-devel libnl3-devel bison flex sed xxd
 
 # Configure the project and build bpfilter
 cmake -S $SOURCES_DIR -B $BUILD_DIR -DNO_DOCS=ON -DNO_TESTS=ON -DNO_CHECKS=ON -DNO_BENCHMARKS=ON

--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -14,6 +14,7 @@ If you want to perform a full build of ``bpfilter`` (including all test tests, c
         gawk \
         bpftool \
         bison \
+        clang \
         clang-tools-extra \
         cmake \
         doxygen \
@@ -38,13 +39,16 @@ If you want to perform a full build of ``bpfilter`` (including all test tests, c
         python3-GitPython \
         python3-linuxdoc \
         python3-scapy \
-        python3-sphinx
+        python3-sphinx \
+        sed \
+        xxd
 
     # Ubuntu 24.04+
     sudo apt-get install -y \
         autoconf \
         automake \
         bison \
+        clang \
         clang-tidy \
         clang-format \
         cmake \
@@ -72,7 +76,9 @@ If you want to perform a full build of ``bpfilter`` (including all test tests, c
         python3-git \
         python3-pip \
         python3-scapy \
-        python3-sphinx
+        python3-sphinx \
+        sed \
+        xxd
 
 You can then use CMake to generate the build system:
 

--- a/doc/developers/generation.rst
+++ b/doc/developers/generation.rst
@@ -6,6 +6,11 @@ Bytecode generation
 
 .. doxygenfile:: program.h
 
+ELF stubs
+---------
+
+.. doxygenfile:: elfstub.h
+
 Switch-cases
 ------------
 

--- a/doc/developers/packets_processing.rst
+++ b/doc/developers/packets_processing.rst
@@ -1,6 +1,11 @@
 Packets processing
 ==================
 
+Runtime
+-------
+
+.. doxygenfile:: runtime.h
+
 Matchers
 --------
 

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.h         ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/map.h          ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/map.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/runtime.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/stub.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/stub.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/swich.h             ${CMAKE_CURRENT_SOURCE_DIR}/cgen/swich.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/tc.h                ${CMAKE_CURRENT_SOURCE_DIR}/cgen/tc.c

--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -4,6 +4,8 @@
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(nl REQUIRED IMPORTED_TARGET libnl-3.0)
 
+include(ElfStubs)
+
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/bpfilter.service.in
     ${CMAKE_BINARY_DIR}/output/usr/lib/systemd/system/bpfilter.service
@@ -17,6 +19,7 @@ add_executable(bpfilter
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgen.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgen.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgroup.h            ${CMAKE_CURRENT_SOURCE_DIR}/cgen/cgroup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/dump.h              ${CMAKE_CURRENT_SOURCE_DIR}/cgen/dump.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/elfstub.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/elfstub.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/fixup.h             ${CMAKE_CURRENT_SOURCE_DIR}/cgen/fixup.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.h               ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip4.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/ip4.c
@@ -51,6 +54,15 @@ add_executable(bpfilter
     ${CMAKE_SOURCE_DIR}/src/external/murmur3.h           ${CMAKE_SOURCE_DIR}/src/external/murmur3.c
 )
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen)
+bf_target_add_elfstubs(bpfilter
+    DIR ${CMAKE_CURRENT_SOURCE_DIR}/bpf
+    SYM_PREFIX "_bf_rawstubs_"
+    DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
+    STUBS
+        "parse_ipv6_eh"
+)
+
 target_compile_definitions(bpfilter
     PRIVATE
         BF_CONTACT="${BF_CONTACT}"
@@ -60,6 +72,7 @@ target_include_directories(bpfilter
     PUBLIC
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_BINARY_DIR}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
 target_link_libraries(bpfilter

--- a/src/bpfilter/bpf/parse_ipv6_eh.bpf.c
+++ b/src/bpfilter/bpf/parse_ipv6_eh.bpf.c
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+#include <linux/in.h>
+#include <linux/ipv6.h>
+
+#include <bpf/bpf_helpers.h>
+#include <stddef.h>
+
+#include "bpfilter/cgen/runtime.h"
+
+#define BF_IPV6_EXT_MAX_CHAIN 6
+
+__u8 bf_parse_ipv6(struct bf_runtime *ctx)
+{
+    struct ipv6hdr *ip6hdr = ctx->l3_hdr;
+    __u8 next_hdr_type = ip6hdr->nexthdr;
+
+    ctx->l4_offset = ctx->l3_offset + sizeof(struct ipv6hdr);
+
+    for (int i = 0; i < BF_IPV6_EXT_MAX_CHAIN; ++i) {
+        struct ipv6_opt_hdr _ext;
+        struct ipv6_opt_hdr *ext =
+            bpf_dynptr_slice(&ctx->dynptr, ctx->l4_offset, &_ext, sizeof(_ext));
+        if (!ext)
+            return 0;
+
+        switch (next_hdr_type) {
+        case IPPROTO_HOPOPTS:
+        case IPPROTO_DSTOPTS:
+        case IPPROTO_ROUTING:
+        case IPPROTO_MH:
+            next_hdr_type = ext->nexthdr;
+            ctx->l4_offset += (ext->hdrlen + 1) * 8;
+            break;
+        case IPPROTO_AH:
+            next_hdr_type = ext->nexthdr;
+            ctx->l4_offset += (ext->hdrlen + 2) * 4;
+            break;
+        case IPPROTO_FRAGMENT:
+            next_hdr_type = ext->nexthdr;
+            ctx->l4_offset += ext->hdrlen + 8;
+            break;
+        default:
+            return next_hdr_type;
+        }
+    }
+
+    return next_hdr_type;
+}

--- a/src/bpfilter/cgen/elfstub.c
+++ b/src/bpfilter/cgen/elfstub.c
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "bpfilter/cgen/elfstub.h"
+
+#include <linux/bpf.h>
+
+#include <elf.h>
+#include <errno.h>
+
+#include "bpfilter/cgen/rawstubs.h"
+#include "core/btf.h"
+#include "core/helper.h"
+#include "core/logger.h"
+
+static_assert(ARRAY_SIZE(_bf_rawstubs) == _BF_ELFSTUB_MAX,
+              "_bf_rawstubs doesn't contain as many entries as bf_elfstub_id");
+
+static int _bf_elfstub_prepare(struct bf_elfstub *stub,
+                               const struct bf_rawstub *raw)
+{
+    const Elf64_Ehdr *ehdr = raw->elf;
+    Elf64_Shdr *shstrtab;
+    Elf64_Shdr *shdrs;
+    Elf64_Shdr *symtab = NULL;
+    Elf64_Shdr *symstrtab = NULL;
+    Elf64_Sym *symbols;
+    char *sym_strtab;
+    size_t sym_count;
+    char *strtab;
+
+    if (raw->len < sizeof(Elf64_Ehdr))
+        return bf_err_r(-EINVAL, "invalid ELF header (wrong header size)");
+
+    // Check ELF magic
+    if (memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0)
+        return bf_err_r(-EINVAL, "invalid ELF header (wrong magic number)");
+
+    // Ensure 64-bit ELF
+    if (ehdr->e_ident[EI_CLASS] != ELFCLASS64)
+        return bf_err_r(-ENOTSUP, "only 64-bit ELF is supported");
+
+    // Get section header table
+    if (ehdr->e_shoff >= raw->len || ehdr->e_shentsize != sizeof(Elf64_Shdr))
+        return bf_err_r(-EINVAL, "invalid section header table");
+
+    if (ehdr->e_shstrndx >= ehdr->e_shnum)
+        return bf_err_r(-EINVAL, "invalid string table index");
+
+    shdrs = (Elf64_Shdr *)(raw->elf + ehdr->e_shoff);
+    shstrtab = &shdrs[ehdr->e_shstrndx];
+    if (shstrtab->sh_offset >= raw->len)
+        return bf_err_r(-EINVAL, "invalid string table offset");
+
+    strtab = (char *)(raw->elf + shstrtab->sh_offset);
+
+    // Find .text section
+    for (int i = 0; i < ehdr->e_shnum; i++) {
+        if (!bf_streq(&strtab[shdrs[i].sh_name], ".text"))
+            continue;
+
+        if (shdrs[i].sh_offset + shdrs[i].sh_size > raw->len)
+            return bf_err_r(-EINVAL, "invalid .text section");
+
+        stub->insns = malloc(shdrs[i].sh_size);
+        if (!stub->insns)
+            return -ENOMEM;
+
+        memcpy(stub->insns, raw->elf + shdrs[i].sh_offset, shdrs[i].sh_size);
+        stub->ninsns = shdrs[i].sh_size / sizeof(struct bpf_insn);
+        break;
+    }
+
+    if (!stub->insns)
+        return bf_err_r(-ENOENT, ".text section not found");
+
+    // Find symbol table and its string table
+    for (int i = 0; i < ehdr->e_shnum; i++) {
+        if (shdrs[i].sh_type != SHT_SYMTAB)
+            continue;
+
+        symtab = &shdrs[i];
+        if (shdrs[i].sh_link < ehdr->e_shnum)
+            symstrtab = &shdrs[shdrs[i].sh_link];
+
+        break;
+    }
+
+    if (!symtab || !symstrtab)
+        return bf_err_r(-ENOENT, "symbol table not found");
+
+    symbols = (Elf64_Sym *)(raw->elf + symtab->sh_offset);
+    sym_strtab = (char *)(raw->elf + symstrtab->sh_offset);
+    sym_count = symtab->sh_size / sizeof(Elf64_Sym);
+
+    // Process REL relocation sections
+    for (int i = 0; i < ehdr->e_shnum; i++) {
+        if (shdrs[i].sh_type != SHT_REL)
+            continue;
+
+        // Check if this relocation section applies to .text
+        if (shdrs[i].sh_info != 0) {
+            // sh_info contains the section index this relocation applies to
+            if (!bf_streq(&strtab[shdrs[shdrs[i].sh_info].sh_name], ".text"))
+                continue;
+        }
+
+        // REL relocations (no addend)
+        Elf64_Rel *rels = (Elf64_Rel *)(raw->elf + shdrs[i].sh_offset);
+        size_t rel_count = shdrs[i].sh_size / sizeof(Elf64_Rel);
+
+        for (size_t j = 0; j < rel_count; j++) {
+            uint32_t type = ELF64_R_TYPE(rels[j].r_info);
+            uint32_t sym_idx = ELF64_R_SYM(rels[j].r_info);
+
+            if (type == R_BPF_64_32 && sym_idx < sym_count) {
+                uint32_t name_idx = symbols[sym_idx].st_name;
+                if (name_idx < symstrtab->sh_size) {
+                    const char *name = &sym_strtab[name_idx];
+                    int id = bf_btf_get_id(name);
+                    if (id < 0)
+                        return bf_err_r(id, "function %s not found", name);
+
+                    size_t idx = rels[j].r_offset / 8;
+                    stub->insns[idx] =
+                        ((struct bpf_insn) {.code = BPF_JMP | BPF_CALL,
+                                            .dst_reg = 0,
+                                            .src_reg = BPF_PSEUDO_KFUNC_CALL,
+                                            .off = 0,
+                                            .imm = id});
+
+                    bf_dbg("updated stub to call '%s' from instruction %lu",
+                           name, idx);
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id)
+{
+    _free_bf_elfstub_ struct bf_elfstub *_stub = NULL;
+    int r;
+
+    bf_assert(stub);
+
+    _stub = calloc(1, sizeof(*_stub));
+    if (!_stub)
+        return -ENOMEM;
+
+    r = _bf_elfstub_prepare(_stub, &_bf_rawstubs[id]);
+    if (r)
+        return r;
+
+    *stub = TAKE_PTR(_stub);
+
+    return 0;
+}
+
+void bf_elfstub_free(struct bf_elfstub **stub)
+{
+    bf_assert(stub);
+
+    if (!*stub)
+        return;
+
+    freep((void *)&(*stub)->insns);
+    freep((void *)stub);
+}

--- a/src/bpfilter/cgen/elfstub.h
+++ b/src/bpfilter/cgen/elfstub.h
@@ -7,14 +7,91 @@
 
 #include <stddef.h>
 
+/**
+ * @file elfstub.h
+ *
+ * ELF stubs are a mechanism to integrate clang-compiled BPF bytecode into
+ * bpfilter-generated BPF programs. Complex logic is more easily implemented
+ * in C and integrated into the final program that developed in BPF bytecode
+ * directly.
+ *
+ * ELF stubs source code is part of bpfilter's sources, they are compiled
+ * using clang, the ELF file is stored in a C array and accessible to the
+ * daemon at runtime.
+ *
+ * **Creating a new ELF stub**
+ *
+ * 1. Add a new source file for the BPF program in the daemon's codebase (in the
+ *    `bpf` folder, as `$NAME.bpf.c`).
+ * 2. Declare the ELF stub in the daemon's CMakeLists.txt (in
+ *    `bf_target_add_elfstubs()`).
+ * 3. Add a new ID for this stub in `bf_elfstub_id`.
+ * 4. Write the BPF C code: define a single function (additional inline
+ *    functions and macros are allowed).
+ *
+ * **Technicalities**
+ *
+ * At build time, ELF stubs are compiled by clang as BPF program. As such, they
+ * are bound to the same limitations as any other BPF program. `xxd` is used to
+ * convert the ELF file into a C array (with size), which is included in a
+ * generated `rawstubs.h` header file.
+ *
+ * `rawstubs.h` defines an array of `bf_rawstub` structures containing:
+ * - `const void *elf`: pointer to the ELF data.
+ * - `size_t len`: size of the ELF file.
+ *
+ * Each ELF stub can be manipulated through an instance of `bf_rawstub`, all
+ * the instances are stored in an array, which is as big as `_BF_ELFSTUB_MAX`.
+ *
+ * However, the ELF stubs are not accessed directly through the `bf_rawstub`
+ * structure, as it's not usable as-is. Instead, the `bf_context` will extract
+ * the actual bytecode from the ELF file, and relocate the kfunc calls. During
+ * generation, `bf_ctx_get_elfstub` is used to retrieve a pointer to
+ * `bf_elfstub` containing the BPF instructions to be copied in the program.
+ *
+ * **Limitations**
+ *
+ * Not any BPF program can be integrated into a bpfilter program, this section
+ * lists the current set of limitations:
+ * - Maps are not supported: BPF maps can be defined, but they are not
+ *   integrated by bpfilter into the program, so the final BPF program won't
+ *   be verifiable.
+ * - Function are not supported: each ELF stub source code should contain a
+ *   single function to be integrated. Inline functions are allowed, as they're
+ *   not real functions in the final ELF file.
+ *
+ * Those limitations might evolve, as new BPF features are developed and the ELF
+ * stub implementation is improved.
+ */
+
 struct bpf_insn;
 
+/**
+ * @brief Identifiers for the ELF stubs.
+ *
+ * Each identifier represents a valid ELF stub. If an ELF stub doesn’t have its
+ * identifier, it doesn’t exist from bpfilter’s standpoint.
+ */
 enum bf_elfstub_id
 {
+    /**
+     * Parse IPv6 extension headers.
+     *
+     * `__u8 bf_parse_ipv6(struct bf_runtime *ctx)`
+     *
+     * **Parameters**
+     * - `ctx`: Address of the `bf_runtime` context of the program.
+     *
+     * **Return** The L4 protocol on success, or 0 if the program fails creating
+     *            a dynamic pointer slice.
+     */
     BF_ELFSTUB_PARSE_IPV6_EH,
     _BF_ELFSTUB_MAX,
 };
 
+/**
+ * @brief Processed ELF stub to be integrated into a BPF program.
+ */
 struct bf_elfstub
 {
     enum bf_elfstub_id id;
@@ -24,5 +101,22 @@ struct bf_elfstub
 
 #define _free_bf_elfstub_ __attribute__((__cleanup__(bf_elfstub_free)))
 
+/**
+ * @brief Allocate and initialize a new ELF stub.
+ *
+ * The corresponding raw ELF stub will be read, its text section will be copied
+ * into the final ELF, and the calls to kfuncs will be relocated according to
+ * the host's kernel.
+ *
+ * @param stub ELF stub to allocate and initialize. Can't be NULL.
+ * @param id Identifier of the raw ELF stub to initialize.
+ * @return 0 on success, or negative errno value on failure.
+ */
 int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id);
+
+/**
+ * Deinitialise and deallocate an ELF stub.
+ *
+ * @param stub ELF stub. Can't be NULL.
+ */
 void bf_elfstub_free(struct bf_elfstub **stub);

--- a/src/bpfilter/cgen/elfstub.h
+++ b/src/bpfilter/cgen/elfstub.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+struct bpf_insn;
+
+enum bf_elfstub_id
+{
+    BF_ELFSTUB_PARSE_IPV6_EH,
+    _BF_ELFSTUB_MAX,
+};
+
+struct bf_elfstub
+{
+    enum bf_elfstub_id id;
+    struct bpf_insn *insns;
+    size_t ninsns;
+};
+
+#define _free_bf_elfstub_ __attribute__((__cleanup__(bf_elfstub_free)))
+
+int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id);
+void bf_elfstub_free(struct bf_elfstub **stub);

--- a/src/bpfilter/cgen/fixup.c
+++ b/src/bpfilter/cgen/fixup.c
@@ -47,6 +47,7 @@ static const char *_bf_fixup_type_to_str(enum bf_fixup_type type)
         [BF_FIXUP_TYPE_PRINTER_MAP_FD] = "BF_FIXUP_TYPE_PRINTER_MAP_FD",
         [BF_FIXUP_TYPE_SET_MAP_FD] = "BF_FIXUP_TYPE_SET_MAP_FD",
         [BF_FIXUP_TYPE_FUNC_CALL] = "BF_FIXUP_TYPE_FUNC_CALL",
+        [BF_FIXUP_ELFSTUB_CALL] = "BF_FIXUP_ELFSTUB_CALL",
     };
 
     bf_assert(0 <= type && type < _BF_FIXUP_TYPE_MAX);

--- a/src/bpfilter/cgen/fixup.h
+++ b/src/bpfilter/cgen/fixup.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 
+#include "bpfilter/cgen/elfstub.h"
 #include "core/dump.h"
 
 /**
@@ -48,6 +49,8 @@ enum bf_fixup_type
     BF_FIXUP_TYPE_SET_MAP_FD,
     /// Jump to a custom function.
     BF_FIXUP_TYPE_FUNC_CALL,
+    /// Call an ELF stub.
+    BF_FIXUP_ELFSTUB_CALL,
     _BF_FIXUP_TYPE_MAX
 };
 
@@ -55,6 +58,7 @@ union bf_fixup_attr
 {
     size_t set_index;
     enum bf_fixup_func function;
+    enum bf_elfstub_id elfstub_id;
 };
 
 struct bf_fixup

--- a/src/bpfilter/cgen/matcher/icmp.c
+++ b/src/bpfilter/cgen/matcher/icmp.c
@@ -39,7 +39,7 @@ static int _bf_matcher_generate_icmp_fields(struct bf_program *program,
 }
 
 static int _bf_matcher_generate_icmp6_fields(struct bf_program *program,
-                                            const struct bf_matcher *matcher)
+                                             const struct bf_matcher *matcher)
 {
     size_t offset = matcher->type == BF_MATCHER_ICMPV6_TYPE ?
                         offsetof(struct icmp6hdr, icmp6_type) :
@@ -54,14 +54,14 @@ static int _bf_matcher_generate_icmp6_fields(struct bf_program *program,
 }
 
 static int _bf_matcher_generate_icmp4_fields(struct bf_program *program,
-                                            const struct bf_matcher *matcher)
+                                             const struct bf_matcher *matcher)
 {
     size_t offset = matcher->type == BF_MATCHER_ICMP_TYPE ?
                         offsetof(struct icmphdr, type) :
                         offsetof(struct icmphdr, code);
 
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program, BPF_JMP_IMM(BPF_JNE, BPF_REG_8, IPPROTO_ICMP, 0));
+    EMIT_FIXUP_JMP_NEXT_RULE(program,
+                             BPF_JMP_IMM(BPF_JNE, BPF_REG_8, IPPROTO_ICMP, 0));
     EMIT(program,
          BPF_LDX_MEM(BPF_DW, BPF_REG_6, BPF_REG_10, BF_PROG_CTX_OFF(l4_hdr)));
 

--- a/src/bpfilter/cgen/matcher/icmp.c
+++ b/src/bpfilter/cgen/matcher/icmp.c
@@ -5,6 +5,7 @@
 
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
+#include <linux/icmp.h>
 #include <linux/icmpv6.h>
 
 #include <errno.h>

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "bpfilter/cgen/elfstub.h"
 #include "bpfilter/cgen/fixup.h"
 #include "bpfilter/cgen/printer.h"
 #include "bpfilter/cgen/runtime.h"
@@ -124,6 +125,13 @@
             return __r;                                                        \
     })
 
+#define EMIT_FIXUP_ELFSTUB(program, elfstub_id)                                \
+    ({                                                                         \
+        int __r = bf_program_emit_fixup_elfstub((program), (elfstub_id));      \
+        if (__r < 0)                                                           \
+            return __r;                                                        \
+    })
+
 #define EMIT_FIXUP_JMP_NEXT_RULE(program, insn)                                \
     ({                                                                         \
         int __r = bf_program_emit_fixup(                                       \
@@ -197,6 +205,7 @@ struct bf_program
 
     /* Bytecode */
     uint32_t functions_location[_BF_FIXUP_FUNC_MAX];
+    uint32_t elfstubs_location[_BF_ELFSTUB_MAX];
     struct bpf_insn *img;
     size_t img_size;
     size_t img_cap;
@@ -240,6 +249,8 @@ int bf_program_emit_fixup(struct bf_program *program, enum bf_fixup_type type,
                           const union bf_fixup_attr *attr);
 int bf_program_emit_fixup_call(struct bf_program *program,
                                enum bf_fixup_func function);
+int bf_program_emit_fixup_elfstub(struct bf_program *program,
+                                  enum bf_elfstub_id id);
 int bf_program_generate(struct bf_program *program);
 
 /**

--- a/src/bpfilter/cgen/runtime.h
+++ b/src/bpfilter/cgen/runtime.h
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <linux/bpf.h>
+
+/**
+ * @file runtime.h
+ *
+ * At runtime, the BPF programs have access to a 512 bytes stack. bpfilter will
+ * use the stack to store runtime data, such as the program's argument, the
+ * packet size...
+ *
+ * `bf_runtime` defines the layout of the data stored on the stack of the
+ * BPF program and simplifies its access.
+ *
+ * This header can be included into C stubs to be integrated into the generated
+ * BPF programs.
+ */
+
+/**
+ * @brief Size of the L2 dynamic pointer slice buffer.
+ *
+ * Only Ethernet is supported at L2, so the buffer should be as big as the
+ * Ethernet header.
+ */
+#define BF_L2_SLICE_LEN 14
+
+/**
+ * @brief Size of the L3 dynamic pointer slice buffer.
+ *
+ * The buffer should be able to contain the largest supported L3 protocol header
+ * among:
+ * - IPv4: 20 bytes (ignoring the options)
+ * - IPv6: 40 bytes (ignoring the extension headers)
+ */
+#define BF_L3_SLICE_LEN 40
+
+/**
+ * @brief Size of the L4 dynamic pointer slice buffer.
+ *
+ * The buffer should be able to contain the largest supported L4 protocol header
+ * among:
+ * - UDP: 8 bytes
+ * - TCP: 20 bytes
+ * - ICMP: 8 bytes (ignoring the payload)
+ * - ICMPV6: 4 bytes (ignoring the body)
+ */
+#define BF_L4_SLICE_LEN 20
+
+/**
+ * @brief Return the offset of a field in the runtime context, from `BPF_REG_10`.
+ *
+ * @param field Field to get the offset of.
+ * @return Offset of `field` in the runtime context based on `BPF_REG_10`.
+ */
+#define BF_PROG_CTX_OFF(field)                                                 \
+    (-(int)sizeof(struct bf_runtime) + (int)offsetof(struct bf_runtime, field))
+
+/**
+ * @brief Return the offset of an index in the scratch area, from `BPF_REG_10`.
+ *
+ * @param index Index of the scratch area entry to get the offset of.
+ * @return Offset of `index` in the scratch area based on `BPF_REG_10`.
+ */
+#define BF_PROG_SCR_OFF(index)                                                 \
+    (-(int)sizeof(struct bf_runtime) +                                         \
+     (int)offsetof(struct bf_runtime, scratch) + (index))
+
+#define bf_aligned(x) __attribute__((aligned(x)))
+
+/**
+ * @brief Runtime stack layout for the generated BPF programs.
+ *
+ * This runtime context is located at `r10 - sizeof(struct bf_runtime)`, it is
+ * valid during the whole lifetime of the BPF program.
+ *
+ * Access to the packet data is performed through a BPF dynamic pointer, this
+ * pointer is stored in the runtime context, as well as the scratch areas used
+ * to store the header slices.
+ *
+ * Each slice storage area is big enough to store the largest protocol header
+ * for a given layer. The BPF subsystem might copy the requested data into the
+ * slice storage area or not. In any case, a pointer to the data is returned,
+ * this pointer is stored in the runtime context and will be used to access the
+ * data.
+ *
+ * L3 and L4 protocol identifiers are used to check which matcher should be
+ * applied to a given packet. They can't be stored in the runtime context as
+ * the verifier might not be able to keep track of them, leading to verification
+ * failures.
+ *
+ * @warning Not all the BPF verifier versions are born equal, as older ones
+ * might require stack access to be 8-bytes aligned to work properly. Hence, all
+ * fields of the runtime context are aligned to 8 bytes, and `bf_runtime` size
+ * must be a multiple of 8.
+ */
+struct bf_runtime
+{
+    /** Argument passed to the BPF program, its content depends on the BPF
+     * program flavor:
+     * - `BF_FLAVOR_XDP`: `struct xdp_md *`
+     * - `BF_FLAVOR_TC`: `struct struct __sk_buff *`
+     * - `BF_FLAVOR_CGROUP`: `struct __sk_buff *`
+     * - `BF_FLAVOR_NF`: `struct bpf_nf_ctx *` */
+    void *arg;
+
+    /** BPF dynamic pointer to access the packet data. Dynamic pointers are
+     * used with for program flavor. */
+    struct bpf_dynptr dynptr;
+
+    /** Total size of the packet. */
+    __u64 pkt_size;
+
+    /** Offset of the layer 3 protocol header. */
+    __u32 bf_aligned(8) l3_offset;
+
+    /** Offset of the layer 4 protocol header. */
+    __u32 bf_aligned(8) l4_offset;
+
+    /** On ingress, index of the input interface. On egress, index of the
+     * output interface. */
+    __u32 bf_aligned(8) ifindex;
+
+    /** Pointer to the L2 protocol header (in a dynamic pointer slice). */
+    void *l2_hdr;
+
+    /** Pointer to the L3 protocol header (in a dynamic pointer slice). */
+    void *l3_hdr;
+
+    /** Pointer to the L4 protocol header (in a dynamic pointer slice). */
+    void *l4_hdr;
+
+    /** Layer 2 header. */
+    __u8 bf_aligned(8) l2[BF_L2_SLICE_LEN];
+
+    /** Layer 3 header. */
+    __u8 bf_aligned(8) l3[BF_L3_SLICE_LEN];
+
+    /** Layer 4 header. */
+    __u8 bf_aligned(8) l4[BF_L4_SLICE_LEN];
+
+    /** Scratch area. */
+    __u8 bf_aligned(8) scratch[64];
+};
+
+_Static_assert(sizeof(struct bf_runtime) % 8 == 0,
+               "bf_runtime should be aligned to 8 bytes");
+
+extern void *bpf_dynptr_slice(const struct bpf_dynptr *, __u32, void *, __u32);
+extern int bpf_dynptr_from_xdp(struct xdp_md *, __u64, struct bpf_dynptr *);

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -133,7 +133,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
     EMIT(program, BPF_LDX_MEM(BPF_H, BPF_REG_7, BPF_REG_0,
                               offsetof(struct ethhdr, h_proto)));
 
-    // Set bf_program_context.l3_offset
+    // Set bf_runtime.l3_offset
     EMIT(program, BPF_ST_MEM(BPF_W, BPF_REG_10, BF_PROG_CTX_OFF(l3_offset),
                              sizeof(struct ethhdr)));
 

--- a/src/bpfilter/cgen/stub.h
+++ b/src/bpfilter/cgen/stub.h
@@ -44,9 +44,9 @@ int bf_stub_make_ctx_skb_dynptr(struct bf_program *program, int skb_reg);
  * - If the slice creation fails, the error counter is updated and the
  *   program accepts the packet
  * - The header address returned by @c bpf_dynptr_slice is stored in
- *   @c bf_program_context.l2_hdr
+ *   `bf_runtime.l2_hdr`
  * - The L3 protocol ID (extracted from the ethertype field) is stored in @c r7
- * - The offset of the L3 header is stored in  @c bf_program_context.l2_offset
+ * - The offset of the L3 header is stored in  `bf_runtime.l2_offset`
  *
  * @param program Program to emit instructions into.
  * @return 0 on success, or negative errno value on error.

--- a/src/bpfilter/ctx.h
+++ b/src/bpfilter/ctx.h
@@ -7,6 +7,7 @@
 
 #include <stdbool.h>
 
+#include "bpfilter/cgen/elfstub.h"
 #include "core/dump.h"
 #include "core/front.h"
 #include "core/hook.h"
@@ -172,3 +173,11 @@ int bf_ctx_get_pindir_fd(void);
  * @return 0 on success, or a negative errno value on failure.
  */
 int bf_ctx_rm_pindir(void);
+
+/**
+ * @brief Get a ELF stub from its ID.
+ *
+ * @param id ID of the ELF stub to retrieve.
+ * @return The requested ELF stub.
+ */
+const struct bf_elfstub *bf_ctx_get_elfstub(enum bf_elfstub_id id);

--- a/tests/e2e/genpkts.py
+++ b/tests/e2e/genpkts.py
@@ -6,7 +6,12 @@ import pathlib
 from scapy.layers.l2 import Ether
 from scapy.layers.inet import IP as IPv4
 from scapy.layers.inet import TCP, UDP, ICMP
-from scapy.layers.inet6 import IPv6, ICMPv6EchoRequest
+from scapy.layers.inet6 import (
+    IPv6,
+    ICMPv6EchoRequest,
+    IPv6ExtHdrHopByHop,
+    IPv6ExtHdrRouting,
+)
 
 packets = [
     {
@@ -38,6 +43,30 @@ packets = [
             src="542c:1a31:f964:946c:5a24:e71e:4d26:b87e",
             dst="5232:185a:52f9:0ab4:8025:7974:2299:eb04",
         )
+        / TCP(sport=31337, dport=31415),
+    },
+    {
+        "name": "pkt_remote_ip6_eh",
+        "family": "NFPROTO_IPV6",
+        "packet": Ether(src=0x01, dst=0x02)
+        / IPv6(
+            src="542c:1a31:f964:946c:5a24:e71e:4d26:b87e",
+            dst="5232:185a:52f9:0ab4:8025:7974:2299:eb04",
+        )
+        / IPv6ExtHdrHopByHop()
+        / IPv6ExtHdrRouting()
+        / IPv6ExtHdrHopByHop(),
+    },
+    {
+        "name": "pkt_remote_ip6_eh_tcp",
+        "family": "NFPROTO_IPV6",
+        "packet": Ether(src=0x01, dst=0x02)
+        / IPv6(
+            src="542c:1a31:f964:946c:5a24:e71e:4d26:b87e",
+            dst="5232:185a:52f9:0ab4:8025:7974:2299:eb04",
+        )
+        / IPv6ExtHdrHopByHop()
+        / IPv6ExtHdrRouting()
         / TCP(sport=31337, dport=31415),
     },
     {

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -1159,6 +1159,32 @@ Test(icmpv6, type_code_v6)
     bft_e2e_test(combo_drop, BF_VERDICT_DROP, pkt_local_ip6_icmp);
 }
 
+Test(ipv6, extension_headers)
+{
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+        BF_HOOK_XDP,
+        BF_VERDICT_ACCEPT,
+        NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                false,
+                BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
+                        (uint8_t[]) { 0xb7, 0x7a },
+                        2
+                    ),
+                    NULL,
+                }
+            ),
+            NULL,
+        }
+    );
+
+    bft_e2e_test(chain, BF_VERDICT_ACCEPT, pkt_remote_ip6_eh);
+    bft_e2e_test(chain, BF_VERDICT_DROP, pkt_remote_ip6_eh_tcp);
+}
+
 int main(int argc, char *argv[])
 {
     _free_bf_test_suite_ bf_test_suite *suite = NULL;

--- a/tests/harness/filters.h
+++ b/tests/harness/filters.h
@@ -32,18 +32,25 @@
 
 #define BF_E2E_NAME "bf_e2e"
 
+// clang-format off
 #define bft_fake_matchers                                                      \
     (struct bf_matcher *[])                                                    \
     {                                                                          \
         bf_matcher_get(                                                        \
             BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
-            (uint8_t[]) {0x7d, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+            (uint8_t[]) {0x7d, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00},      \
+            8                                                                  \
+        ),                                                                     \
         bf_matcher_get(                                                        \
             BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
-            (uint8_t[]) {0x7e, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+            (uint8_t[]) {0x7e, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00},      \
+            8                                                                  \
+        ),                                                                     \
         bf_matcher_get(                                                        \
             BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,                               \
-            (uint8_t[]) {0x7f, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00}, 8),  \
+            (uint8_t[]) {0x7f, 0x02, 0x0a, 0x0b, 0xff, 0xff, 0x00, 0x00},      \
+            8                                                                  \
+        ),                                                                     \
         NULL,                                                                  \
     }
 
@@ -56,6 +63,7 @@
         bf_rule_get(false, BF_VERDICT_DROP, bft_fake_matchers),                \
         NULL,                                                                  \
     }
+// clang-format on
 
 /**
  * Create a new hook options object.

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -211,7 +211,8 @@ int bf_test_suite_add_test(bf_test_suite *suite, const char *group_name,
     return 0;
 }
 
-int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests, void *sentinel)
+int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests,
+                                void *sentinel)
 {
     _free_bf_list_ bf_list *symbols = NULL;
     _free_bf_test_suite_ bf_test_suite *_suite = NULL;

--- a/tests/harness/test.h
+++ b/tests/harness/test.h
@@ -157,7 +157,8 @@ int bf_test_suite_make_cmtests(const bf_test_suite *suite);
  *        tests section ends. Can't be NULL.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests, void *sentinel);
+int bf_test_discover_test_suite(bf_test_suite **suite, bf_test *tests,
+                                void *sentinel);
 
 /**
  * A filter to apply to the tests to run.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -40,12 +40,18 @@ function(bf_test_configure_non_build_srcs TARGET)
     endforeach()
 
     foreach(_bf_src IN LISTS _LOCAL_SOURCES)
+        get_source_file_property(
+            IS_HEADER_ONLY ${_bf_src}
+            TARGET_DIRECTORY bpfilter
+            HEADER_FILE_ONLY
+        )
+
         # Get absolute path to source file, and path relative to the project's
         # root directory.
         get_filename_component(_abs_bf_src ${_bf_src} ABSOLUTE)
         file(RELATIVE_PATH _rel_bf_src ${CMAKE_SOURCE_DIR}/src ${_abs_bf_src})
 
-        if (${_rel_bf_src} IN_LIST _test_srcs)
+        if (${_rel_bf_src} IN_LIST _test_srcs OR IS_HEADER_ONLY)
             set_source_files_properties(${_abs_bf_src}
                 PROPERTIES
                     HEADER_FILE_ONLY ON

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -84,6 +84,8 @@ function(bf_test_mock TARGET)
     endforeach()
 endfunction()
 
+include(ElfStubs)
+
 enable_testing()
 
 set(bf_test_srcs
@@ -130,6 +132,15 @@ add_executable(unit_bin EXCLUDE_FROM_ALL
     ${lib_srcs}
 )
 
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include/bpfilter/cgen)
+bf_target_add_elfstubs(unit_bin
+    DIR ${CMAKE_SOURCE_DIR}/src/bpfilter/bpf
+    SYM_PREFIX "_bf_rawstubs_"
+    DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
+    STUBS
+        "parse_ipv6_eh"
+)
+
 bf_test_configure_non_build_srcs(unit_bin
     TESTS
         ${bf_test_srcs}
@@ -155,6 +166,7 @@ target_include_directories(unit_bin
         ${CMAKE_SOURCE_DIR}/src         # First look for headers in src/
         ${CMAKE_CURRENT_SOURCE_DIR}     # Then use overrides in tests/units
         ${CMAKE_BINARY_DIR}/include
+        ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
 target_link_libraries(unit_bin
@@ -168,6 +180,7 @@ bf_test_mock(unit_bin
     FUNCTIONS
         bf_bpf
         bf_bpf_obj_get
+        bf_btf_get_id
         bf_ctx_token
         btf__load_vmlinux_btf
         calloc

--- a/tests/unit/bpfilter/ctx.c
+++ b/tests/unit/bpfilter/ctx.c
@@ -19,6 +19,9 @@ Test(ctx, create_delete_assert)
 
 Test(ctx, create_delete)
 {
+    _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_empty(bf_btf_get_id);
+    bf_test_mock_will_return_always(_, 1);
+
     // Rely on the cleanup attrubte
     _free_bf_ctx_ struct bf_ctx *ctx0 = NULL;
 
@@ -47,6 +50,9 @@ Test(ctx, create_delete)
 
 Test(ctx, set_get_chain)
 {
+    _clean_bf_test_mock_ bf_test_mock _ = bf_test_mock_empty(bf_btf_get_id);
+    bf_test_mock_will_return_always(_, 1);
+
     // Rely on the cleanup attrubte
     _free_bf_ctx_ struct bf_ctx *ctx = NULL;
     _free_bf_cgen_ struct bf_cgen *cgen0 = bf_test_cgen_quick();

--- a/tests/unit/mock.c
+++ b/tests/unit/mock.c
@@ -159,3 +159,11 @@ bf_test_mock_define(int, bf_ctx_token, (void))
 
     return mock_type(int);
 }
+
+bf_test_mock_define(int, bf_btf_get_id, (const char *name))
+{
+    if (!bf_test_mock_bf_btf_get_id_is_enabled())
+        return bf_test_mock_real(bf_btf_get_id)(name);
+
+    return mock_type(int);
+}

--- a/tests/unit/mock.h
+++ b/tests/unit/mock.h
@@ -36,3 +36,4 @@ bf_test_mock_declare(int, snprintf,
                     (char *str, size_t size, const char *fmt, ...));
 bf_test_mock_declare(int, bf_bpf, (enum bpf_cmd cmd, union bpf_attr *attr));
 bf_test_mock_declare(int, bf_ctx_token, (void));
+bf_test_mock_declare(int, bf_btf_get_id, (const char *name));

--- a/tools/checks/CMakeLists.txt
+++ b/tools/checks/CMakeLists.txt
@@ -14,6 +14,24 @@ file(GLOB_RECURSE bf_srcs
     ${CMAKE_SOURCE_DIR}/tests/harness/*.h       ${CMAKE_SOURCE_DIR}/tests/harness/*.c
 )
 
+# Create a custom rawstubs.h header to be included instead of bpfilter's
+# rawstubs.h, without any included source file ($STUB.inc.c), as those are
+# generated source file and we don't want to check them.
+file(GLOB_RECURSE bf_elfstubs ${CMAKE_SOURCE_DIR}/src/bpfilter/bpf/*.c)
+foreach (stub ${bf_elfstubs})
+    get_filename_component(filename ${stub} NAME_WE)
+
+    set(HDR_INC "${HDR_INC}static const unsigned char ${filename}[1] = {};\nstatic const unsigned int ${filename}_len = 1;\n")
+    set(HDR_DECL "${HDR_DECL}{ .elf = ${filename}, .len = ${filename}_len, },")
+endforeach ()
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen)
+configure_file(
+    ${CMAKE_SOURCE_DIR}/tools/cmake/rawstubs.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
+    @ONLY
+)
+
 add_custom_command(
     DEPENDS
         ${CMAKE_BINARY_DIR}/compile_commands.json
@@ -55,6 +73,7 @@ foreach (filepath ${bf_srcs})
                 --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
                 -p ${CMAKE_CURRENT_BINARY_DIR}
                 --extra-arg=-fno-caret-diagnostics
+                --extra-arg-before="-I${CMAKE_CURRENT_BINARY_DIR}/include"
                 ${filepath}
         COMMAND
             ${CLANG_FORMAT_BIN}

--- a/tools/cmake/ElfStubs.cmake
+++ b/tools/cmake/ElfStubs.cmake
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+
+# - Compile stub BPF programs to be integrated into a target
+#
+# This function performs a multi-steps process to compile BPF programs and
+# make them available to a C binary:
+#   1. Compile the C BPF programs into an ELF file using clang.
+#   2. Use xxd to generate a C source file containing two symbols: an array of
+#      bytes defining the ELF file, and an integer to define its length.
+#   3. Generate a header file declaring an array of custom structures
+#      representing all the ELF stubs available.
+#
+# Each generated C source file is added to the target as a dependency *but not
+# compiled*. The generated header in step 3 will include those header files
+# directly.
+#
+# Params:
+#   - TARGET: name of the target to define stubs for.
+#   - DIR: directory containing the source files for the stubs.
+#   - SYM_PREFIX: prefix of the C symbols.
+#   - DECL_HDR_PATH: path to the generated header file. The caller is
+#     responsible for adding the containing directory to the list of include
+#     directory for the taret.
+#   - STUBS: list of strings defining the name of the stubs sources.
+#     bf_target_add_elfstubs() will look for the stubs following the pattern:
+#     ${DIR}/${STUB_NAME}.bpf.c.
+function(bf_target_add_elfstubs TARGET)
+    cmake_parse_arguments(PARSE_ARGV 1 _LOCAL
+        ""
+        "DIR;SYM_PREFIX;DECL_HDR_PATH"
+        "STUBS"
+    )
+
+    find_program(CLANG_BIN clang REQUIRED)
+    find_program(XXD_BIN xxd REQUIRED)
+    find_program(SED_BIN sed REQUIRED)
+
+    list(LENGTH _LOCAL_STUBS N_STUBS)
+    message(STATUS "Building ${N_STUBS} stub program(s) for target '${TARGET}'")
+
+    set(ELFSTUBS_ELF_DIR ${CMAKE_CURRENT_BINARY_DIR}/elfstubs/elf)
+    set(ELFSTUBS_INC_DIR ${CMAKE_CURRENT_BINARY_DIR}/elfstubs/src)
+    file(MAKE_DIRECTORY ${ELFSTUBS_ELF_DIR} ${ELFSTUBS_INC_DIR})
+
+    set(DECL_TEMPLATE_PATH ${CMAKE_SOURCE_DIR}/tools/cmake/rawstubs.h.in)
+
+    foreach(_stub IN LISTS _LOCAL_STUBS)
+        add_custom_command(
+            COMMAND
+                ${CLANG_BIN}
+                    -O2
+                    -target bpf
+                    -I ${CMAKE_SOURCE_DIR}/src
+                    -I ${CMAKE_SOURCE_DIR}/src/external
+                    -c ${_LOCAL_DIR}/${_stub}.bpf.c
+                    -o ${ELFSTUBS_ELF_DIR}/${_stub}.o
+            COMMAND
+                ${XXD_BIN}
+                    -i
+                    -n ${SYM_PREFIX}${_stub}
+                    ${ELFSTUBS_ELF_DIR}/${_stub}.o
+                    ${ELFSTUBS_INC_DIR}/${_stub}.inc.c
+            COMMAND
+                # By default, xxd variables are not static nor const, fix it
+                ${SED_BIN}
+                    -i 's/^unsigned /static const unsigned /'
+                    ${ELFSTUBS_INC_DIR}/${_stub}.inc.c
+            DEPENDS
+                ${_LOCAL_DIR}/${_stub}.bpf.c
+                ${DECL_TEMPLATE_PATH}
+            OUTPUT
+                ${ELFSTUBS_INC_DIR}/${_stub}.inc.c
+            COMMENT "Generate ${_stub} stub"
+        )
+
+        set(HDR_INC "${HDR_INC}#include \"${_stub}.inc.c\"\n")
+        set(HDR_DECL "${HDR_DECL}{ .elf = ${SYM_PREFIX}${_stub}, .len = ${SYM_PREFIX}${_stub}_len, },\n")
+
+        # Add the source file containing the ELF file to the sources of the
+        # given target, so the target will be build when the stub changes. It
+        # will be included in the generated private header, so it should be
+        # marked as header file.
+        target_sources(${TARGET} PRIVATE ${ELFSTUBS_INC_DIR}/${_stub}.inc.c)
+        set_source_files_properties(${ELFSTUBS_INC_DIR}/${_stub}.inc.c
+            PROPERTIES
+                HEADER_FILE_ONLY ON
+        )
+
+        message(VERBOSE "  - ${_stub}")
+    endforeach()
+
+    configure_file(${DECL_TEMPLATE_PATH} ${_LOCAL_DECL_HDR_PATH} @ONLY)
+    target_sources(${TARGET} PRIVATE ${_LOCAL_DECL_HDR_PATH})
+
+    target_include_directories(${TARGET} PRIVATE ${ELFSTUBS_INC_DIR})
+endfunction()

--- a/tools/cmake/rawstubs.h.in
+++ b/tools/cmake/rawstubs.h.in
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <elf.h>
+#include <stddef.h>
+
+struct bpf_insn;
+
+@HDR_INC@
+
+struct bf_rawstub {
+    const void *elf;
+    size_t len;
+} _bf_rawstubs[] = {
+    @HDR_DECL@
+};


### PR DESCRIPTION
Create (and document) a new mechanism to create bytecode from compiled BPF C programs. This allows us to write BPF C code, compile it, and integrate it into the final BPF program generated by bpfilter. Restrictions to this mechanism are described in the documentation.

Use this new ELF stubs mechanism to parse IPv6 extension headers. Extension headers are not that common in the wild, so the implementation will first look for a TCP or UDP value in the `nexthdr` field of the IPv6 packet, if not, then take the slow path to process extension headers by calling the ELF stub.