### PR TITLE
Allow `tcp.(d|s)port` and `udp.(d|s)port` in sets

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -608,21 +608,25 @@ TCP
       - Operator
       - Payload
       - Notes
-    * - :rspan:`2` Source port
-      - :rspan:`2` ``tcp.sport``
+    * - :rspan:`3` Source port
+      - :rspan:`3` ``tcp.sport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
+      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
     * - ``not``
+    * - ``in``
+      - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`2` Destination port
-      - :rspan:`2` ``tcp.dport``
+    * - :rspan:`3` Destination port
+      - :rspan:`3` ``tcp.dport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
+      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
     * - ``not``
+    * - ``in``
+      - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
@@ -658,21 +662,25 @@ UDP
       - Operator
       - Payload
       - Notes
-    * - :rspan:`2` Source port
-      - :rspan:`2` ``udp.sport``
+    * - :rspan:`3` Source port
+      - :rspan:`3` ``udp.sport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
+      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
     * - ``not``
+    * - ``in``
+      - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`2` Destination port
-      - :rspan:`2` ``udp.dport``
+    * - :rspan:`3` Destination port
+      - :rspan:`3` ``udp.dport``
       - ``eq``
       - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
+      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
     * - ``not``
+    * - ``in``
+      - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -68,8 +68,9 @@ _bf_matcher_generate_meta_probability(struct bf_program *program,
 
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_get_prandom_u32));
     EMIT_FIXUP_JMP_NEXT_RULE(
-        program, BPF_JMP_IMM(BPF_JGT, BPF_REG_0,
-                             (uint32_t)((uint64_t)UINT32_MAX * (proba / 100.0)), 0));
+        program,
+        BPF_JMP_IMM(BPF_JGT, BPF_REG_0,
+                    (uint32_t)((uint64_t)UINT32_MAX * (proba / 100.0)), 0));
 
     return 0;
 }
