### PR TITLE
Build libbpfilter as a shared library

### DIFF
--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -80,13 +80,13 @@ configure_file(
 )
 
 add_library(libbpfilter
-    STATIC
+    SHARED
         ${libbpfilter_srcs}
 )
 
 target_compile_definitions(libbpfilter
     PRIVATE
-        # MPack should use the C standard library API
+        # MPack should use the C standard library API
         MPACK_STDLIB
 )
 


### PR DESCRIPTION
[e81667f](https://github.com/facebook/bpfilter/commit/e81667f188be09d452858c543f34f1a8625109ca) merged core and libbpfilter modules together, but changed libbpfilter to a static library, which is a mistake.