### PR TITLE
daemon: cgen: link: probe for best XDP attachment mode

### DIFF
--- a/src/bpfilter/cgen/prog/link.h
+++ b/src/bpfilter/cgen/prog/link.h
@@ -94,8 +94,6 @@ void bf_link_dump(const struct bf_link *link, prefix_t *prefix);
 /**
  * Attach a BPF program to a hook using a the link.
  *
- * @todo Automatically use the most appropriate XDP mode based on the driver's
- * capabilities.
  * @todo Validate `hookopts` before attaching the link.
  *
  * @param link `bf_link` object to use to attach the program. Can't be NULL.


### PR DESCRIPTION
As mentioned in #362, instead of always using XDP_FLAGS_SKB_MODE, try hardware offload first, then driver mode, falling back to SKB mode only if neither is available. This improves performance on NICs that support XDP driver or hardware offloading.

(Note: I searched around for a way to do this without trial and error - HW->DRV->SKB -, but was unable to find a way to determine what XDP options are available dynamically. If anyone knows of a way to do that, please let me know.)

Test Plan:
- Manual Testing: Was able to test that on a server that XDP_FLAGS_DRV_MODE properly attaches in driver mode, and that XDP_FLAGS_SKB_MODE properly functions as the fallback. I was unable to get access to a Netronome NIC to test the HW offloading.