@@ -110,12 +111,12 @@ static int _bf_matcher_generate_meta_port(struct bf_program *program,
 
     switch (bf_matcher_get_op(matcher)) {
     case BF_MATCHER_EQ:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JNE, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JNE, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_NE:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_RANGE:
         /* Convert the big-endian value stored in the packet into a

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -69,7 +69,7 @@ _bf_matcher_generate_meta_probability(struct bf_program *program,
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_get_prandom_u32));
     EMIT_FIXUP_JMP_NEXT_RULE(
         program, BPF_JMP_IMM(BPF_JGT, BPF_REG_0,
-                             (int)(UINT32_MAX * (proba / 100.0)), 0));
+                             (uint32_t)((uint64_t)UINT32_MAX * (proba / 100.0)), 0));
 
     return 0;
 }

--- a/src/bpfilter/cgen/matcher/tcp.c
+++ b/src/bpfilter/cgen/matcher/tcp.c
@@ -33,12 +33,12 @@ static int _bf_matcher_generate_tcp_port(struct bf_program *program,
 
     switch (bf_matcher_get_op(matcher)) {
     case BF_MATCHER_EQ:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JNE, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JNE, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_NE:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_RANGE:
         /* Convert the big-endian value stored in the packet into a

--- a/src/bpfilter/cgen/matcher/udp.c
+++ b/src/bpfilter/cgen/matcher/udp.c
@@ -33,12 +33,12 @@ static int _bf_matcher_generate_udp_port(struct bf_program *program,
 
     switch (bf_matcher_get_op(matcher)) {
     case BF_MATCHER_EQ:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JNE, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JNE, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_NE:
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, htobe16(*port), 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JEQ, BPF_REG_1, *port, 0));
         break;
     case BF_MATCHER_RANGE:
         /* Convert the big-endian value stored in the packet into a

--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -75,15 +75,15 @@ enum bf_matcher_type
     BF_MATCHER_IP6_DNET,
     /// Matches IPv6 next header
     BF_MATCHER_IP6_NEXTHDR,
-    /// Matches against the TCP source port
+    /// Matches against the TCP source port. Stored as big-endian.
     BF_MATCHER_TCP_SPORT,
-    /// Matches against the TCP destination port
+    /// Matches against the TCP destination port. Stored as big-endian.
     BF_MATCHER_TCP_DPORT,
     /// Matchers against the TCP flags
     BF_MATCHER_TCP_FLAGS,
-    /// Matches against the UDP source port
+    /// Matches against the UDP source port. Stored as big-endian.
     BF_MATCHER_UDP_SPORT,
-    /// Matches against the UDP destination port
+    /// Matches against the UDP destination port. Stored as big-endian.
     BF_MATCHER_UDP_DPORT,
     /// Matches against the ICMP type
     BF_MATCHER_ICMP_TYPE,

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -16,6 +16,7 @@
 #include <linux/udp.h>
 
 #include <ctype.h>
+#include <endian.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -194,7 +195,7 @@ int _bf_parse_l4_port(enum bf_matcher_type type, enum bf_matcher_op op,
 
     port = strtoul(raw_payload, &endptr, BF_BASE_10);
     if (*endptr == '\0' && port <= UINT16_MAX) {
-        *(uint16_t *)payload = (uint16_t)port;
+        *(uint16_t *)payload = htobe16((uint16_t)port);
         return 0;
     }
 
@@ -208,7 +209,7 @@ void _bf_print_l4_port(const void *payload)
 {
     bf_assert(payload);
 
-    (void)fprintf(stdout, "%" PRIu16, *(uint16_t *)payload);
+    (void)fprintf(stdout, "%" PRIu16, (uint16_t)be16toh(*(uint16_t *)payload));
 }
 
 #define BF_PORT_RANGE_MAX_LEN 16 // 65535-65535, with nul char, round to **2
@@ -890,6 +891,8 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
+                    BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
+                                   _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,
                                    _bf_print_l4_port_range),
@@ -906,6 +909,8 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
+                                   _bf_parse_l4_port, _bf_print_l4_port),
+                    BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,
@@ -942,6 +947,8 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
+                    BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
+                                   _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,
                                    _bf_print_l4_port_range),
@@ -958,6 +965,8 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
+                                   _bf_parse_l4_port, _bf_print_l4_port),
+                    BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -2114,7 +2114,7 @@ Test(ipv6, extension_headers)
                 BF_VERDICT_DROP,
                 (struct bf_matcher *[]) {
                     bf_matcher_get(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
-                        (uint8_t[]) { 0xb7, 0x7a },
+                        (uint8_t[]) { 0x7a, 0xb7 },
                         2
                     ),
                     NULL,

--- a/tests/e2e/main.c
+++ b/tests/e2e/main.c
@@ -193,6 +193,39 @@ Test(meta, l4_proto)
     bft_e2e_test(nomatch_ne, BF_VERDICT_ACCEPT, pkt_remote_ip6_eh_tcp);
 }
 
+Test(meta, probability)
+{
+    _free_bf_chain_ struct bf_chain *always_drop = bf_test_chain_get(
+        BF_HOOK_XDP, BF_VERDICT_ACCEPT, NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                0, false, BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
+                                   (uint8_t[]) { 100 },
+                                   1),
+                    NULL,
+                }),
+            NULL,
+        });
+    bft_e2e_test(always_drop, BF_VERDICT_DROP, pkt_local_ip6_hop);
+
+    _free_bf_chain_ struct bf_chain *never_drop = bf_test_chain_get(
+        BF_HOOK_XDP, BF_VERDICT_ACCEPT, NULL,
+        (struct bf_rule *[]) {
+            bf_rule_get(
+                0, false, BF_VERDICT_DROP,
+                (struct bf_matcher *[]) {
+                    bf_matcher_get(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
+                                   (uint8_t[]) { 0 },
+                                   1),
+                    NULL,
+                }),
+            NULL,
+        });
+    bft_e2e_test(never_drop, BF_VERDICT_ACCEPT, pkt_local_ip6_hop);
+}
+
 Test(ip4, proto)
 {
     _free_bf_chain_ struct bf_chain *match_eq = bf_test_chain_get(

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -131,6 +131,7 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         tcp.sport not 0
         tcp.sport not 17
         tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
         tcp.sport range 0-65535
         tcp.sport range 17-31
         tcp.dport eq 0
@@ -139,6 +140,7 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         tcp.dport not 0
         tcp.dport not 17
         tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
         tcp.dport range 0-65535
         tcp.dport range 17-31
         counter
@@ -163,6 +165,7 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         udp.sport not 0
         udp.sport not 17
         udp.sport not 65535
+        (udp.sport) in {16;124;6463}
         udp.sport range 0-65535
         udp.sport range 17-31
         udp.dport eq 0
@@ -171,6 +174,7 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         udp.dport not 0
         udp.dport not 17
         udp.dport not 65535
+        (udp.dport) in {16;124;6463}
         udp.dport range 0-65535
         udp.dport range 17-31
         counter


### PR DESCRIPTION
Allow users to use `tcp.(d|s)port` and `udp.(d|s)port` in sets by adding support for `BF_MATCHER_IN` operators. This change requires their payload to be stored in big-endian format, so it doesn't have to be converted when stored in a BPF map.