### PR TITLE
cli,lib,daemon: support packet marking and add meta.mark matcher

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -348,12 +348,14 @@ Rules are defined such as:
         [$SET...]
         [log link,internet,transport]
         [counter]
+        [mark $MARK]
         $VERDICT
 
 With:
   - ``$MATCHER``: zero or more matchers. Matchers are defined later.
   - ``log``: optional. If set, log the requested protocol headers. ``link`` will log the link (layer 2) header, ``internet`` with log the internet (layer 3) header, and ``transport`` will log the transport (layer 4) header. At least one header type is required.
   - ``counter``: optional literal. If set, the filter will counter the number of packets and bytes matched by the rule.
+  - ``mark``: optional, ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. If set, write the packet's marker value. This marker can be used later on in a rule (see ``meta.mark``) or with a TC filter.
   - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP`` or ``CONTINUE``.
     - ``ACCEPT``: forward the packet to the kernel
     - ``DROP``: discard the packet.
@@ -494,6 +496,12 @@ Meta
       - ``eq``
       - ``$PROBABILITY``
       - ``$PROBABILITY`` is a valid decimal percentage value (i.e., within [0%, 100%]).
+    * - :rspan:`1` Mark
+      - :rspan:`1` ``meta.mark``
+      - ``eq``
+      - :rspan:`1` ``$MARK``
+      - :rspan:`1` ``$MARK`` must be a valid decimal or hexadecimal 32-bits value.
+    * - ``not``
 
 IPv4
 ####

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -22,9 +22,11 @@
 
 %s STATE_HOOK_OPTS
 %s STATE_LOG_OPTS
+%s STATE_MARK_OPTS
 %s STATE_MATCHER_SET
 %s STATE_MATCHER_META_IFACE
 %s STATE_MATCHER_META_L3_PROTO
+%s STATE_MATCHER_META_MARK
 %s STATE_MATCHER_L4_PROTO
 %s STATE_MATCHER_META_PROBA
 %s STATE_MATCHER_IPV4_ADDR
@@ -60,6 +62,15 @@ BF_HOOK_[A-Z_]+ { BEGIN(STATE_HOOK_OPTS); yylval.sval = strdup(yytext); return H
 }
     /* Verdicts */
 (ACCEPT|DROP|CONTINUE)   { yylval.sval = strdup(yytext); return VERDICT; }
+
+    /* Mark */
+mark            { BEGIN(STATE_MARK_OPTS); return MARK; }
+<STATE_MARK_OPTS>{
+    {int} {
+        yylval.sval = strdup(yytext);
+        return STRING;
+    }
+}
 
     /* Logs */
 log             { BEGIN(STATE_LOG_OPTS); return LOG; }
