### PR TITLE
lib: restore logger prefix

### DIFF
--- a/src/libbpfilter/include/bpfilter/logger.h
+++ b/src/libbpfilter/include/bpfilter/logger.h
@@ -51,18 +51,10 @@ enum bf_log_level
     _BF_LOG_MAX,
 };
 
-#ifdef NDEBUG
 #define _bf_logger_prefix_fmt "%s%-7s%s: "
 #define _bf_logger_prefix_fmt_args(level, color)                               \
     bf_logger_get_color((color), BF_STYLE_BOLD), bf_log_level_to_str(level),   \
         bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET)
-#else
-#define _bf_logger_prefix_fmt "%s%-7s[%s:%d]%s: "
-#define _bf_logger_prefix_fmt_args(level, color)                               \
-    bf_logger_get_color((color), BF_STYLE_BOLD), bf_log_level_to_str(level),   \
-        __func__, __LINE__,                                                    \
-        bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET)
-#endif
 
 /**
  * Log an error message to stderr.


### PR DESCRIPTION
Logger prefix was updated in:
6240d95 libbpfilter: logger: log function name and line number on debug builds

```
However, it breaks object dumps:
debug  [bf_rule_dump:152]:     |-- struct bf_rule at 0xfc6fa25e02c0
debug  [bf_rule_dump:156]:     |   |-- index: 5
debug  [bf_rule_dump:159]:     |   |-- matchers: 3
debug  [bf_matcher_dump:1231]:     |   |   |-- struct bf_matcher at 0xfc2fa25e0c10
debug  [bf_matcher_dump:1235]:     |   |   |   |-- type: meta.l4_proto
debug  [bf_matcher_dump:1236]:     |   |   |   |-- op: eq
debug  [bf_matcher_dump:1237]:     |   |   |   |-- len: 18
debug  [bf_matcher_dump:1238]:     |   |   |   `-- payload:
debug  [bf_dump_hex:71]:     |   |   |       `-- 0x01 0xbe
```

Revert the logger prefix to its original value.

CC original committer @AliGhaffarian 