### PR TITLE
Remove the dependency of the `core` module to the `bpfilter` module

### DIFF
--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -525,3 +525,18 @@ int bf_map_bpf_type_from_str(const char *str, enum bf_map_bpf_type *bpf_type)
 
     return -EINVAL;
 }
+
+static enum bf_map_bpf_type _bf_map_bpf_type_to_set_type[] = {
+    [BF_SET_IP4] = BF_MAP_BPF_TYPE_HASH,
+    [BF_SET_SRCIP6PORT] = BF_MAP_BPF_TYPE_HASH,
+    [BF_SET_SRCIP6] = BF_MAP_BPF_TYPE_HASH,
+    [BF_SET_IP4_SUBNET] = BF_MAP_BPF_TYPE_LPM_TRIE,
+    [BF_SET_IP6_SUBNET] = BF_MAP_BPF_TYPE_LPM_TRIE,
+};
+
+static_assert(ARRAY_SIZE(_bf_map_bpf_type_to_set_type) == _BF_SET_MAX, "");
+
+enum bf_map_bpf_type bf_map_bpf_type_from_set_type(enum bf_set_type type)
+{
+    return _bf_map_bpf_type_to_set_type[type];
+}

--- a/src/bpfilter/cgen/prog/map.h
+++ b/src/bpfilter/cgen/prog/map.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 
 #include "core/dump.h"
+#include "core/set.h"
 
 enum bf_map_bpf_type
 {
@@ -252,3 +253,11 @@ const char *bf_map_bpf_type_to_str(enum bf_map_bpf_type bpf_type);
  * @return 0 on success, or a negative errno value on failure.
  */
 int bf_map_bpf_type_from_str(const char *str, enum bf_map_bpf_type *bpf_type);
+
+/**
+ * @brief Convert a generic set type into a BPF map type.
+ *
+ * @param type Set type to convert.
+ * @return BPF map type corresponding to the set type.
+ */
+enum bf_map_bpf_type bf_map_bpf_type_from_set_type(enum bf_set_type type);

--- a/src/bpfilter/cgen/program.c
+++ b/src/bpfilter/cgen/program.c
@@ -116,7 +116,7 @@ int bf_program_new(struct bf_program **program, const struct bf_chain *chain)
 
         (void)snprintf(name, BPF_OBJ_NAME_LEN, "set_%04x", (uint8_t)set_idx++);
         r = bf_map_new(&map, name, BF_MAP_TYPE_SET,
-                       bf_set_type_to_map_bpf_type(set->type), set->elem_size,
+                       bf_map_bpf_type_from_set_type(set->type), set->elem_size,
                        1, bf_list_size(&set->elems));
         if (r < 0)
             return r;

--- a/src/core/set.c
+++ b/src/core/set.c
@@ -11,8 +11,6 @@
 #include <string.h>
 #include <time.h>
 
-#include "bpfilter/cgen/prog/map.h"
-#include "bpfilter/cgen/runtime.h"
 #include "core/dump.h"
 #include "core/helper.h"
 #include "core/list.h"
@@ -22,11 +20,8 @@
 size_t _bf_set_type_elem_size(enum bf_set_type type)
 {
     static const size_t sizes[_BF_SET_MAX] = {
-        [BF_SET_IP4] = 4,
-        [BF_SET_SRCIP6PORT] = 18,
-        [BF_SET_SRCIP6] = 16,
-        [BF_SET_IP4_SUBNET] = sizeof(struct bf_ip4_lpm_key),
-        [BF_SET_IP6_SUBNET] = sizeof(struct bf_ip6_lpm_key),
+        [BF_SET_IP4] = 4,        [BF_SET_SRCIP6PORT] = 18, [BF_SET_SRCIP6] = 16,
+        [BF_SET_IP4_SUBNET] = 8, [BF_SET_IP6_SUBNET] = 20,
     };
 
     static_assert(ARRAY_SIZE(sizes) == _BF_SET_MAX,
@@ -204,21 +199,6 @@ const char *bf_set_type_to_str(enum bf_set_type type)
     bf_assert(0 <= type && type < _BF_SET_MAX);
 
     return _bf_set_type_strs[type];
-}
-
-static enum bf_map_bpf_type _bf_set_type_to_map_bpf_type[] = {
-    [BF_SET_IP4] = BF_MAP_BPF_TYPE_HASH,
-    [BF_SET_SRCIP6PORT] = BF_MAP_BPF_TYPE_HASH,
-    [BF_SET_SRCIP6] = BF_MAP_BPF_TYPE_HASH,
-    [BF_SET_IP4_SUBNET] = BF_MAP_BPF_TYPE_LPM_TRIE,
-    [BF_SET_IP6_SUBNET] = BF_MAP_BPF_TYPE_LPM_TRIE,
-};
-
-static_assert(ARRAY_SIZE(_bf_set_type_to_map_bpf_type) == _BF_SET_MAX, "");
-
-enum bf_map_bpf_type bf_set_type_to_map_bpf_type(enum bf_set_type type)
-{
-    return _bf_set_type_to_map_bpf_type[type];
 }
 
 int bf_set_type_from_str(const char *str, enum bf_set_type *type)

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -81,4 +81,3 @@ int bf_set_add_elem(struct bf_set *set, void *elem);
 
 const char *bf_set_type_to_str(enum bf_set_type type);
 int bf_set_type_from_str(const char *str, enum bf_set_type *type);
-enum bf_map_bpf_type bf_set_type_to_map_bpf_type(enum bf_set_type type);


### PR DESCRIPTION
`set.c` defines a function to convert a set type into a BPF map type, which requires the map types defined in `map.h`. Hence, it creates a dependency from the core module to the bpfilter module, which is an error.

Move the function to convert a set type into a BPF map type into map.c to remove the dependency.