### PR TITLE
tests: e2e: validate sets and empty sets survive daemon restarts

### DIFF
--- a/tests/e2e/daemon/restore_attached.sh
+++ b/tests/e2e/daemon/restore_attached.sh
@@ -6,9 +6,29 @@ make_sandbox
 
 start_bpfilter
     ${FROM_NS} bfcli chain set --from-str "chain test_chain BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT"
+    ping -c 1 -W 0.1 ${NS_IP_ADDR}
 stop_bpfilter --skip-cleanup
 
 start_bpfilter
-    # Ensure it's restored properly
-    ${FROM_NS} bfcli chain set --from-str "chain test_chain BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT"
+    # Ensure it's restored as attached with the correct ifindex
+    chain_output=$(${FROM_NS} bfcli chain get --name test_chain)
+    echo "$chain_output"
+    echo "$chain_output" | grep -q "ifindex=${NS_IFINDEX}"
+
+    # Attached chains with sets: set elements and filtering survive a restart
+    ${FROM_NS} bfcli chain set --from-str "chain test_chain BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT
+        set myset (ip4.saddr) in { ${HOST_IP_ADDR}; 192.168.1.2 }
+        set empty_set (ip4.saddr) in {}
+        rule (ip4.saddr) in myset counter DROP
+        rule (ip4.saddr) in empty_set ACCEPT"
+    (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
+stop_bpfilter --skip-cleanup
+
+start_bpfilter
+    chain_output=$(${FROM_NS} bfcli chain get --name test_chain)
+    echo "$chain_output"
+    echo "$chain_output" | grep -q "${HOST_IP_ADDR}"
+    echo "$chain_output" | grep -q "192.168.1.2"
+    echo "$chain_output" | grep -q "empty_set"
+    (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
 stop_bpfilter

--- a/tests/e2e/daemon/restore_non_attached.sh
+++ b/tests/e2e/daemon/restore_non_attached.sh
@@ -10,4 +10,25 @@ stop_bpfilter --skip-cleanup
 
 start_bpfilter
     ${FROM_NS} bfcli chain attach --name test_chain --option ifindex=${NS_IFINDEX}
+
+    # Non-attached chains with sets: set elements survive a restart, and the
+    # chain can be attached afterward
+    ${FROM_NS} bfcli chain set --from-str "chain test_chain BF_HOOK_XDP ACCEPT
+        set myset (ip4.saddr) in { ${HOST_IP_ADDR}; 192.168.1.2 }
+        set empty_set (ip4.saddr) in {}
+        rule (ip4.saddr) in myset counter DROP
+        rule (ip4.saddr) in empty_set ACCEPT"
+
+    ping -c 1 -W 0.1 ${NS_IP_ADDR}
+stop_bpfilter --skip-cleanup
+
+start_bpfilter
+    chain_output=$(${FROM_NS} bfcli chain get --name test_chain)
+    echo "$chain_output"
+    echo "$chain_output" | grep -q "${HOST_IP_ADDR}"
+    echo "$chain_output" | grep -q "192.168.1.2"
+    echo "$chain_output" | grep -q "empty_set"
+
+    ${FROM_NS} bfcli chain attach --name test_chain --option ifindex=${NS_IFINDEX}
+    (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
 stop_bpfilter


### PR DESCRIPTION
Add set restore scenarios to restore_attached and restore_non_attached tests. Each creates a chain with both a populated set and an empty set, restarts the daemon, and verifies that set elements are preserved and filtering works after restore.