### PR TITLE
daemon: cgen: fix NULL check in bf_fixup_new

### DIFF
--- a/src/bpfilter/cgen/fixup.c
+++ b/src/bpfilter/cgen/fixup.c
@@ -17,7 +17,7 @@ int bf_fixup_new(struct bf_fixup **fixup, enum bf_fixup_type type,
     assert(fixup);
 
     *fixup = calloc(1, sizeof(struct bf_fixup));
-    if (!fixup)
+    if (!*fixup)
         return -ENOMEM;
 
     (*fixup)->type = type;


### PR DESCRIPTION
`bf_fixup_new` checks the pointer-to-pointer parameter instead of the dereferenced `calloc` result. A `calloc` failure goes undetected, leading to a NULL pointer dereference in the caller.