### PR TITLE
build: set base benchmark commit in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,7 +167,7 @@ jobs:
             BENCH_FAIL_ON=""
           fi
           tools/benchmarks/bfbencher \
-            --since HEAD~3 \
+            --since 30bd49f \
             --until $BENCH_UNTIL \
             $BENCH_INCLUDE \
             --cache-dir ~/bfbencher-cache \


### PR DESCRIPTION
Now that the benchmarks update have been merged into the main branch, we can use the final commit hash as base revision for running bfbencher.