### PR TITLE
On chain update, pin the new program, not the old one

### DIFF
--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -415,7 +415,7 @@ int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain)
     }
 
     if (bf_opts_persist()) {
-        r = bf_program_pin(cgen->program, pindir_fd);
+        r = bf_program_pin(new_prog, pindir_fd);
         if (r)
             bf_warn_r(r, "failed to pin new prog, ignoring");
     }


### PR DESCRIPTION
`bf_cgen_update()` unpin the old program, before updating the link, and pinning the old program back. Obviously, we need to pin the new program, not the old one.

This commit pin the new program and add end-to-end tests to validate the update has been performed correctly.