### PR TITLE
Move `bf_realloc()` to `helper.c`

### DIFF
--- a/src/core/helper.c
+++ b/src/core/helper.c
@@ -45,6 +45,21 @@ int bf_strncpy(char *dst, size_t len, const char *src)
     return copy_len != src_len ? -E2BIG : 0;
 }
 
+int bf_realloc(void **ptr, size_t size)
+{
+    _cleanup_free_ void *_ptr;
+
+    bf_assert(ptr);
+
+    _ptr = realloc(*ptr, size);
+    if (!_ptr)
+        return -ENOMEM;
+
+    *ptr = TAKE_PTR(_ptr);
+
+    return 0;
+}
+
 int bf_read_file(const char *path, void **buf, size_t *len)
 {
     _cleanup_close_ int fd = -1;

--- a/src/core/helper.h
+++ b/src/core/helper.h
@@ -296,20 +296,7 @@ static inline void *bf_memcpy(void *dst, const void *src, size_t len)
  * @param size New size of the memory buffer.
  * @return 0 on success, or a negative errno value on failure.
  */
-static inline int bf_realloc(void **ptr, size_t size)
-{
-    _cleanup_free_ void *_ptr;
-
-    bf_assert(ptr);
-
-    _ptr = realloc(*ptr, size);
-    if (!_ptr)
-        return -ENOMEM;
-
-    *ptr = TAKE_PTR(_ptr);
-
-    return 0;
-}
+int bf_realloc(void **ptr, size_t size);
 
 /**
  * @brief Check if strings are equal.


### PR DESCRIPTION
bf_realloc() uses TAKE_PTR() which rely on a compiler extension and might trigger a build failure on some platforms.