### PR TITLE
Allow users to name and reuse sets

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -368,9 +368,18 @@ Sets
 
 Sets defines a group of data of the same type. At runtime, the chain will check if the corresponding packet data is in the set, instead of checking against every single value from the set, which makes it much faster.
 
-In your ruleset, sets are defined as:
+There are multiple ways to define sets in your ruleset. bpfilter supports named and anonymous sets:
 
 .. code:: shell
+
+    set $NAME $KEY in {
+        $ELEMENT_0;
+        $ELEMENT_1
+    }
+
+    rule
+        $KEY in $NAME
+        [...]
 
     rule
         $KEY in { $ELEMENT_0; $ELEMENT_1 }
@@ -384,12 +393,20 @@ In your ruleset, sets are defined as:
         [...]
 
 With:
+  - ``$NAME``: name of the set, for named sets. Allows users to define a set at the beginning of the ruleset, then use it in multiple rules. Sets defined directly in a rule are anonymous, they can't be reused in a different rule. When using a named set, the key used in the rule to refer to the set must be the same as the key used to define the set.
   - ``$KEY``: the key of the same, the format of the data stored in the set. Keys are defined as ``($MATCHER_0 [, $MATCHERS...])```. This instructs bpfilter that the key is formed from the payload of the list matchers. For example, ``(ip4.saddr, ip4.proto)`` describe the key as the source IPv4 address followed by the IPv4 protocol field. Each matcher defined in the key is called a "component".
   - ``$ELEMENT``: elements are the data to store in the set, each component of the key should have a corresponding value in each element. Components of an element are comma-separated, elements themselves are delimited by semicolon or new line.
 
 Here is an example:
 
 .. code:: shell
+
+    set dns (ip4.saddr) in { 1.1.1.1; 1.0.0.1 }
+
+    rule
+        (ip4.saddr) in dns
+        counter
+        ACCEPT
 
     rule
         (ip4.saddr, ip4.proto) in {

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -43,6 +43,7 @@ int             (-|(0x))?[0-9a-zA-Z]+
 
 chain           { return CHAIN; }
 rule            { return RULE; }
+set             { return SET; }
 
     /* Keywords */
 counter         { return COUNTER; }
@@ -69,7 +70,7 @@ log             { BEGIN(STATE_LOG_OPTS); return LOG; }
 }
 
     /* Sets */
-\(([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)([ \t\n\r\f\v]*,[ \t\n\r\f\v]*([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+))*.*\) {
+\([ \t\n\r\f\v]*([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)([ \t\n\r\f\v]*,[ \t\n\r\f\v]*([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+))*[ \t\n\r\f\v]*\) {
     BEGIN(STATE_MATCHER_SET);
     yylval.sval = strdup(yytext);
     return SET_TYPE;

--- a/src/core/set.h
+++ b/src/core/set.h
@@ -45,6 +45,9 @@ struct bf_marsh;
  */
 struct bf_set
 {
+    /** Name of the set. If NULL, the set is anonymous. */
+    const char *name;
+
     /** Key of the set. Can't contain more than `BF_SET_MAX_N_COMPS` types. */
     enum bf_matcher_type key[BF_SET_MAX_N_COMPS];
 
@@ -67,25 +70,30 @@ struct bf_set
  * @brief Allocate and initialise a new set.
  *
  * @param set Set to allocate and initialise. Can't be NULL.
+ * @param name Name of the set, can be used to identify it. If NULL, the set
+ *        is anonymous.
  * @param key Key of the set, as an array of `bf_matcher_type`. Not all the
  *        matcher types can be used as set key components. Can't be NULL.
  * @param n_comps Number of components in `key`.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_set_new(struct bf_set **set, enum bf_matcher_type *key, size_t n_comps);
+int bf_set_new(struct bf_set **set, const char *name, enum bf_matcher_type *key,
+               size_t n_comps);
 
 /**
  * @brief Allocate and initialise a new set from a raw key and payload values.
  *
  * @param set Set to allocate and initialise. Can't be NULL.
+ * @param name Name of the set, can be used to identify it. If NULL, the set
+ *        is anonymous.
  * @param raw_key Set key, as a string of comma-separated matcher types enclosed
  *        in parentheses. Can't be NULL.
  * @param raw_payload Set payload, to parse according to `raw_key`. Can't be
  *        NULL.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_set_new_from_raw(struct bf_set **set, const char *raw_key,
-                        const char *raw_payload);
+int bf_set_new_from_raw(struct bf_set **set, const char *name,
+                        const char *raw_key, const char *raw_payload);
 
 int bf_set_new_from_marsh(struct bf_set **set, const struct bf_marsh *marsh);
 void bf_set_free(struct bf_set **set);

--- a/tests/harness/filters.c
+++ b/tests/harness/filters.c
@@ -54,7 +54,7 @@ struct bf_set *bft_set_get(enum bf_matcher_type *key, size_t n_comps,
     _free_bf_set_ struct bf_set *set = NULL;
     int r;
 
-    r = bf_set_new(&set, key, n_comps);
+    r = bf_set_new(&set, NULL, key, n_comps);
     if (r < 0) {
         bf_err_r(r, "failed to create a new test set");
         return NULL;

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -1,5 +1,10 @@
 # Create an XDP chain
 chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
     rule
         meta.dport eq 22
         log internet
@@ -203,6 +208,7 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         counter
         ACCEPT
     rule
+        (ip4.saddr, ip4.proto) in my_custom_set
         (ip4.saddr, ip4.proto) in {
             192.168.1.131, tcp
             192.168.1.132, udp

--- a/tests/unit/core/set.c
+++ b/tests/unit/core/set.c
@@ -15,48 +15,48 @@ Test(set, new_and_free)
 {
     _free_bf_set_ struct bf_set *set = NULL;
 
-    expect_assert_failure(bf_set_new(NULL, NOT_NULL, 1));
-    expect_assert_failure(bf_set_new(NOT_NULL, NULL, 1));
+    expect_assert_failure(bf_set_new(NULL, NULL, NOT_NULL, 1));
+    expect_assert_failure(bf_set_new(NOT_NULL, NULL, NULL, 1));
     expect_assert_failure(bf_set_free(NULL));
 
     // NOK: no components in key
-    assert_error(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_error(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP4_PROTO
     }, 0));
 
     // NOK: more components than the maximum value allowed
-    assert_error(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_error(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP4_PROTO
     }, BF_SET_MAX_N_COMPS + 1));
 
     // NOK: key contains an invalid matcher type
-    assert_error(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_error(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         _BF_MATCHER_TYPE_MAX + 1, BF_MATCHER_IP4_PROTO
     }, 2));
 
     // NOK: using a CIDR matcher in combination with any other matcher
-    assert_error(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_error(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP6_DNET, BF_MATCHER_IP4_PROTO
     }, 2));
-    assert_error(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_error(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP6_DNET, BF_MATCHER_IP6_SNET
     }, 2));
 
     // OK: single component
-    assert_success(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_success(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP4_PROTO,
     }, 1));
     bf_set_free(&set);
 
     // OK: multiple components
-    assert_success(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_success(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP4_PROTO, BF_MATCHER_IP4_DADDR, BF_MATCHER_IP6_SADDR
     }, 3));
     assert_false(set->use_trie);
     bf_set_free(&set);
 
     // OK: single component, use trie
-    assert_success(bf_set_new(&set, (enum bf_matcher_type[]){
+    assert_success(bf_set_new(&set, NULL, (enum bf_matcher_type[]){
         BF_MATCHER_IP6_SNET
     }, 1));
     assert_true(set->elem_size);
@@ -68,61 +68,61 @@ Test(set, new_from_raw)
 {
     _free_bf_set_ struct bf_set *set = NULL;
 
-    expect_assert_failure(bf_set_new_from_raw(NULL, NOT_NULL, NOT_NULL));
-    expect_assert_failure(bf_set_new_from_raw(NOT_NULL, NULL, NOT_NULL));
-    expect_assert_failure(bf_set_new_from_raw(NOT_NULL, NOT_NULL, NULL));
+    expect_assert_failure(bf_set_new_from_raw(NULL, NULL, NOT_NULL, NOT_NULL));
+    expect_assert_failure(bf_set_new_from_raw(NOT_NULL, NULL, NULL, NOT_NULL));
+    expect_assert_failure(bf_set_new_from_raw(NOT_NULL, NULL, NOT_NULL, NULL));
 
     // NOK: empty key
-    assert_error(bf_set_new_from_raw(&set, "()", "{}"));
+    assert_error(bf_set_new_from_raw(&set, NULL, "()", "{}"));
 
     // NOK: too many key components
-    assert_error(bf_set_new_from_raw(&set,
+    assert_error(bf_set_new_from_raw(&set, NULL,
         "(ip4.proto,ip4.proto,ip4.proto,ip4.proto,"
         "ip4.proto,ip4.proto,ip4.proto,ip4.proto,ip4.proto)",
         "{}"
     ));
 
     // NOK: invalid key component
-    assert_error(bf_set_new_from_raw(&set, "(ip4.invalid)", "{}"));
+    assert_error(bf_set_new_from_raw(&set, NULL, "(ip4.invalid)", "{}"));
 
     // NOK: invalid delimiter
-    assert_error(bf_set_new_from_raw(&set, "(ip4.proto; ip4.proto)", "{}"));
+    assert_error(bf_set_new_from_raw(&set, NULL, "(ip4.proto; ip4.proto)", "{}"));
 
     // NOK: more components in element than key
-    assert_error(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp, 21}"));
+    assert_error(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp, 21}"));
 
     // OK: no element
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{}"));
     assert_int_equal(bf_list_size(&set->elems), 0);
     bf_set_free(&set);
 
     // OK: single element
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp}"));
     assert_int_equal(bf_list_size(&set->elems), 1);
     bf_set_free(&set);
 
     // OK: multiple elements
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp; udp; icmp}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp; udp; icmp}"));
     assert_int_equal(bf_list_size(&set->elems), 3);
     bf_set_free(&set);
 
     // OK: extra spaces
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp    ;    udp;    icmp}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp    ;    udp;    icmp}"));
     assert_int_equal(bf_list_size(&set->elems), 3);
     bf_set_free(&set);
 
     // OK: using \n as a delimiter
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp   \n  udp \n  icmp}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp   \n  udp \n  icmp}"));
     assert_int_equal(bf_list_size(&set->elems), 3);
     bf_set_free(&set);
 
     // OK: contain an empty element
-    assert_success(bf_set_new_from_raw(&set, "(ip4.proto)", "{tcp   \n\n udp \n  icmp}"));
+    assert_success(bf_set_new_from_raw(&set, NULL, "(ip4.proto)", "{tcp   \n\n udp \n  icmp}"));
     assert_int_equal(bf_list_size(&set->elems), 3);
     bf_set_free(&set);
 
     // OK: multiple components
-    assert_success(bf_set_new_from_raw(&set,
+    assert_success(bf_set_new_from_raw(&set, NULL,
         "(ip4.proto, ip4.saddr, ip4.daddr)",
         "{"
             "tcp, 192.168.1.1, 192.168.1.10\n"
@@ -146,7 +146,7 @@ Test(set, marsh_and_unmarsh)
     expect_assert_failure(bf_set_new_from_marsh(NULL, NOT_NULL));
 
     // Create a non-empty set
-    assert_success(bf_set_new_from_raw(&in,
+    assert_success(bf_set_new_from_raw(&in, NULL,
         "(ip4.proto, ip4.saddr, ip4.daddr)",
         "{"
             "tcp, 192.168.1.1, 192.168.1.10\n"
@@ -186,7 +186,7 @@ Test(set, dump)
     expect_assert_failure(bf_set_dump(NULL, NOT_NULL));
 
     // Create a non-empty set
-    assert_success(bf_set_new_from_raw(&set,
+    assert_success(bf_set_new_from_raw(&set, NULL,
         "(ip4.proto, ip4.saddr, ip4.daddr)",
         "{"
             "tcp, 192.168.1.1, 192.168.1.10\n"
@@ -212,7 +212,7 @@ Test(set, add_element)
     expect_assert_failure(bf_set_add_elem(NULL, NOT_NULL));
 
     // Create a non-empty set
-    assert_success(bf_set_new_from_raw(&set,
+    assert_success(bf_set_new_from_raw(&set, NULL,
         "(ip4.proto, ip4.saddr, ip4.daddr)", "{}"
     ));
 


### PR DESCRIPTION
Currently, users can use sets to efficiently filter packets against a large pool of similarly formatted data. Sets are defined as part of a rule, and can't be reused for other rules. If a user wants to filter on the same 10k elements sets in 2 different rules, bpfilter will create the set twice.

This change adds a new syntax to allow users to create named sets at the beginning of a chain, then filter on it in a rule using its name:

```
chain mychain BF_HOOK_XDP{ifindex=2} ACCEPT
    set myset (ip4.saddr, ip4.proto) in {
        192.168.1.1, udp;
        192.168.1.1, tcp
    }

    rule
        (ip4.saddr, ip4.proto) in myset
        tcp.flags any syn
        counter
        ACCEPT
      
    rule
        (ip4.saddr, ip4.proto) in myset
        counter
        ACCEPT
```