### PR TITLE
fix: check correct variable after strdup in _bf_parse_tcp_flags

### DIFF
--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -614,7 +614,7 @@ static int _bf_parse_tcp_flags(enum bf_matcher_type type, enum bf_matcher_op op,
     uint8_t *flags = payload;
 
     _raw_payload = strdup(raw_payload);
-    if (!raw_payload)
+    if (!_raw_payload)
         goto err;
 
     *flags = 0;


### PR DESCRIPTION
## Summary

Fix a null check bug in `_bf_parse_tcp_flags()` where the wrong variable is checked after `strdup()`.

## The Bug

In `src/libbpfilter/matcher.c` at line 617, after calling `strdup(raw_payload)` and storing the result in `_raw_payload`, the code incorrectly checks `raw_payload` (the input parameter) instead of `_raw_payload` (the strdup result):

```c
_raw_payload = strdup(raw_payload);
if (!raw_payload)   // BUG: checks input instead of strdup result
    goto err;
```

## The Fix

Check `_raw_payload` (the result of strdup) instead:

```c
_raw_payload = strdup(raw_payload);
if (!_raw_payload)  // FIXED: check the strdup result
    goto err;
```

## Impact

If `strdup()` fails due to memory allocation failure, it returns `NULL`. Without this fix:
- The null check passes (because `raw_payload` input is non-null)
- `_raw_payload` is used on line 621: `tmp = _raw_payload;`
- This leads to null pointer dereference in the subsequent `strtok_r()` call

This fix ensures proper error handling when memory allocation fails.