### PR TITLE
daemon: cgen: ipt: fix uninitialized warning

### DIFF
--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -472,7 +472,7 @@ static int _bf_ipt_gen_ipt_replace(struct ipt_replace **replace,
     struct bf_ipt_gen_ruleset_entry ruleset[NF_INET_NUMHOOKS] = {};
     struct ipt_entry *entry;
     size_t next_chain_off = 0;
-    size_t nrules;
+    size_t nrules = 0;
     size_t rule_size =
         sizeof(struct ipt_entry) + sizeof(struct xt_standard_target);
     size_t err_size = sizeof(struct ipt_entry) + sizeof(struct xt_error_target);


### PR DESCRIPTION
```
/home/jordalgo/local/bpfilter/src/bpfilter/xlate/ipt/ipt.c:488:54: warning: 'nrules' may be used uninitialized [-Wmaybe-uninitialized]
  488 |     _replace = calloc(1, sizeof(*_replace) + (nrules * rule_size) + err_size);
      |                                              ~~~~~~~~^~~~~~~~~~~~
/home/jordalgo/local/bpfilter/src/bpfilter/xlate/ipt/ipt.c:475:12: note: 'nrules' was declared here
  475 |     size_t nrules;
      |            ^~~~~~
```