### PR TITLE
Support `bpf_printk()` in ELF stubs

### DIFF
--- a/src/bpfilter/CMakeLists.txt
+++ b/src/bpfilter/CMakeLists.txt
@@ -61,6 +61,7 @@ bf_target_add_elfstubs(bpfilter
     DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
     STUBS
         "parse_ipv6_eh"
+        "update_counters"
 )
 
 target_compile_definitions(bpfilter

--- a/src/bpfilter/bpf/update_counters.bpf.c
+++ b/src/bpfilter/bpf/update_counters.bpf.c
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+#include <linux/in.h>
+#include <linux/ipv6.h>
+
+#include <bpf/bpf_helpers.h>
+#include <stddef.h>
+
+#include "bpfilter/cgen/runtime.h"
+
+struct bf_counter
+{
+    __u64 packets;
+    __u64 bytes;
+};
+
+__u8 bf_update_counters(struct bf_runtime *ctx, void *map, __u64 key)
+{
+    struct bf_counter *counter;
+
+    counter = bpf_map_lookup_elem(map, &key);
+    if (!counter) {
+        bpf_printk("failed to fetch the rule's counters");
+        return 1;
+    }
+
+    counter->packets += 1;
+    counter->bytes += ctx->pkt_size;
+
+    return 0;
+}

--- a/src/bpfilter/cgen/elfstub.h
+++ b/src/bpfilter/cgen/elfstub.h
@@ -7,6 +7,8 @@
 
 #include <stddef.h>
 
+#include "core/list.h"
+
 /**
  * @file elfstub.h
  *
@@ -62,6 +64,9 @@
  *
  * Those limitations might evolve, as new BPF features are developed and the ELF
  * stub implementation is improved.
+ *
+ * While map are not supported, `bpf_printk()` can be used, as bpfilter is
+ * able to add the strings to its own map.
  */
 
 struct bpf_insn;
@@ -89,6 +94,12 @@ enum bf_elfstub_id
     _BF_ELFSTUB_MAX,
 };
 
+struct bf_printk_str
+{
+    size_t insn_idx;
+    const char *str;
+};
+
 /**
  * @brief Processed ELF stub to be integrated into a BPF program.
  */
@@ -97,6 +108,7 @@ struct bf_elfstub
     enum bf_elfstub_id id;
     struct bpf_insn *insns;
     size_t ninsns;
+    bf_list strs;
 };
 
 #define _free_bf_elfstub_ __attribute__((__cleanup__(bf_elfstub_free)))

--- a/src/bpfilter/cgen/elfstub.h
+++ b/src/bpfilter/cgen/elfstub.h
@@ -85,12 +85,25 @@ enum bf_elfstub_id
      * `__u8 bf_parse_ipv6(struct bf_runtime *ctx)`
      *
      * **Parameters**
-     * - `ctx`: Address of the `bf_runtime` context of the program.
+     * - `ctx`: address of the `bf_runtime` context of the program.
      *
      * **Return** The L4 protocol on success, or 0 if the program fails creating
      *            a dynamic pointer slice.
      */
     BF_ELFSTUB_PARSE_IPV6_EH,
+    /**
+     * Update the counters for a given rule.
+     *
+     * `__u8 bf_update_counters(struct bf_runtime *ctx, void *map, __u64 key)`
+     *
+     * **Parameters**
+     * - `ctx`: address of the `bf_runtime` context of the program.
+     * - `map`: address of the counters map.
+     * - `key`: key of the map to update.
+     *
+     * **Return** 0 on success, or 1 on error.
+     */
+    BF_ELFSTUB_UPDATE_COUNTERS,
     _BF_ELFSTUB_MAX,
 };
 

--- a/src/bpfilter/cgen/fixup.c
+++ b/src/bpfilter/cgen/fixup.c
@@ -46,7 +46,6 @@ static const char *_bf_fixup_type_to_str(enum bf_fixup_type type)
         [BF_FIXUP_TYPE_COUNTERS_MAP_FD] = "BF_FIXUP_TYPE_COUNTERS_MAP_FD",
         [BF_FIXUP_TYPE_PRINTER_MAP_FD] = "BF_FIXUP_TYPE_PRINTER_MAP_FD",
         [BF_FIXUP_TYPE_SET_MAP_FD] = "BF_FIXUP_TYPE_SET_MAP_FD",
