### PR TITLE
build: use correct variable format to import benchmark report in doc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -223,7 +223,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: benchmarks-report
-          path: $GITHUB_WORKSPACE/build/doc/html/external/benchmarks/
+          path: ${{ github.workspace }}/build/doc/html/external/benchmarks/
       - name: Fix permissions
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
`$GITHUB_WORKSPACE` is not supported outside `run` commands, we need to use the proper `${{ }}`` expression instead.