### PR TITLE
Add the rule ID to the logged data

### DIFF
--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -253,13 +253,13 @@ static void _bf_chain_log_header(const struct bf_log *log)
     (void)strftime(time_str, sizeof(time_str), "%H:%M:%S",
                    localtime(&time.tv_sec));
 
-    (void)fprintf(stdout, "\n%s[%s.%06ld]%s Packet: %s%llu bytes%s\n",
-                  bf_logger_get_color(BF_COLOR_LIGHT_CYAN, BF_STYLE_NORMAL),
-                  time_str, time.tv_nsec / BF_TIME_US,
-                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),
-                  bf_logger_get_color(BF_COLOR_DEFAULT, BF_STYLE_BOLD),
-                  log->pkt_size,
-                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+    (void)fprintf(
+        stdout, "\n%s[%s.%06ld]%s Rule #%u matched %s%llu bytes%s\n",
+        bf_logger_get_color(BF_COLOR_LIGHT_CYAN, BF_STYLE_NORMAL), time_str,
+        time.tv_nsec / BF_TIME_US,
+        bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), log->rule_id,
+        bf_logger_get_color(BF_COLOR_DEFAULT, BF_STYLE_BOLD), log->pkt_size,
+        bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
 }
 
 static void _bf_chain_log_l2(const struct bf_log *log)
@@ -309,7 +309,7 @@ static void _bf_chain_log_l3(const struct bf_log *log)
 
     switch (be16toh(log->l3_proto)) {
     case ETH_P_IP:
-        iphdr = (struct iphdr *)log->l3hdr;
+        iphdr = (struct iphdr *)&log->l3hdr[0];
 
         inet_ntop(AF_INET, &iphdr->saddr, src_addr, sizeof(src_addr));
         inet_ntop(AF_INET, &iphdr->daddr, dst_addr, sizeof(dst_addr));

--- a/src/bpfilter/bpf/log.bpf.c
+++ b/src/bpfilter/bpf/log.bpf.c
@@ -10,12 +10,12 @@
 
 #include "bpfilter/cgen/runtime.h"
 
-__u8 bf_log(struct bf_runtime *ctx, void *map, __u8 headers, __u16 l3_proto,
-            __u8 l4_proto)
+__u8 bf_log(struct bf_runtime *ctx, __u32 rule_idx, __u8 headers,
+            __u16 l3_proto, __u8 l4_proto)
 {
     struct bf_log *log;
 
-    log = bpf_ringbuf_reserve(map, sizeof(struct bf_log), 0);
+    log = bpf_ringbuf_reserve(ctx->log_map, sizeof(struct bf_log), 0);
     if (!log) {
         bpf_printk("failed to reserve %d bytes in ringbuf",
                    sizeof(struct bf_log));
@@ -23,6 +23,7 @@ __u8 bf_log(struct bf_runtime *ctx, void *map, __u8 headers, __u16 l3_proto,
     }
 
     log->ts = bpf_ktime_get_ns();
+    log->rule_id = rule_idx;
     log->pkt_size = ctx->pkt_size;
     log->req_headers = headers;
     log->headers = 0;

--- a/src/bpfilter/cgen/program.h
+++ b/src/bpfilter/cgen/program.h
@@ -209,8 +209,6 @@ struct bf_program
 
     /// Link objects attaching the program to a hook.
     struct bf_link *link;
-    /// Program with ip6.nexthdr rules
-    bool ipv6_nexthdr;
 
     /* Bytecode */
     uint32_t elfstubs_location[_BF_ELFSTUB_MAX];

--- a/src/bpfilter/cgen/runtime.h
+++ b/src/bpfilter/cgen/runtime.h
@@ -96,6 +96,9 @@ struct bf_runtime
      * used with for program flavor. */
     struct bpf_dynptr dynptr;
 
+    /** Ring buffer map containing the logged packets. */
+    void *log_map;
+
     /** Total size of the packet. */
     __u64 pkt_size;
 

--- a/src/core/chain.h
+++ b/src/core/chain.h
@@ -16,9 +16,36 @@ struct bf_rule;
 
 #define _free_bf_chain_ __attribute__((cleanup(bf_chain_free)))
 
+/**
+ * @brief Features used by the rules defined in the chain.
+ *
+ * Some features used by the rules have an impact at the chain or program level,
+ * these flags are used to define which feature is used at the chain level,  and
+ * generate the bytecode accordingly.
+ *
+ * For example, a pointer to the log ring buffer is store in the program's
+ * runtime context. This pointer should not be populated if no rule is has a
+ * 'log' instruction.
+ *
+ * Grouping the list of required features at the chain level prevents us from
+ * parsing all the rules and matchers everytime the feature would affect the
+ * bytecode.
+ */
+enum bf_chain_flags
+{
+    /** A rule will log data to the ring buffer. */
+    BF_CHAIN_LOG,
+
+    /** A rule will filter on IPv6 nexthdr field. */
+    BF_CHAIN_STORE_NEXTHDR,
+
+    _BF_CHAIN_FLAGS_MAX,
+};
+
 struct bf_chain
 {
     const char *name;
+    uint8_t flags;
     enum bf_hook hook;
     enum bf_verdict policy;
     bf_list sets;

--- a/src/core/runtime.h
+++ b/src/core/runtime.h
@@ -81,6 +81,9 @@ struct bf_log
     /** Timestamp of the packet processing. */
     __u64 ts;
 
+    /** ID of the rule triggering the log. */
+    __u32 rule_id;
+
     /** Total size of the packet, including the payload. */
     __u64 pkt_size;
 

--- a/tools/cmake/ElfStubs.cmake
+++ b/tools/cmake/ElfStubs.cmake
@@ -53,6 +53,7 @@ function(bf_target_add_elfstubs TARGET)
                 ${CLANG_BIN}
                     -O2
                     -target bpf
+                    -g
                     -I ${CMAKE_SOURCE_DIR}/src
                     -I ${CMAKE_SOURCE_DIR}/src/external
                     -c ${_LOCAL_DIR}/${_stub}.bpf.c


### PR DESCRIPTION
Include the matching rule index in the logged data, so the user knows which rule a log message is coming from.

Additionally, improve the conditional generation logic to prevent parsing the rules and matchers more than once to detect which rule logs or filters on `ipv6.nexthdr`.