### PR TITLE
doc: document broken iptables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 ## Key features
 
 - **High performance**: utilizes eBPF's near-native performance capabilities
-- **Flexible integration**: use the custom `iptables` integration or **bpfilter**'s `bfcli` command line for extended functionalities
 - **Low overhead**: minimal resource consumption with maximized efficiency
 - **Developer-friendly**: clean architecture with clear separation of components
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -58,7 +58,6 @@
    <h5>Key features</h5>
 
 - **High performance**: utilizes eBPF's near-native performance capabilities
-- **Flexible integration**: use the custom ``iptables`` integration or **bpfilter**'s ``bfcli`` command line for extended functionalities
 - **Low overhead**: minimal resource consumption with maximized efficiency
 - **Developer-friendly**: clean architecture with clear separation of components
 

--- a/doc/usage/index.rst
+++ b/doc/usage/index.rst
@@ -19,7 +19,7 @@ Before anything, you will have to run the daemon on your system, see :doc:`daemo
 Once the daemon is running, you need to choose which front-end's CLI to use:
 
 - :doc:`bfcli`: ``bpfilter``-specific CLI, developed as part of the project. ``bfcli`` supports new ``bpfilter`` features before other CLIs as it's used for development. It allows for a more flexible rule definition: you can use a combination of filters and hooks that might not be possible with other CLIs. However, it doesn't support ``nftables`` or ``iptables`` rules format.
-- :doc:`nftables`: requires a custom version of the ``nft`` binary with ``bpfilter`` support (see below), and support for new ``bpfilter`` features is usually a bit delayed.
+- :doc:`nftables` (work in progress): requires a custom version of the ``nft`` binary with ``bpfilter`` support, and support for new ``bpfilter`` features is usually a bit delayed.
 - :doc:`iptables`: similar to ``nftables``, however ``iptables`` has been deprecated globally in favor of ``nftables``.
 
 Install

--- a/doc/usage/iptables.rst
+++ b/doc/usage/iptables.rst
@@ -1,32 +1,6 @@
 ``iptables``
 ============
 
-A custom ``iptables`` binary is required to use with ``bpfilter``, but it can be built directly from the ``bpfilter`` source tree: ``make iptables``. Once you have build ``iptables``, you can force it to communicate with ``bpfilter`` instead of the kernel using ``--bpf``.
+.. warning::
 
-The following filters are supported:
-
-- Source IPv4 address and mask.
-- Destination IPv4 address and mask.
-- Layer 4 protocol.
-
-Filtering rules can be defined for any table, and ``ACCEPT`` and ``DROP`` action are supported. The ruleset can also be fetched back from ``bpfilter``. For example:
-
-.. code:: shell
-
-    # Start bpfilter daemon
-    $ sudo bpfilter
-
-    # Add a new rule to block ping requests
-    $ sudo iptables -I INPUT --bpf -p icmp -j DROP
-
-    # Show the rules and counters after the host was pinged
-    $ sudo iptables --bpf -nv -L
-    Chain INPUT (policy ACCEPT 327 packets, 42757 bytes)
-    pkts bytes target     prot opt in     out     source               destination
-        2   196 DROP       icmp --  *      *       0.0.0.0/0            0.0.0.0/0
-
-    Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
-    pkts bytes target     prot opt in     out     source               destination
-
-    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
-    pkts bytes target     prot opt in     out     source               destination
+    ``iptables`` support is currently broken. See `#385 <https://github.com/facebook/bpfilter/issues/385>`_ for updates.


### PR DESCRIPTION
As of commit c951864, iptables are no longer supported. There are currently no plans to support legacy iptables.