### PR TITLE
doc: make install requires root

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo dnf install -y clang cmake gcc libbpf-devel libnl3-devel bison flex sed xxd
 
 # Configure the project and build bpfilter
 cmake -S $SOURCES_DIR -B $BUILD_DIR -DNO_DOCS=ON -DNO_TESTS=ON -DNO_CHECKS=ON -DNO_BENCHMARKS=ON
-make -C $BUILD_DIR install
+sudo make -C $BUILD_DIR install
 ```
 
 ### Usage


### PR DESCRIPTION
When trying to build from source, make command requires root:

```
CMake Error at src/bpfilter/cmake_install.cmake:52 (file):
  file INSTALL cannot copy file
  "/home/user/Clones/bpfilter/build/output/sbin/bpfilter" to
  "/usr/local/sbin/bpfilter": Permission denied.
Call Stack (most recent call first):
  cmake_install.cmake:52 (include)
```