### PR TITLE
Do not print counters for rules with counters disabled

### DIFF
--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -134,9 +134,11 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
             (void)fprintf(stdout, "\n");
         }
 
-        counter = bf_list_node_get_data(counter_node);
-        (void)fprintf(stdout, "        counters %lu packets %lu bytes\n",
-                      counter->packets, counter->bytes);
+        if (rule->counters) {
+            counter = bf_list_node_get_data(counter_node);
+            (void)fprintf(stdout, "        counters %lu packets %lu bytes\n",
+                          counter->packets, counter->bytes);
+        }
         counter_node = bf_list_node_next(counter_node);
 
         (void)fprintf(stdout, "        %s\n", bf_verdict_to_str(rule->verdict));


### PR DESCRIPTION
bfcli will print a 'counters ...' line for every rule when printing a chain or the ruleset, even if the rule doesn't have counters enabled.

Check if the rule has counters enabled before printing it.