### PR TITLE
bfcli: fix parsing log flags

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -287,7 +287,7 @@ rule_option     : LOG LOG_HEADERS
                     char *tmp = in;
                     char *saveptr;
                     char *token;
-                    uint8_t log;
+                    uint8_t log = 0;
 
                     while ((token = strtok_r(tmp, ",", &saveptr))) {
                         enum bf_pkthdr header;

--- a/tests/e2e/daemon/netns_to_host.sh
+++ b/tests/e2e/daemon/netns_to_host.sh
@@ -10,7 +10,7 @@ start_bpfilter
 
 (! ${FROM_NS} bfcli ruleset set --from-str "chain xdp BF_HOOK_XDP{ifindex=${HOST_IFINDEX}} ACCEPT rule ip4.proto icmp log link,transport counter DROP")
 ${FROM_NS} ping -c 1 -W 0.1 ${HOST_IP_ADDR}
-${FROM_NS} bfcli ruleset set --from-str "chain xdp BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp log link,internet counter DROP"
+${FROM_NS} bfcli ruleset set --from-str "chain tc BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp log link,internet counter DROP"
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-${FROM_NS} bfcli chain get --name xdp | awk '/log link,internet/{getline; print $2}' | grep -q "^1$"
+${FROM_NS} bfcli chain get --name tc | awk '/log link,internet/{getline; print $2}' | grep -q "^1$"
 ${FROM_NS} bfcli ruleset flush


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #368
* #367
* __->__ #366

ReviewStack: https://reviewstack.dev/facebook/bpfilter/pull/366

---

`ctest --test-dir build -R e2e.daemon.netns_to_host`  was flaky, which was annoying me, as it was failing on unrelated changes.

With some Claude-assisted debugging, I found out it's because `uint8_t log` sometimes contains garbage data, that we later OR into in `log |= BF_FLAG(header);` line. When that happens, the printed output doesn't match what `awk` is expecting.