-        [BF_FIXUP_TYPE_FUNC_CALL] = "BF_FIXUP_TYPE_FUNC_CALL",
         [BF_FIXUP_ELFSTUB_CALL] = "BF_FIXUP_ELFSTUB_CALL",
     };
 
@@ -54,18 +53,6 @@ static const char *_bf_fixup_type_to_str(enum bf_fixup_type type)
     static_assert(ARRAY_SIZE(str) == _BF_FIXUP_TYPE_MAX);
 
     return str[type];
-}
-
-static const char *_bf_fixup_func_to_str(enum bf_fixup_func func)
-{
-    static const char *str[] = {
-        [BF_FIXUP_FUNC_UPDATE_COUNTERS] = "BF_FIXUP_FUNC_UPDATE_COUNTERS",
-    };
-
-    bf_assert(0 <= func && func < _BF_FIXUP_FUNC_MAX);
-    static_assert(ARRAY_SIZE(str) == _BF_FIXUP_FUNC_MAX);
-
-    return str[func];
 }
 
 void bf_fixup_dump(const struct bf_fixup *fixup, prefix_t *prefix)
@@ -88,10 +75,6 @@ void bf_fixup_dump(const struct bf_fixup *fixup, prefix_t *prefix)
         break;
     case BF_FIXUP_TYPE_SET_MAP_FD:
         DUMP(prefix, "set_index: %lu", fixup->attr.set_index);
-        break;
-    case BF_FIXUP_TYPE_FUNC_CALL:
-        DUMP(prefix, "function: %s",
-             _bf_fixup_func_to_str(fixup->attr.function));
         break;
     default:
         DUMP(prefix, "unsupported bf_fixup_type: %d", fixup->type);

--- a/src/bpfilter/cgen/fixup.h
+++ b/src/bpfilter/cgen/fixup.h
@@ -21,18 +21,6 @@ enum bf_fixup_insn
 };
 
 /**
- * Custom function to call.
- *
- * A fixup can be used to jump to a custom function defined later in the
- * BPF program. This enum contains the list of functions available.
- */
-enum bf_fixup_func
-{
-    BF_FIXUP_FUNC_UPDATE_COUNTERS,
-    _BF_FIXUP_FUNC_MAX,
-};
-
-/**
  * Type of the fixup.
  *
  * Defines how a fixup should be processed.
@@ -47,8 +35,6 @@ enum bf_fixup_type
     BF_FIXUP_TYPE_PRINTER_MAP_FD,
     /// Set a set map file descriptor in the @c BPF_LD_MAP_FD instruction.
     BF_FIXUP_TYPE_SET_MAP_FD,
-    /// Jump to a custom function.
-    BF_FIXUP_TYPE_FUNC_CALL,
     /// Call an ELF stub.
     BF_FIXUP_ELFSTUB_CALL,
     _BF_FIXUP_TYPE_MAX
@@ -57,7 +43,6 @@ enum bf_fixup_type
 union bf_fixup_attr
 {
     size_t set_index;
-    enum bf_fixup_func function;
     enum bf_elfstub_id elfstub_id;
 };
 

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -118,13 +118,6 @@
             return __r;                                                        \
     })
 
-#define EMIT_FIXUP_CALL(program, function)                                     \
-    ({                                                                         \
-        int __r = bf_program_emit_fixup_call((program), (function));           \
-        if (__r < 0)                                                           \
-            return __r;                                                        \
-    })
-
 #define EMIT_FIXUP_ELFSTUB(program, elfstub_id)                                \
     ({                                                                         \
         int __r = bf_program_emit_fixup_elfstub((program), (elfstub_id));      \
@@ -204,7 +197,6 @@ struct bf_program
     struct bf_link *link;
 
     /* Bytecode */
-    uint32_t functions_location[_BF_FIXUP_FUNC_MAX];
     uint32_t elfstubs_location[_BF_ELFSTUB_MAX];
     struct bpf_insn *img;
     size_t img_size;
@@ -247,8 +239,6 @@ int bf_program_emit_kfunc_call(struct bf_program *program, const char *name);
 int bf_program_emit_fixup(struct bf_program *program, enum bf_fixup_type type,
                           struct bpf_insn insn,
                           const union bf_fixup_attr *attr);
