### PR TITLE
Fix out-of-bounds write when parsing `tcp.flags`

### DIFF
--- a/src/core/matcher.c
+++ b/src/core/matcher.c
@@ -491,7 +491,7 @@ static int _bf_parse_tcp_flags(const struct bf_matcher *matcher, void *payload,
     char *tmp;
     char *saveptr;
     char *token;
-    enum bf_tcp_flag *flags = payload;
+    uint8_t *flags = payload;
 
     _raw_payload = strdup(raw_payload);
     if (!raw_payload)
@@ -508,7 +508,7 @@ static int _bf_parse_tcp_flags(const struct bf_matcher *matcher, void *payload,
         if (r)
             goto err;
 
-        *flags |= 1 << new_flag;
+        *flags |= (uint8_t)(1 << new_flag);
 
         tmp = NULL;
     }

--- a/src/core/matcher.h
+++ b/src/core/matcher.h
@@ -157,6 +157,9 @@ enum bf_tcp_flag
     _BF_TCP_MAX,
 };
 
+static_assert(_BF_TCP_MAX <= 8,
+              "too many TCP flags, they can't be used as bitmask in uint8_t");
+
 /**
  * Matcher comparison operator.
  *


### PR DESCRIPTION
The payload pointer is converted into an `enum bf_tcp_flag *` value and set to 0 (`*flag = 0`). However, the payload is 1 byte while a `bf_tcp_flag` enum type is 4, leading to out-of-bounds access.

Use `uint8_t` to represent the payload, and add a static assertion to `enum bf_tcp_flag` to ensure we never have more than 8 values to ensure the bitmask can still fit in `uint8_t`.