### PR TITLE
Fix `sk_buff.mark` offset used for Netfilter hooks

### DIFF
--- a/src/bpfilter/cgen/nf.c
+++ b/src/bpfilter/cgen/nf.c
@@ -133,7 +133,9 @@ static int _bf_nf_gen_inline_get_mark(struct bf_program *program, int reg)
     if ((offset = bf_btf_get_field_off("bpf_nf_ctx", "skb")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_1, offset));
-    EMIT(program, BPF_LDX_MEM(BPF_W, reg, BPF_REG_2, 0x140));
+    if ((offset = bf_btf_get_field_off("sk_buff", "mark")) < 0)
+        return offset;
+    EMIT(program, BPF_LDX_MEM(BPF_W, reg, BPF_REG_2, offset));
 
     return 0;
 }

--- a/src/libbpfilter/btf.c
+++ b/src/libbpfilter/btf.c
@@ -98,44 +98,116 @@ int bf_btf_kernel_has_token(void)
     return -ENOENT;
 }
 
-int bf_btf_get_field_off(const char *struct_name, const char *field_name)
+#define _bf_btf_type_is_compound(type)                                         \
+    (BTF_INFO_KIND((type)->info) == BTF_KIND_UNION ||                          \
+     BTF_INFO_KIND((type)->info) == BTF_KIND_STRUCT)
+
+/**
+ * @brief Find the offset of `field_name` in BTF type ID `compound_id`.
+ *
+ * @param compound_id Compound BTF type id.
+ * @param field_name Name of the field to find the offset of. Can't be NULL.
+ * @return Offset (in bits) of `field_name` in `compound_id` BTF type.
+ */
+static ssize_t _bf_btf_offset_in_compound(uint32_t compound_id,
+                                          const char *field_name)
 {
-    int offset = -1;
-    int struct_id;
-    struct btf_member *member;
-    const struct btf_type *type;
+    ssize_t offset;
+    const struct btf_type *compound_type, *member_type;
+    const struct btf_member *member;
 
-    struct_id = btf__find_by_name_kind(_bf_btf, struct_name, BTF_KIND_STRUCT);
-    if (struct_id < 0) {
-        return bf_err_r(struct_id, "can't find structure '%s' in kernel BTF",
-                        struct_name);
-    }
+    bf_assert(field_name);
 
-    type = btf__type_by_id(_bf_btf, struct_id);
-    if (!type)
-        return bf_err_r(errno, "can't get btf_type for '%s'", struct_name);
+    compound_type = btf__type_by_id(_bf_btf, compound_id);
+    if (!compound_type)
+        return -errno;
 
-    member = (struct btf_member *)(type + 1);
-    for (size_t i = 0; i < BTF_INFO_VLEN(type->info); ++i, ++member) {
-        const char *cur_name = btf__name_by_offset(_bf_btf, member->name_off);
-        if (!cur_name || !bf_streq(cur_name, field_name))
-            continue;
+    if (!_bf_btf_type_is_compound(compound_type))
+        return -ENOTSUP;
 
-        if (BTF_INFO_KFLAG(type->info)) {
-            offset = BTF_MEMBER_BIT_OFFSET(member->offset);
-        } else {
-            if (member->offset > INT_MAX) {
-                return bf_err_r(-E2BIG, "BTF member offset is too big: %u",
-                                member->offset);
+    member = (const struct btf_member *)(compound_type + 1);
+    for (size_t i = 0; i < BTF_INFO_VLEN(compound_type->info); ++i, ++member) {
+        const char *name = btf__name_by_offset(_bf_btf, member->name_off);
+
+        member_type = btf__type_by_id(_bf_btf, member->type);
+        if (!member_type)
+            return -errno;
+
+        // Member is an anonymous compound type? Check its members
+        if (*name == '\0' && _bf_btf_type_is_compound(member_type)) {
+            offset = _bf_btf_offset_in_compound(member->type, field_name);
+            if (offset < 0)
+                continue;
+
+            if (BTF_MEMBER_BIT_OFFSET(member->offset) % 8) {
+                // Assuming this is not possible, but who knows
+                return bf_err_r(-ENOTSUP,
+                                "anonymous compound parent is a bitfield");
             }
-            offset = (int)member->offset;
+
+            if (BTF_INFO_KFLAG(compound_type->info))
+                offset += BTF_MEMBER_BIT_OFFSET(member->offset);
+            else
+                offset += member->offset;
+
+            return offset;
         }
 
-        break;
+        if (!bf_streq(name, field_name))
+            continue;
+
+        offset = (ssize_t)member->offset;
+        if (BTF_INFO_KFLAG(compound_type->info))
+            offset = BTF_MEMBER_BIT_OFFSET(member->offset);
+
+        return offset;
     }
 
-    if (offset < 0 || offset % 8)
-        return -ENOENT;
+    return -EINVAL;
+}
 
-    return offset / 8;
+static int _bf_btf_get_compound_type_id(const char *name)
+{
+    int compound_id;
+
+    compound_id = btf__find_by_name_kind(_bf_btf, name, BTF_KIND_STRUCT);
+    if (compound_id < 0 && compound_id != -ENOENT)
+        return compound_id;
+    if (compound_id >= 0)
+        return compound_id;
+
+    compound_id = btf__find_by_name_kind(_bf_btf, name, BTF_KIND_UNION);
+    if (compound_id < 0 && compound_id != -ENOENT)
+        return compound_id;
+
+    return compound_id;
+}
+
+int bf_btf_get_field_off(const char *struct_name, const char *field_name)
+{
+    int id;
+    ssize_t offset;
+
+    bf_assert(struct_name);
+    bf_assert(field_name);
+
+    id = _bf_btf_get_compound_type_id(struct_name);
+    if (id < 0)
+        return bf_err_r(id, "failed to find BTF type ID for '%s'", struct_name);
+
+    offset = _bf_btf_offset_in_compound(id, field_name);
+    if (offset < 0) {
+        return bf_err_r((int)offset, "failed to find offset of %s.%s",
+                        struct_name, field_name);
+    }
+    if (offset % 8) {
+        return bf_err_r(-EINVAL, "%s.%s has a bit offset", struct_name,
+                        field_name);
+    }
+    if (offset / 8 > INT_MAX) {
+        return bf_err_r(-E2BIG, "%s.%s has an offset bigger than %d",
+                        struct_name, field_name, INT_MAX);
+    }
+
+    return (int)(offset / 8);
 }

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -59,5 +59,6 @@ add_custom_target(e2e
                 --bpfilter $<TARGET_FILE:bpfilter>
                 --bfcli $<TARGET_FILE:bfcli>
                 --setuserns $<TARGET_FILE:setuserns_bin>
+                --rulesets-dir ${CMAKE_CURRENT_SOURCE_DIR}/rulesets
     COMMENT "Running end-to-end tests"
 )

--- a/tests/e2e/rulesets/cgroup_egress.bf
+++ b/tests/e2e/rulesets/cgroup_egress.bf
@@ -1,0 +1,244 @@
+chain cgroup_egress BF_HOOK_CGROUP_EGRESS ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        mark 0xff
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        mark 17
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/cgroup_ingress.bf
+++ b/tests/e2e/rulesets/cgroup_ingress.bf
@@ -1,0 +1,244 @@
+chain cgroup_ingress BF_HOOK_CGROUP_INGRESS ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        mark 0xff
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        mark 17
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/nf_forward.bf
+++ b/tests/e2e/rulesets/nf_forward.bf
@@ -1,0 +1,242 @@
+chain nf_forward BF_HOOK_NF_FORWARD ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/nf_local_in.bf
+++ b/tests/e2e/rulesets/nf_local_in.bf
@@ -1,0 +1,242 @@
+chain nf_local_in BF_HOOK_NF_LOCAL_IN ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/nf_local_out.bf
+++ b/tests/e2e/rulesets/nf_local_out.bf
@@ -1,0 +1,242 @@
+chain nf_local_out BF_HOOK_NF_LOCAL_OUT ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/nf_post_routing.bf
+++ b/tests/e2e/rulesets/nf_post_routing.bf
@@ -1,0 +1,242 @@
+chain nf_post_routing BF_HOOK_NF_POST_ROUTING ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/nf_pre_routing.bf
+++ b/tests/e2e/rulesets/nf_pre_routing.bf
@@ -1,0 +1,242 @@
+chain nf_pre_routing BF_HOOK_NF_PRE_ROUTING ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/tc_egress.bf
+++ b/tests/e2e/rulesets/tc_egress.bf
@@ -1,0 +1,244 @@
+chain tc_egress BF_HOOK_TC_EGRESS ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        mark 0xff
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        mark 17
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/tc_ingress.bf
+++ b/tests/e2e/rulesets/tc_ingress.bf
@@ -1,0 +1,244 @@
+chain tc_ingress BF_HOOK_TC_INGRESS ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        log internet
+        mark 0xff
+        counter
+        ACCEPT
+    rule
+        meta.dport eq 22
+        mark 17
+        counter
+        log internet
+        ACCEPT
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        meta.mark eq 15
+        meta.mark eq 0x115
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT

--- a/tests/e2e/rulesets/xdp.bf
+++ b/tests/e2e/rulesets/xdp.bf
@@ -1,0 +1,227 @@
+chain xdp BF_HOOK_XDP ACCEPT
+    set my_custom_set (ip4.saddr, ip4.proto) in {
+        192.168.1.1, tcp
+        192.168.1.1, udp
+    }
+
+    rule
+        meta.dport eq 22
+        ACCEPT
+    rule
+        meta.iface eq lo
+        meta.iface eq 1
+        counter
+        ACCEPT
+    rule
+        meta.l3_proto eq ipv4
+        meta.l3_proto eq ipv6
+        meta.l3_proto eq IPv4
+        meta.l3_proto eq IPv6
+        meta.l3_proto eq 1024
+        meta.l3_proto eq 0x0600
+        counter
+        ACCEPT
+    rule
+        meta.l4_proto eq icmp
+        meta.l4_proto eq ICMPv6
+        meta.l4_proto eq 6
+        counter
+        ACCEPT
+    rule
+        meta.sport eq 0
+        meta.sport eq 17
+        meta.sport eq 65535
+        meta.sport not 0
+        meta.sport not 17
+        meta.sport not 65535
+        meta.sport range 0-65535
+        meta.sport range 17-31
+        meta.dport eq 0
+        meta.dport eq 17
+        meta.dport eq 65535
+        meta.dport not 0
+        meta.dport not 17
+        meta.dport not 65535
+        meta.dport range 0-65535
+        meta.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        meta.probability eq 0%
+        meta.probability eq 50%
+        meta.probability eq 100%
+        counter
+        ACCEPT
+    rule
+        ip4.saddr eq 1.1.1.1
+        ip4.saddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.daddr eq 1.1.1.1
+        ip4.daddr not 1.1.1.1
+        counter
+        ACCEPT
+    rule
+        ip4.snet eq 1.1.1.1/24
+        ip4.snet not 192.168.1.1/10
+        counter
+        ACCEPT
+    rule
+        ip4.dnet eq 1.1.1.1/26
+        ip4.dnet not 192.168.1.1/12
+        counter
+        ACCEPT
+    rule
+        ip4.proto eq icmp
+        ip4.proto eq ICMPv6
+        ip4.proto eq 6
+        counter
+        ACCEPT
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq udp
+        ip6.nexthdr eq icmpv6
+        counter
+        ACCEPT
+    rule
+        ip6.saddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.saddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.saddr not ::1
+        ip6.saddr not 2001:db8::1
+        counter
+        ACCEPT
+    rule
+        ip6.daddr eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+        ip6.daddr eq 2001:db8:85a3::8a2e:370:7334
+        ip6.daddr not ::1
+        ip6.daddr not 2001:db8::1
+        counter
+        CONTINUE
+    rule
+        ip6.snet eq 2001:db8::1/42
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.snet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.snet not ::1/64
+        ip6.snet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/64
+        ip6.dnet eq 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+        ip6.dnet not ::1/64
+        ip6.dnet not ::1/128
+        counter
+        CONTINUE
+    rule
+        ip6.nexthdr eq tcp
+        ip6.nexthdr eq 21
+        ip6.nexthdr eq 15
+        ip6.nexthdr eq hop
+        ip6.nexthdr eq routing
+        counter
+        CONTINUE
+    rule
+        tcp.sport eq 0
+        tcp.sport eq 17
+        tcp.sport eq 65535
+        tcp.sport not 0
+        tcp.sport not 17
+        tcp.sport not 65535
+        (tcp.sport) in {16;124;6463}
+        tcp.sport range 0-65535
+        tcp.sport range 17-31
+        tcp.dport eq 0
+        tcp.dport eq 17
+        tcp.dport eq 65535
+        tcp.dport not 0
+        tcp.dport not 17
+        tcp.dport not 65535
+        (tcp.dport) in {16;124;6463}
+        tcp.dport range 0-65535
+        tcp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        tcp.flags eq SYN
+        tcp.flags eq ACK
+        tcp.flags not ECE
+        tcp.flags not CWR
+        tcp.flags any ack
+        tcp.flags any SYN,ack
+        tcp.flags any cwr,ece,syn
+        tcp.flags all ack
+        tcp.flags all SYN,ack
+        tcp.flags all cwr,ece,syn
+        counter
+        ACCEPT
+    rule
+        udp.sport eq 0
+        udp.sport eq 17
+        udp.sport eq 65535
+        udp.sport not 0
+        udp.sport not 17
+        udp.sport not 65535
+        (udp.sport) in {16;124;6463}
+        udp.sport range 0-65535
+        udp.sport range 17-31
+        udp.dport eq 0
+        udp.dport eq 17
+        udp.dport eq 65535
+        udp.dport not 0
+        udp.dport not 17
+        udp.dport not 65535
+        (udp.dport) in {16;124;6463}
+        udp.dport range 0-65535
+        udp.dport range 17-31
+        counter
+        ACCEPT
+    rule
+        icmp.type eq echo-reply
+        icmp.type eq 8
+        icmp.type eq 0x08
+        icmp.type not echo-reply
+        icmp.type not 8
+        icmp.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmp.code eq 17
+        icmp.code eq 0x17
+        icmp.code not 17
+        icmp.code not 0x17
+        counter
+        ACCEPT
+    rule
+        icmpv6.type eq echo-reply
+        icmpv6.type eq 8
+        icmpv6.type eq 0x08
+        icmpv6.type not echo-reply
+        icmpv6.type not 8
+        icmpv6.type not 0x08
+        counter
+        ACCEPT
+    rule
+        icmpv6.code eq 17
+        icmpv6.code eq 0x17
+        icmpv6.code not 17
+        icmpv6.code not 0x17
+        counter
+        ACCEPT
+    rule
+        (ip4.saddr, ip4.proto) in my_custom_set
+        (ip4.saddr, ip4.proto) in {
+            192.168.1.131, tcp
+            192.168.1.132, udp
+        }
+        (ip6.snet) in {
+            fdb2:2c26:f4e4::1/128
+            fdb2:2c26:f4e4::1/64
+        }
+        (ip6.dnet) in {
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/128
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/127
+            fdb2:2c26:f4e4:0:21c:42ff:fe09:1a95/126
+        }
+        counter
+        ACCEPT


### PR DESCRIPTION
Netfilter bytecode generation uses an invalid `sk_buff.mark` offset (`0x140` instead of `168`), while leads to a loading failure. This hasn't been detected, as the default test ruleset (`tests/rules.bpfilter`) uses the XDP hook by default. 

This change resolves this issue by:
- Update `bf_btf_get_field_off()` to support nested anonymous structures and unions, which makes it useful for `sk_buff.mark`
- Update Netfilter bytecode generation to use `bf_btf_get_field_off()` instead of hard-coding the field offset
- Update the end-to-end tests to load a chain containing all the matchers for each hook