-int bf_program_emit_fixup_call(struct bf_program *program,
-                               enum bf_fixup_func function);
 int bf_program_emit_fixup_elfstub(struct bf_program *program,
                                   enum bf_elfstub_id id);
 int bf_program_generate(struct bf_program *program);

--- a/src/bpfilter/cgen/stub.c
+++ b/src/bpfilter/cgen/stub.c
@@ -64,11 +64,12 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
 
         // Update the error counter
+        EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+        EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+        EMIT_LOAD_COUNTERS_FD_FIXUP(program, BPF_REG_2);
         EMIT(program,
-             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
-                                  BF_PROG_CTX_OFF(pkt_size)));
-        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
+             BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
+        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create a new dynamic pointer");
@@ -115,11 +116,12 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
         // Update the error counter
+        EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+        EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+        EMIT_LOAD_COUNTERS_FD_FIXUP(program, BPF_REG_2);
         EMIT(program,
-             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
-                                  BF_PROG_CTX_OFF(pkt_size)));
-        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
+             BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
+        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L2 dynamic pointer slice");
@@ -185,12 +187,12 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
         _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
-        // Update the error counter
+        EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+        EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+        EMIT_LOAD_COUNTERS_FD_FIXUP(program, BPF_REG_2);
         EMIT(program,
-             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
-                                  BF_PROG_CTX_OFF(pkt_size)));
-        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
+             BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
+        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L3 dynamic pointer slice");
@@ -335,12 +337,12 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
         _clean_bf_jmpctx_ struct bf_jmpctx _ =
             bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JNE, BPF_REG_0, 0, 0));
 
-        // Update the error counter
+        EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+        EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+        EMIT_LOAD_COUNTERS_FD_FIXUP(program, BPF_REG_2);
         EMIT(program,
-             BPF_MOV32_IMM(BPF_REG_1, bf_program_error_counter_idx(program)));
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_10,
-                                  BF_PROG_CTX_OFF(pkt_size)));
-        EMIT_FIXUP_CALL(program, BF_FIXUP_FUNC_UPDATE_COUNTERS);
+             BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
+        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
         if (bf_opts_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L4 dynamic pointer slice");

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -139,6 +139,7 @@ bf_target_add_elfstubs(unit_bin
     DECL_HDR_PATH ${CMAKE_CURRENT_BINARY_DIR}/include/bpfilter/cgen/rawstubs.h
     STUBS
         "parse_ipv6_eh"
+        "update_counters"
 )
 
 bf_test_configure_non_build_srcs(unit_bin

--- a/tests/unit/bpfilter/cgen/program.c
+++ b/tests/unit/bpfilter/cgen/program.c
@@ -9,30 +9,6 @@
 #include "harness/test.h"
 #include "mock.h"
 
-Test(program, emit_fixup_call)
-{
-    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_quick();
-
-    expect_assert_failure(bf_program_emit_fixup_call(
-        NULL, BF_FIXUP_FUNC_UPDATE_COUNTERS));
-
-    {
-        // Instructions buffer should grow
-        _free_bf_program_ struct bf_program *program = NULL;
-        size_t start_cap;
-
-        assert_success(bf_program_new(&program, chain));
-
-        start_cap = program->img_cap;
-
-        // Instructions buffer is empty after initialisation, ensure it grows.
-        assert_int_equal(0,
-                         bf_program_emit_fixup_call(
-                             program, BF_FIXUP_FUNC_UPDATE_COUNTERS));
-        assert_int_not_equal(program->img_cap, start_cap);
-    }
-}
-
 Test(program, can_get_flavor_from_hook)
 {
     for (enum bf_flavor flavor = 0; flavor < _BF_FLAVOR_MAX; ++flavor)


### PR DESCRIPTION
Improve ELF parsing to allow ELF stubs to use `bpf_printk()`. `bpf_printk()` calls are relocated like any kfunc call, but the format string is copied from the `.rodata` section for the ELF file and put into a BPF map, similarly to `EMIT_PRINT()`.

As `bpf_printk()` is now supported, the function generated to update counters has been replaced by an ELF stub. All the `bf_program` pieces related to function have also been removed, and ELF stub is used exclusively now.