### PR TITLE
Restore counter values on chain update

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -206,7 +206,7 @@ See below for a list of available hook options.
 ``chain update``
 ~~~~~~~~~~~~~~~~
 
-Update an existing chain. The new chain will atomically update the existing one. Hook options are ignored. The new chain will replace the existing chain with the same name.
+Update an existing chain. The new chain will atomically update the existing one. Hook options are ignored. The new chain will replace the existing chain with the same name. Counters are reset to zero.
 
 If you want to modify the hook options, use ``bfcli chain set`` instead.
 
@@ -242,7 +242,7 @@ If you want to modify the hook options, use ``bfcli chain set`` instead.
 ``chain update-set``
 ~~~~~~~~~~~~~~~~~~~~
 
-Atomically update the content of a named set in a chain using delta operations. This is more efficient than replacing the entire chain when you only need to modify set membership.
+Atomically update the content of a named set in a chain using delta operations. This is more efficient than replacing the entire chain when you only need to modify set membership. Counters are preserved across the update.
 
 **Options**
   - ``--name NAME``: name of the chain containing the set.

--- a/src/bpfilter/cgen/cgen.h
+++ b/src/bpfilter/cgen/cgen.h
@@ -130,6 +130,17 @@ int bf_cgen_attach(struct bf_cgen *cgen, const struct bf_ns *ns,
                    struct bf_hookopts **hookopts);
 
 /**
+ * Flags to control the behavior of `bf_cgen_update`.
+ */
+enum bf_cgen_update_flags
+{
+    /** Preserve counter values from the old program. */
+    BF_CGEN_UPDATE_PRESERVE_COUNTERS,
+
+    _BF_CGEN_UPDATE_MAX,
+};
+
+/**
  * Update the program attached to the hook.
  *
  * A new program will be generated based on `new_chain`, before it is loaded
@@ -142,9 +153,11 @@ int bf_cgen_attach(struct bf_cgen *cgen, const struct bf_ns *ns,
  * @param cgen Codegen to update. Can't be NULL.
  * @param new_chain Chain containing the new rules, sets, and policy.
  *        Can't be NULL.
+ * @param flags Flags to control update behavior. 0 if no flags.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain);
+int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain,
+                   uint32_t flags);
 
 /**
  * Detach a program from the kernel.

--- a/src/bpfilter/xlate/cli.c
+++ b/src/bpfilter/xlate/cli.c
@@ -509,7 +509,7 @@ int _bf_cli_chain_update(const struct bf_request *request,
     if (!cgen)
         return -ENOENT;
 
-    r = bf_cgen_update(cgen, &chain);
+    r = bf_cgen_update(cgen, &chain, 0);
     if (r)
         return -EINVAL;
 
@@ -607,7 +607,8 @@ int _bf_cli_chain_update_set(const struct bf_request *request,
     if (r)
         return bf_err_r(r, "failed to calculate set difference");
 
-    r = bf_cgen_update(cgen, &new_chain);
+    r = bf_cgen_update(cgen, &new_chain,
+                       BF_FLAG(BF_CGEN_UPDATE_PRESERVE_COUNTERS));
     if (r)
         return bf_err_r(r, "failed to update chain with new set data");
 

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -718,7 +718,7 @@ static int _bf_ipt_ruleset_set(const struct bf_request *req)
 
             TAKE_PTR(cgen);
         } else {
-            r = bf_cgen_update(cgen, &chain);
+            r = bf_cgen_update(cgen, &chain, 0);
             if (r) {
                 TAKE_PTR(cgen);
                 bf_err_r(

--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -116,6 +116,13 @@ extern const char *strerrordesc_np(int errnum);
  */
 #define BF_FLAG(n) (1 << (n))
 
+/**
+ * @brief Generate a bitmask covering all valid flags below `max_value`.
+ *
+ * @return Mask with bits 0 through max_value-1 set.
+ */
+#define BF_FLAGS_MASK(max_value) ((1ULL << (max_value)) - 1)
+
 #define bf_packed __attribute__((packed))
 #define bf_aligned(x) __attribute__((aligned(x)))
 #define bf_unused __attribute__((unused))


### PR DESCRIPTION
As mentioned in #389, when `bf_cgen_update()` replaces a chain, the new BPF program starts with a zeroed counter map. The behavior should be that when updating a specific entity within a chain (set, rule, etc.), the counters should be preserved (see @qdeslandes comment [below](https://github.com/facebook/bpfilter/pull/416#pullrequestreview-3835437432) for more details and rationale).

This PR adds that behavior specifically for `chain update-set`, while leaving the existing behavior for `chain update`.

Notes/Thoughts:
- With the current implementation, counters are copied from the old map to the new map after the new program is loaded but before the link swap. This means that it is possible for some packets to be unaccounted for in the time between the data being transferred and when the new chain begins filtering. While it is possible to keep the same maps (and thus the exact number) since we know the number of rules will be the same, doing that would require a more invasive approach (the flag would need to propagate into more methods) and will not work for `add-rule` or `remove-rule`.
- A `bf_cgen_update_flags` enum is added for flexibility in case we need future arguments as opposed to a boolean (which is simpler but harder to work with if we need to use or update this in the future). However, the goal either way should be for this to be temporary (in line with the consolidated behavior mentioned [here](https://github.com/facebook/bpfilter/pull/416#pullrequestreview-3835437432)).

~## Design~
~The implementation assumes:~
- ~Chains may have large numbers of rules, sets, and set elements, but rules won't have exceedingly large numbers of matchers~
- ~Update overhead should remain negligible relative to program generation and loading~
- ~Simplicity is preferred over hyper-optimizations where possible~

~**Set mapping.** Because set matchers reference sets by position and positions can change between chains, a set index mapping is built first. To efficiently compare large sets, old sets are hashed (FNV-1a with commutative element sum for order-independence), sorted by hash, and binary-searched for each new set. Hash matches are verified deterministically with `bf_set_equal()`, which copies each set's elements into a flat array, sorts them, and compares with memcmp.~

~**Rule matching.** Rules are hashed the same way - FNV-1a of scalar fields plus a commutative sum of per-matcher hashes. A new rules set matchers hash their mapped old index so equivalent rules produce identical hashes regardless of set position (this abstracts away the whole idea of the set so we don't need to worry about it). Old rules are sorted by hash and binary-searched for each new rule, with full order-independent matcher comparison to verify matches. Once again, hash matches are verified deterministically using `_bf_rule_equal`.~

~**Counter transfer.** For each matched pair, the old counter is read and written to the new program's counter map. Policy and error counters are always preserved. This happens after `bf_program_load` but before `bf_link_update`, so there is no race.~

~## Performance
Tested with up to 10k rules and 100 sets of 50k elements each. The mapping and transfer overhead was negligible relative to program generation and loading.~

## Test plan 
- Added tests to `chain_update.sh` and `chain_update_set.sh`
- Manual testing 
- ~Unit tests for `bf_fnv1a` and `bf_set_equal`~
- ~E2E test covering rule reordering and set index shuffling~