### PR TITLE
doc: don't install while building

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sudo dnf install -y clang cmake gcc libbpf-devel libnl3-devel bison flex sed xxd
 
 # Configure the project and build bpfilter
 cmake -S $SOURCES_DIR -B $BUILD_DIR -DNO_DOCS=ON -DNO_TESTS=ON -DNO_CHECKS=ON -DNO_BENCHMARKS=ON
-make -C $BUILD_DIR install
+make -C $BUILD_DIR
 ```
 
 ### Usage


### PR DESCRIPTION
In the [build from source](https://github.com/facebook/bpfilter?tab=readme-ov-file#build-from-sources) section of the readme file, install argument is passed to make