### PR TITLE
cli: fix parsing bf_hook enum

### DIFF
--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -171,23 +171,16 @@ chain           : CHAIN STRING hook hookopts verdict sets rules
 
 verdict         : VERDICT
                 {
-                    enum bf_verdict verdict;
-
-                    if (bf_verdict_from_str($1, &verdict) < 0)
+                    if (bf_verdict_from_str($1, &$$) < 0)
                         bf_parse_err("unknown verdict '%s'\n", $1);
-
                     free($1);
-                    $$ = verdict;
                 }
 
 hook            : HOOK
                 {
-                    enum bf_hook hook = bf_hook_from_str($1);
-                    if (hook < 0)
+                    if (bf_hook_from_str($1, &$$) < 0)
                         bf_parse_err("unknown hook '%s'\n", $1);
-
                     free($1);
-                    $$ = hook;
                 }
 
 hookopts        : %empty { $$ = NULL; }
@@ -464,24 +457,16 @@ matcher         : matcher_type matcher_op RAW_PAYLOAD
                 ;
 matcher_type    : MATCHER_TYPE
                 {
-                    enum bf_matcher_type type;
-
-                    if (bf_matcher_type_from_str($1, &type) < 0)
+                    if (bf_matcher_type_from_str($1, &$$) < 0)
                         bf_parse_err("unknown matcher type '%s'\n", $1);
-
                     free($1);
-                    $$ = type;
                 }
 matcher_op      : %empty { $$ = BF_MATCHER_EQ; }
                 | MATCHER_OP
                 {
-                    enum bf_matcher_op op;
-
-                    if (bf_matcher_op_from_str($1, &op) < 0)
+                    if (bf_matcher_op_from_str($1, &$$) < 0)
                         bf_parse_err("unknown matcher operator '%s'\n", $1);
-
                     free($1);
-                    $$ = op;
                 }
                 ;
 

--- a/src/libbpfilter/hook.c
+++ b/src/libbpfilter/hook.c
@@ -41,16 +41,21 @@ static_assert(ARRAY_SIZE(_bf_hook_strs) == _BF_HOOK_MAX,
 
 const char *bf_hook_to_str(enum bf_hook hook)
 {
+    if (hook < 0 || hook >= _BF_HOOK_MAX)
+        return "<bf_hook unknown>";
+
     return _bf_hook_strs[hook];
 }
 
-enum bf_hook bf_hook_from_str(const char *str)
+int bf_hook_from_str(const char *str, enum bf_hook *hook)
 {
-    bf_assert(str);
+    assert(hook);
 
-    for (enum bf_hook hook = 0; hook < _BF_HOOK_MAX; ++hook) {
-        if (bf_streq(_bf_hook_strs[hook], str))
-            return hook;
+    for (enum bf_hook i = 0; i < _BF_HOOK_MAX; ++i) {
+        if (bf_streq(_bf_hook_strs[i], str)) {
+            *hook = i;
+            return 0;
+        }
     }
 
     return -EINVAL;

--- a/src/libbpfilter/include/bpfilter/hook.h
+++ b/src/libbpfilter/include/bpfilter/hook.h
@@ -74,10 +74,10 @@ const char *bf_hook_to_str(enum bf_hook hook);
  * Convert a string to a `bf_hook` value.
  *
  * @param str String to convert to a `bf_hook` value. Can't be NULL.
- * @return A valid `bf_hook` value on success, or a negative errno value
- *         on error.
+ * @param hook Hook type value, if the parsing succeeds. Can't be NULL.
+ * @return 0 on success, or a negative errno value on error.
  */
-enum bf_hook bf_hook_from_str(const char *str);
+int bf_hook_from_str(const char *str, enum bf_hook *hook);
 
 /**
  * Convert a `bf_hook` value to a `bf_flavor` value.

--- a/tests/unit/libbpfilter/hook.c
+++ b/tests/unit/libbpfilter/hook.c
@@ -35,24 +35,8 @@ static void hook_from_str(void **state)
 {
     (void)state;
 
-    // Test valid conversions
-    assert_int_equal(bf_hook_from_str("BF_HOOK_XDP"), BF_HOOK_XDP);
-    assert_int_equal(bf_hook_from_str("BF_HOOK_TC_INGRESS"),
-                     BF_HOOK_TC_INGRESS);
-    assert_int_equal(bf_hook_from_str("BF_HOOK_NF_PRE_ROUTING"),
-                     BF_HOOK_NF_PRE_ROUTING);
-    assert_int_equal(bf_hook_from_str("BF_HOOK_TC_EGRESS"), BF_HOOK_TC_EGRESS);
-
-    // Test round-trip for all hooks
-    for (enum bf_hook hook = 0; hook < _BF_HOOK_MAX; ++hook) {
-        const char *str = bf_hook_to_str(hook);
-        assert_int_equal(bf_hook_from_str(str), hook);
-    }
-
-    // Test invalid strings
-    assert_err((int)bf_hook_from_str("BF_HOOK_XD"));
-    assert_err((int)bf_hook_from_str("invalid"));
-    assert_err((int)bf_hook_from_str("BF_HOOK"));
+    assert_enum_to_from_str(enum bf_hook, bf_hook_to_str, bf_hook_from_str, BF_HOOK_XDP,
+                            _BF_HOOK_MAX);
 }
 
 static void hook_to_flavor(void **state)


### PR DESCRIPTION
Discussed in https://github.com/facebook/bpfilter/pull/353. This PR makes `bf_hook_from_str` work like `bf_verdict_from_str`.