@@ -118,6 +129,15 @@ meta\.probability  { BEGIN(STATE_MATCHER_META_PROBA); yylval.sval = strdup(yytex
 <STATE_MATCHER_META_PROBA>{
     (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}% {
+        yylval.sval = strdup(yytext);
+        return RAW_PAYLOAD;
+    }
+}
+
+meta\.mark          { BEGIN(STATE_MATCHER_META_MARK); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+<STATE_MATCHER_META_MARK>{
+    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    {int} {
         yylval.sval = strdup(yytext);
         return RAW_PAYLOAD;
     }

--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -59,6 +59,10 @@ int bf_cgen_new(struct bf_cgen **cgen, enum bf_front front,
 
     (*cgen)->front = front;
     (*cgen)->program = NULL;
+    (*cgen)->chain = NULL;
+
+    if (!bf_chain_validate(*chain))
+        return bf_err_r(-EINVAL, "chain '%s' is invalid", (*chain)->name);
     (*cgen)->chain = TAKE_PTR(*chain);
 
     return 0;
@@ -88,6 +92,9 @@ int bf_cgen_new_from_pack(struct bf_cgen **cgen, bf_rpack_node_t node)
     r = bf_chain_new_from_pack(&_cgen->chain, child);
     if (r)
         return bf_rpack_key_err(r, "bf_cgen.chain");
+
+    if (!bf_chain_validate(_cgen->chain))
+        return bf_err_r(-EINVAL, "chain '%s' is invalid", _cgen->chain->name);
 
     r = bf_rpack_kv_node(node, "program", &child);
     if (r)

--- a/src/bpfilter/cgen/cgroup.c
+++ b/src/bpfilter/cgen/cgroup.c
@@ -102,6 +102,28 @@ static int _bf_cgroup_gen_inline_epilogue(struct bf_program *program)
     return 0;
 }
 
+static int _bf_cgroup_gen_inline_set_mark(struct bf_program *program,
+                                          uint32_t mark)
+{
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_2, mark));
+    EMIT(program, BPF_STX_MEM(BPF_W, BPF_REG_1, BPF_REG_2,
+                              offsetof(struct __sk_buff, mark)));
+
+    return 0;
+}
+
+static int _bf_cgroup_gen_inline_get_mark(struct bf_program *program, int reg)
+{
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
+    EMIT(program,
+         BPF_LDX_MEM(BPF_W, reg, BPF_REG_1, offsetof(struct __sk_buff, mark)));
+
+    return 0;
+}
+
 /**
  * Convert a standard verdict into a return value.
  *
@@ -125,5 +147,7 @@ static int _bf_cgroup_get_verdict(enum bf_verdict verdict)
 const struct bf_flavor_ops bf_flavor_ops_cgroup = {
     .gen_inline_prologue = _bf_cgroup_gen_inline_prologue,
     .gen_inline_epilogue = _bf_cgroup_gen_inline_epilogue,
+    .gen_inline_set_mark = _bf_cgroup_gen_inline_set_mark,
+    .gen_inline_get_mark = _bf_cgroup_gen_inline_get_mark,
     .get_verdict = _bf_cgroup_get_verdict,
 };

--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -124,6 +124,20 @@ static int _bf_nf_gen_inline_epilogue(struct bf_program *program)
     return 0;
 }
 
+static int _bf_nf_gen_inline_get_mark(struct bf_program *program, int reg)
+{
+    int offset;
+
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
+    if ((offset = bf_btf_get_field_off("bpf_nf_ctx", "skb")) < 0)
+        return offset;
+    EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_1, offset));
+    EMIT(program, BPF_LDX_MEM(BPF_W, reg, BPF_REG_2, 0x140));
+
+    return 0;
+}
+
 /**
  * Convert a standard verdict into a return value.
  *
@@ -147,5 +161,6 @@ static int _bf_nf_get_verdict(enum bf_verdict verdict)
 const struct bf_flavor_ops bf_flavor_ops_nf = {
     .gen_inline_prologue = _bf_nf_gen_inline_prologue,
     .gen_inline_epilogue = _bf_nf_gen_inline_epilogue,
+    .gen_inline_get_mark = _bf_nf_gen_inline_get_mark,
     .get_verdict = _bf_nf_get_verdict,
 };

--- a/src/bpfilter/cgen/tc.c
+++ b/src/bpfilter/cgen/tc.c
@@ -74,6 +74,27 @@ static int _bf_tc_gen_inline_epilogue(struct bf_program *program)
     return 0;
 }
 
+static int _bf_tc_gen_inline_set_mark(struct bf_program *program, uint32_t mark)
+{
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_2, mark));
+    EMIT(program, BPF_STX_MEM(BPF_W, BPF_REG_1, BPF_REG_2,
+                              offsetof(struct __sk_buff, mark)));
+
+    return 0;
+}
+
+static int _bf_tc_gen_inline_get_mark(struct bf_program *program, int reg)
+{
+    EMIT(program,
+         BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
+    EMIT(program,
+         BPF_LDX_MEM(BPF_W, reg, BPF_REG_1, offsetof(struct __sk_buff, mark)));
+
+    return 0;
+}
+
 /**
  * Convert a standard verdict into a return value.
  *
@@ -97,5 +118,7 @@ static int _bf_tc_get_verdict(enum bf_verdict verdict)
 const struct bf_flavor_ops bf_flavor_ops_tc = {
     .gen_inline_prologue = _bf_tc_gen_inline_prologue,
     .gen_inline_epilogue = _bf_tc_gen_inline_epilogue,
+    .gen_inline_set_mark = _bf_tc_gen_inline_set_mark,
+    .gen_inline_get_mark = _bf_tc_gen_inline_get_mark,
     .get_verdict = _bf_tc_get_verdict,
 };

--- a/src/libbpfilter/include/bpfilter/chain.h
+++ b/src/libbpfilter/include/bpfilter/chain.h
@@ -40,6 +40,12 @@ enum bf_chain_flags
     /** A rule will filter on IPv6 nexthdr field. */
     BF_CHAIN_STORE_NEXTHDR,
 
+    /** A rule sets the sk_buff mark value. */
+    BF_CHAIN_SET_MARK,
+
+    /** A rule reads the sk_buff mark value. */
+    BF_CHAIN_GET_MARK,
+
     _BF_CHAIN_FLAGS_MAX,
 };
 
@@ -99,6 +105,18 @@ void bf_chain_free(struct bf_chain **chain);
  * @return 0 on success, or a negative error value on failure.
  */
 int bf_chain_pack(const struct bf_chain *chain, bf_wpack_t *pack);
+
+/**
+ * @brief Validate a chain.
+ *
+ * Ensure the chain, rules, and matchers are compatible with each other. E.g.
+ * XDP doesn't provide support for `sk_buff->mark`. A chain should be validated
+ * before the bytecode is generated.
+ *
+ * @param chain Chain to validate. Can't be NULL.
+ * @return True if the chain is valid, false otherwise.
+ */
+bool bf_chain_validate(struct bf_chain *chain);
 
 /**
  * Dump the content of a `bf_chain` object.

--- a/src/libbpfilter/include/bpfilter/flavor.h
+++ b/src/libbpfilter/include/bpfilter/flavor.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <bpfilter/verdict.h>
 
 struct bf_program;
@@ -87,6 +89,9 @@ struct bf_flavor_ops
     int (*gen_inline_prologue)(struct bf_program *program);
 
     int (*gen_inline_epilogue)(struct bf_program *program);
+
+    int (*gen_inline_set_mark)(struct bf_program *program, uint32_t mark);
+    int (*gen_inline_get_mark)(struct bf_program *program, int reg);
 
     /**
      * Generates a flavor-specific return code corresponding to the verdict.

--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -60,6 +60,8 @@ enum bf_matcher_type
     BF_MATCHER_META_SPORT,
     /// Matches the destination port for UDP and TCP packets.
     BF_MATCHER_META_DPORT,
+    /// Matches a specific `sk_buff->mark` value.
+    BF_MATCHER_META_MARK,
     /// Matches IPv4 source address.
     BF_MATCHER_IP4_SADDR,
     /// Matches IPv4 source network.

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -6,6 +6,7 @@
 #include "bpfilter/rule.h"
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -87,6 +88,10 @@ int bf_rule_new_from_pack(struct bf_rule **rule, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_rule.counters");
 
+    r = bf_rpack_kv_u64(node, "mark", &_rule->mark);
+    if (r)
+        return bf_rpack_key_err(r, "bf_rule.mark");
+
     r = bf_rpack_kv_enum(node, "verdict", &_rule->verdict);
     if (r)
         return bf_rpack_key_err(r, "bf_rule.verdict");
@@ -131,6 +136,7 @@ int bf_rule_pack(const struct bf_rule *rule, bf_wpack_t *pack)
     bf_wpack_kv_u32(pack, "index", rule->index);
     bf_wpack_kv_u8(pack, "log", rule->log);
     bf_wpack_kv_bool(pack, "counters", rule->counters);
+    bf_wpack_kv_u64(pack, "mark", rule->mark);
     bf_wpack_kv_int(pack, "verdict", rule->verdict);
 
     bf_wpack_kv_list(pack, "matchers", &rule->matchers);
@@ -164,6 +170,7 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
 
     DUMP(prefix, "log: %02x", rule->log);
     DUMP(prefix, "counters: %s", rule->counters ? "yes" : "no");
+    DUMP(prefix, "mark: 0x%" PRIx64, rule->mark);
     DUMP(bf_dump_prefix_last(prefix), "verdict: %s",
          bf_verdict_to_str(rule->verdict));
 

--- a/tests/e2e/e2e.c
+++ b/tests/e2e/e2e.c
@@ -82,6 +82,14 @@ static int _bft_e2e_test_with_counter(struct bf_chain *chain,
         int test_ret;
 
         chain->hook = _bf_tests_meta[flavor].hook;
+        
+        /* Skip the test for the current hook if the change doesn't validate.
+         * The chain should be valid, but we run the test for every hook, so
+         * if one of the features use is incompatible with the current hook
+         * the validate fails. */
+        if (!bf_chain_validate(chain))
+            continue;
+        
         r = bf_chain_load(chain);
         if (r) {
             bf_info("failed to load test chain");

--- a/tests/rules.bpfilter
+++ b/tests/rules.bpfilter
@@ -8,10 +8,12 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
     rule
         meta.dport eq 22
         log internet
+        mark 0xff
         counter
         ACCEPT
     rule
         meta.dport eq 22
+        mark 17
         counter
         log internet
         ACCEPT
@@ -61,6 +63,11 @@ chain myxdpprog BF_HOOK_XDP{ifindex=2} ACCEPT
         meta.probability eq 0%
         meta.probability eq 50%
         meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
         counter
         ACCEPT
     rule


### PR DESCRIPTION
Add the new `mark` rule keyword to mark a matched packet. The mark is set in the `sk_buff` structure, and can be matched on later on by a `meta.mark` matcher, or outstide bpfilter with a TC filter.