### PR TITLE
tools: update Claude PR reviewer prompt

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -23,6 +23,7 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: anthropics/claude-code-action@v1
+              if: github.event.pull_request.draft == false
               with:
                   # Anthropic auth
                   # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -30,17 +31,47 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
 
                   # Prompt
-                  plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
-                  plugins: "code-review@claude-code-plugins"
                   prompt: |
-                      /code-review:code-review --comment
+                      REPO: ${{ github.repository }}
+                      PR NUMBER: ${{ github.event.pull_request.number }}
+
+                      Please review this pull request. Use instructions in /review-pr command. However, the patch will be
+                      built and tested by other GitHub Actions workflows, so you should skip these parts of that command.
+
+                      You can use multiple subagents to parallelize tasks. Each subagent should be told the PR title and description.
+
+                      Use `gh pr view <PR NUMBER> --comments` and `gh pr diff <PR NUMBER> --patch` to access the PR content.
+                      You are in repository without that patch applied. Do not apply it.
+
+                      For every issue, rate how significant it is. Make sure you are confident in your diagnosis.
+
+                      For every CLAUDE.md compliance violation, check if repo has other places where this issue appears.
+                      If it does, do not point out the violation in the place it appears.
+                      Instead in the final top-level comment, include a suggestion how to improve CLAUDE.md.
+
+                      Provide detailed feedback as PR comments, using inline comments for specific issues.
+                      Use `mcp__github_comment__update_claude_comment` for top-level feedback. Keep it short.
+                      Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+                      Prefix all your GitHub comments with "Claude: ".
+                      Use `gh pr view <PR NUMBER> --comments` output to make sure you don't comment about the same issue twice.
+
+                      When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview
+                      won't render correctly: https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/README.md#L10-L15
                   claude_args: |
                       --max-turns 50
                       --model claude-opus-4-6
-                      --allowedTools "Read,Write,Grep,Glob,Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*)"
+                      --allowedTools "
+                        Read,Write,Edit,MultiEdit,LS,Grep,Glob,
+                        Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*),
+                        mcp__github_comment__update_claude_comment,
+                        mcp__github_inline_comment__create_inline_comment,
+                        "
 
                   # Run even when triggered by 3rd party developer's PR
                   allowed_non_write_users: "*"
+
+                  # Make in-progress comment, then update it
+                  track_progress: true
 
                   # Enable access to other GH Actions outputs
                   additional_permissions: |


### PR DESCRIPTION
Combining the best parts of https://github.com/anthropics/claude-code-action/blob/0cf5eeec4f908121edd03a81411b55485994f8d3/docs/solutions.md and https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md to create a better prompt, that we can keep iterating on.

Demo: https://github.com/pzmarzly/demo--claude-bot-reviews/pull/8 (comments 2 and 3).