### PR TITLE
lib,cli,daemon: store log fields in host byteorder

### DIFF
--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -390,7 +390,7 @@ static void _bf_chain_log_l3(const struct bf_log *log)
         return;
     }
 
-    switch (be16toh(log->l3_proto)) {
+    switch (log->l3_proto) {
     case ETH_P_IP:
         iphdr = (struct iphdr *)&log->l3hdr[0];
 
@@ -445,7 +445,7 @@ static void _bf_chain_log_l3(const struct bf_log *log)
 
     default:
         (void)fprintf(stdout, "  Internet  : <unknown protocol 0x%04x>\n",
-                      be16toh(log->l3_proto));
+                      log->l3_proto);
     }
 }
 

--- a/src/bpfilter/bpf/log.bpf.c
+++ b/src/bpfilter/bpf/log.bpf.c
@@ -5,6 +5,7 @@
 
 #include <linux/bpf.h>
 
+#include <bpf/bpf_endian.h>
 #include <bpf/bpf_helpers.h>
 #include <stddef.h>
 
@@ -27,7 +28,7 @@ __u8 bf_log(struct bf_runtime *ctx, __u32 rule_idx, __u8 headers,
     log->pkt_size = ctx->pkt_size;
     log->req_headers = headers;
     log->headers = 0;
-    log->l3_proto = l3_proto;
+    log->l3_proto = bpf_ntohs(l3_proto);
     log->l4_proto = l4_proto;
 
     if (headers & (1 << BF_PKTHDR_LINK) && ctx->l2_hdr &&

--- a/src/libbpfilter/include/bpfilter/runtime.h
+++ b/src/libbpfilter/include/bpfilter/runtime.h
@@ -80,6 +80,9 @@ enum bf_pkthdr
  *
  * The structure is published into a log buffer by the chain, when a hit rule
  * has a `log` action defined.
+ *
+ * Except for the raw packet headers (`l2hdr`, `l3hdr`, and `l4hdr`), all the
+ * values are stored in host byteorder.
  */
 struct bf_log
 {


### PR DESCRIPTION
`bf_log` stores the L3 header identifier in network byteorder, which requires the user to convert it. Use `bpf_ntohs()` to store the L3 header identifier into the log structure.

The various packet headers are left unchanged.