### PR TITLE
tools: add claude PR reviews

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -1,0 +1,31 @@
+name: Claude PR Review
+on:
+    pull_request:
+        types: [opened, synchronize]
+jobs:
+    review:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write # gh CLI authentication
+            pull-requests: write # make a comment on PR
+            contents: read # clone repo
+            actions: read # see GH Actions outputs
+            issues: read # read issues (for context)
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - uses: anthropics/claude-code-action@v1
+              with:
+                  # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                  plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+                  plugins: "code-review@claude-code-plugins"
+                  prompt: |
+                      /code-review:code-review --comment
+                  claude_args: |
+                      --max-turns 50
+                      --model claude-opus-4-6
+                      --allowedTools "Read,Write,Grep,Glob,Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*)"
+                  additional_permissions: |
+                      actions: read


### PR DESCRIPTION
This GitHub CI workflow watches all comments in the repo, and if they contain the word `@claude`, trigger the Claude bot.

Copy-pasted from Claude bot setup guide.