### PR TITLE
Handle required and incompatible options in `bfcli`

### DIFF
--- a/src/bfcli/opts.h
+++ b/src/bfcli/opts.h
@@ -62,6 +62,8 @@ struct bfc_opts
     enum bfc_object object;
     enum bfc_action action;
 
+    uint32_t set_opts;
+
     const char *from_str;
     const char *from_file;
     const char *name;
@@ -73,7 +75,8 @@ struct bfc_opts_cmd
     enum bfc_object object;
     enum bfc_action action;
     const char *name;
-    int valid_opts;
+    uint32_t valid_opts;
+    uint32_t required_opts;
     const char *doc;
     int (*cb)(const struct bfc_opts *opts);
 };

--- a/tests/e2e/cli.sh
+++ b/tests/e2e/cli.sh
@@ -399,6 +399,42 @@ suite_netns_to_host() {
 }
 with_daemon suite_netns_to_host
 
+suite_bcli_options_error() {
+    log "[SUITE] bfcli: options error"
+    expect_failure "ruleset set: --from-str and --from-file are incompatible" \
+        ${FROM_NS} ${BFCLI} ruleset set --from-str \"\" --from-file \"\"
+    expect_failure "ruleset set: --from-str or --from-file are required" \
+        ${FROM_NS} ${BFCLI} ruleset set
+
+    expect_failure "chain set: --from-str and --from-file are incompatible" \
+        ${FROM_NS} ${BFCLI} chain set --from-str \"\" --from-file \"\"
+    expect_failure "chain set: --from-str or --from-file are required" \
+        ${FROM_NS} ${BFCLI} chain set
+
+    expect_failure "chain get: --name is required" \
+        ${FROM_NS} ${BFCLI} chain get
+
+    expect_failure "chain logs: --name is required" \
+        ${FROM_NS} ${BFCLI} chain logs
+
+    expect_failure "chain load: --from-str and --from-file are incompatible" \
+        ${FROM_NS} ${BFCLI} chain load --from-str \"\" --from-file \"\"
+    expect_failure "chain load: --from-str or --from-file are required" \
+        ${FROM_NS} ${BFCLI} chain load
+
+    expect_failure "chain attach: --name is required" \
+        ${FROM_NS} ${BFCLI} chain attach
+
+    expect_failure "chain attach: --from-str and --from-file are incompatible" \
+        ${FROM_NS} ${BFCLI} chain attach --from-str \"\" --from-file \"\"
+    expect_failure "chain attach: --from-str or --from-file are required" \
+        ${FROM_NS} ${BFCLI} chain attach
+
+    expect_failure "chain flush: --name is required" \
+        ${FROM_NS} ${BFCLI} chain flush
+}
+with_daemon suite_bcli_options_error
+
 suite_host_to_netns() {
     log "[SUITE] netns: host -> netns"
     expect_failure "can't attach chain to host iface from netns" \


### PR DESCRIPTION
Add `required_opts` field to `bfc_opts_cmd` to list the required options for each command, if a required option is missing, bfcli will print an error.

Add rejects field to `bfc_opts_opt` to list the options incompatible with a given option (e.g. `--from-str` and `--from-file`).

A missing required option is ignored if another option it's incompatible with is set.