### PR TITLE
tests: check: use run-clang-tidy to parallelize linting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ include(GitVersion)
 get_version_from_git()
 message(NOTICE "bpfilter version ${PROJECT_VERSION}${PROJECT_VERSION_SUFFIX}")
 
+# Store the number of CPUs in a variable, can be used to parallelize commands
+include(ProcessorCount)
+ProcessorCount(CPU_COUNT)
+if(CPU_COUNT EQUAL 0)
+    set(CPU_COUNT 1)
+endif()
+
 include(GNUInstallDirs)
 
 option(NO_DOCS "Disable documentation generation" 0)

--- a/tests/check/CMakeLists.txt
+++ b/tests/check/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 # Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
 
-find_program(CLANG_TIDY_BIN NAMES clang-tidy-18 clang-tidy REQUIRED)
+find_program(RUN_CLANG_TIDY_BIN NAMES run-clang-tidy-18 run-clang-tidy REQUIRED)
 find_program(CLANG_FORMAT_BIN NAMES clang-format-18 clang-format REQUIRED)
 
 file(GLOB_RECURSE bf_srcs
@@ -20,11 +20,11 @@ set(bf_all_srcs ${bf_srcs} ${bf_test_srcs})
 
 add_test(NAME "check.lint"
     COMMAND
-        ${CLANG_TIDY_BIN}
-            --quiet
-            --config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
+        ${RUN_CLANG_TIDY_BIN}
+            -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
             -p ${CMAKE_BINARY_DIR}
-            --extra-arg=-fno-caret-diagnostics
+            -extra-arg=-fno-caret-diagnostics
+            -j ${CPU_COUNT}
             ${bf_srcs}
 )
 


### PR DESCRIPTION
Detect the number of available CPUs via ProcessorCount and use run-clang-tidy instead of clang-tidy to run lint checks in parallel, reducing wall-clock time on multi-core machines.