### PR TITLE
Copy packet size from `__sk_buff.len`

### DIFF
--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -34,12 +34,9 @@ static int _bf_cgroup_gen_inline_prologue(struct bf_program *program)
 
     bf_assert(program);
 
-    // Calculate the packet size (+ETH_HLEN) and store it into the runtime context
-    EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1,
-                              offsetof(struct __sk_buff, data)));
+    // Copy the packet size (+ETH_HLEN) into the runtime context
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_3, BPF_REG_1,
-                              offsetof(struct __sk_buff, data_end)));
-    EMIT(program, BPF_ALU64_REG(BPF_SUB, BPF_REG_3, BPF_REG_2));
+                              offsetof(struct __sk_buff, len)));
     EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_3, ETH_HLEN));
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_3, BF_PROG_CTX_OFF(pkt_size)));

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -28,12 +28,9 @@ static int _bf_tc_gen_inline_prologue(struct bf_program *program)
 
     bf_assert(program);
 
-    // Calculate the packet size and store it into the runtime context
-    EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1,
-                              offsetof(struct __sk_buff, data)));
+    // Copy the packet size into the runtime context
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_3, BPF_REG_1,
-                              offsetof(struct __sk_buff, data_end)));
-    EMIT(program, BPF_ALU64_REG(BPF_SUB, BPF_REG_3, BPF_REG_2));
+                              offsetof(struct __sk_buff, len)));
     EMIT(program,
          BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_3, BF_PROG_CTX_OFF(pkt_size)));
 

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -67,6 +67,30 @@ Test(counters, update_partially_disabled)
                               bft_counter_p(1, 1, BFT_NO_BYTES));
 }
 
+Test(counters, packet_size)
+{
+    // Counters should be properly updated, even though some rules have counters
+    // disabled
+    _free_bf_chain_ struct bf_chain *chain = bf_test_chain_get(
+        BF_HOOK_XDP, BF_VERDICT_ACCEPT, NULL,
+        (struct bf_rule *[]) {
+            // Do not match
+            bf_rule_get(0, true, BF_VERDICT_ACCEPT,
+                        (struct bf_matcher *[]) {
+                            bf_matcher_get(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
+                                           (uint8_t[]) {
+                                                127, 2, 10, 10
+                                           },
+                                           4),
+                            NULL,
+                        }),
+            NULL,
+        });
+
+    bft_e2e_test_with_counter(chain, BF_VERDICT_ACCEPT, pkt_local_ip4,
+                              bft_counter_p(0, 1, pkt_local_ip4[0].pkt_len));
+}
+
 Test(meta, l4_proto)
 {
     _free_bf_chain_ struct bf_chain *match_eq = bf_test_chain_get(


### PR DESCRIPTION
Instead of calculating the packet size by substracting `data` from `data_end`, use `__sk_buff.len`. This reduces the number of instructions for TC and CGROUP_SKB programs by 2.

Additionally, it prevents erroneous size calculation if `data_end` is unset (can occur with `BPF_PROG_RUN`).