### PR TITLE
[RESEND] bpfilter: xlate: use const argument when possible

### DIFF
--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -26,7 +26,7 @@
 
 static int _bf_cli_setup(void);
 static int _bf_cli_teardown(void);
-static int _bf_cli_request_handler(struct bf_request *request,
+static int _bf_cli_request_handler(const struct bf_request *request,
                                    struct bf_response **response);
 static int _bf_cli_marsh(struct bf_marsh **marsh);
 static int _bf_cli_unmarsh(struct bf_marsh *marsh);
@@ -583,7 +583,7 @@ int _bf_cli_chain_flush(const struct bf_request *request,
     return bf_ctx_delete_cgen(cgen, true);
 }
 
-static int _bf_cli_request_handler(struct bf_request *request,
+static int _bf_cli_request_handler(const struct bf_request *request,
                                    struct bf_response **response)
 {
     int r;

--- a/src/bpfilter/xlate/front.h
+++ b/src/bpfilter/xlate/front.h
@@ -14,8 +14,6 @@ struct bf_marsh;
 /**
  * @struct bf_front_ops
  *
- * @todo Make bf_front_ops.request_handler take a const struct bf_request.
- *
  * @var bf_front_ops::setup
  *  Setup the front.
  * @var bf_front_ops::teardown
@@ -27,7 +25,7 @@ struct bf_front_ops
 {
     int (*setup)(void);
     int (*teardown)(void);
-    int (*request_handler)(struct bf_request *request,
+    int (*request_handler)(const struct bf_request *request,
                            struct bf_response **response);
     int (*marsh)(struct bf_marsh **marsh);
     int (*unmarsh)(struct bf_marsh *marsh);

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -710,7 +710,7 @@ static int _bf_ipt_set_counters_handler(struct xt_counters_info *counters,
     return 0;
 }
 
-int _bf_ipt_get_info_handler(struct bf_request *request,
+int _bf_ipt_get_info_handler(const struct bf_request *request,
                              struct bf_response **response)
 {
     _cleanup_free_ struct ipt_replace *replace = NULL;
@@ -746,7 +746,7 @@ int _bf_ipt_get_info_handler(struct bf_request *request,
  * @param response
  * @return 0 on success, negative errno value on failure.
  */
-int _bf_ipt_get_entries_handler(struct bf_request *request,
+int _bf_ipt_get_entries_handler(const struct bf_request *request,
                                 struct bf_response **response)
 {
     _cleanup_free_ struct ipt_replace *replace = NULL;
@@ -804,7 +804,7 @@ static int _bf_ipt_teardown(void)
  * @param response
  * @return
  */
-static int _bf_ipt_request_handler(struct bf_request *request,
+static int _bf_ipt_request_handler(const struct bf_request *request,
                                    struct bf_response **response)
 {
     int r;

--- a/src/bpfilter/xlate/nft/nft.c
+++ b/src/bpfilter/xlate/nft/nft.c
@@ -35,7 +35,7 @@ static int _bf_nft_unmarsh(struct bf_marsh *marsh)
     return 0;
 }
 
-static int _bf_nft_request_handler(struct bf_request *request,
+static int _bf_nft_request_handler(const struct bf_request *request,
                                    struct bf_response **response)
 {
     UNUSED(request);


### PR DESCRIPTION
resolves the following todo
src/bpfilter/xlate/front.h: @todo  Make bf_front_ops.request_handler take a const struct bf_request.