### PR TITLE
daemon: validate enum values coming from user

### DIFF
--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -79,7 +79,7 @@ int bf_cgen_new_from_pack(struct bf_cgen **cgen, bf_rpack_node_t node)
 
     _cgen->program = NULL;
 
-    r = bf_rpack_kv_enum(node, "front", &_cgen->front);
+    r = bf_rpack_kv_enum(node, "front", &_cgen->front, 0, _BF_FRONT_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_cgen.front");
 

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -103,11 +103,11 @@ int bf_map_new_from_pack(struct bf_map **map, int dir_fd, bf_rpack_node_t node)
         return bf_err_r(-EINVAL, "map name can't be empty");
     bf_strncpy(_map->name, BPF_OBJ_NAME_LEN, name);
 
-    r = bf_rpack_kv_enum(node, "type", &_map->type);
+    r = bf_rpack_kv_enum(node, "type", &_map->type, 0, _BF_MAP_TYPE_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_map.type");
 
-    r = bf_rpack_kv_enum(node, "bpf_type", &_map->bpf_type);
+    r = bf_rpack_kv_enum(node, "bpf_type", &_map->bpf_type, 0, __MAX_BPF_MAP_TYPE);
     if (r)
         return bf_rpack_key_err(r, "bf_map.bpf_type");
 

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -73,8 +73,11 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
     size_t ridx = 0;
     int r;
 
-    bf_assert(chain && name);
-    bf_assert(policy < _BF_TERMINAL_VERDICT_MAX);
+    assert(chain && name);
+    if (hook >= _BF_HOOK_MAX)
+        return bf_err_r(-EINVAL, "unknown hook type");
+    if (policy >= _BF_TERMINAL_VERDICT_MAX)
+        return bf_err_r(-EINVAL, "unknown policy type");
 
     _chain = malloc(sizeof(*_chain));
     if (!_chain)
@@ -124,11 +127,11 @@ int bf_chain_new_from_pack(struct bf_chain **chain, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_chain.name");
 
-    r = bf_rpack_kv_enum(node, "hook", &hook);
+    r = bf_rpack_kv_enum(node, "hook", &hook, 0, _BF_HOOK_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_chain.hook");
 
-    r = bf_rpack_kv_enum(node, "policy", &policy);
+    r = bf_rpack_kv_enum(node, "policy", &policy, 0, _BF_TERMINAL_VERDICT_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_chain.policy");
 

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -1295,11 +1295,11 @@ int bf_matcher_new_from_pack(struct bf_matcher **matcher, bf_rpack_node_t node)
 
     bf_assert(matcher);
 
-    r = bf_rpack_kv_enum(node, "type", &type);
+    r = bf_rpack_kv_enum(node, "type", &type, 0, _BF_MATCHER_TYPE_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_matcher.type");
 
-    r = bf_rpack_kv_enum(node, "op", &op);
+    r = bf_rpack_kv_enum(node, "op", &op, 0, _BF_MATCHER_OP_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_matcher.op");
 

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -93,7 +93,7 @@ int bf_rule_new_from_pack(struct bf_rule **rule, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_rule.mark");
 
-    r = bf_rpack_kv_enum(node, "verdict", &_rule->verdict);
+    r = bf_rpack_kv_enum(node, "verdict", &_rule->verdict, 0, _BF_VERDICT_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_rule.verdict");
 

--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -291,7 +291,7 @@ int bf_set_new_from_pack(struct bf_set **set, bf_rpack_node_t node)
                 n_comps, BF_SET_MAX_N_COMPS);
         }
 
-        r = bf_rpack_enum(comp_node, &key[i]);
+        r = bf_rpack_enum(comp_node, &key[i], 0, _BF_MATCHER_TYPE_MAX);
         if (r)
             return bf_rpack_key_err(r, "bf_set.key");
     }

--- a/tests/unit/libbpfilter/pack.c
+++ b/tests/unit/libbpfilter/pack.c
@@ -399,7 +399,9 @@ static void wpack_enum(void **state)
     assert_ok(bf_rpack_new(&rpack, data, data_len));
     root = bf_rpack_root(rpack);
 
-    assert_ok(bf_rpack_kv_enum(root, "enum_val", &enum_val));
+    assert_ok(bf_rpack_kv_enum(root, "enum_val", &enum_val, 0, 10));
+    assert_err(bf_rpack_kv_enum(root, "enum_val", &enum_val, 0, 5));
+    assert_err(bf_rpack_kv_enum(root, "enum_val", &enum_val, 6, 10));
     assert_int_equal(enum_val, 5);
 }
 


### PR DESCRIPTION
Right now a request with an invalid enum value will most likely cause a SIGSEGV on daemon side. Let's protect ourselves a bit, and reject such requests.

See https://github.com/facebook/bpfilter/pull/353 for example of how easy it was to crash the daemon.