### PR TITLE
cli: fix incorrect hookopts field check in chain dump

### DIFF
--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -124,7 +124,7 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
             need_comma = true;
         }
 
-        if (bf_hookopts_is_used(hookopts, BF_HOOKOPTS_FAMILY)) {
+        if (bf_hookopts_is_used(hookopts, BF_HOOKOPTS_PRIORITIES)) {
             (void)fprintf(stdout, "%spriorities=%d-%d", need_comma ? "," : "",
                           hookopts->priorities[0], hookopts->priorities[1]);
             need_comma = true;


### PR DESCRIPTION
## Summary
- Fix copy-paste bug where `BF_HOOKOPTS_FAMILY` was checked instead of `BF_HOOKOPTS_PRIORITIES` when printing priorities
- The bug caused priorities to not be printed when only `BF_HOOKOPTS_PRIORITIES` was set
- The bug also caused priorities to be printed with potentially invalid values when only `BF_HOOKOPTS_FAMILY` was set

## Bug Details
In `bfc_chain_dump()`, the condition for printing the `priorities` field incorrectly checked for `BF_HOOKOPTS_FAMILY`:

```c
// Before (incorrect - copy-paste error)
if (bf_hookopts_is_used(hookopts, BF_HOOKOPTS_FAMILY)) {
    (void)fprintf(stdout, "%spriorities=%d-%d", ...);
    ...
}

// After (correct)
if (bf_hookopts_is_used(hookopts, BF_HOOKOPTS_PRIORITIES)) {
    (void)fprintf(stdout, "%spriorities=%d-%d", ...);
    ...
}
```

This was clearly a copy-paste error from the preceding block that checks `BF_HOOKOPTS_FAMILY` for the `family` field.

## Testing
- Code inspection confirms the fix matches the enum definition in `hook.h`