### PR TITLE
daemon: cgen: move asserts before pointer dereferences

### DIFF
--- a/src/bpfilter/cgen/cgen.c
+++ b/src/bpfilter/cgen/cgen.c
@@ -428,11 +428,13 @@ void bf_cgen_unload(struct bf_cgen *cgen)
 
 int bf_cgen_get_counters(const struct bf_cgen *cgen, bf_list *counters)
 {
-    bf_list _counters = bf_list_default_from(*counters);
+    bf_list _counters;
     int r;
 
     assert(cgen);
     assert(counters);
+
+    _counters = bf_list_default_from(*counters);
 
     /* Iterate over all the rules, then the policy counter (size(rules)) and
      * the errors counters (sizeof(rules) + 1)*/

--- a/src/bpfilter/cgen/prog/link.c
+++ b/src/bpfilter/cgen/prog/link.c
@@ -32,7 +32,7 @@ int bf_link_new(struct bf_link **link, const char *name, enum bf_hook hook,
     _cleanup_close_ int fd = -1;
     _cleanup_close_ int fd_extra = -1;
     _cleanup_close_ int cgroup_fd = -1;
-    struct bf_hookopts *_hookopts = *hookopts;
+    struct bf_hookopts *_hookopts = NULL;
     int r;
 
     assert(link);
@@ -47,6 +47,7 @@ int bf_link_new(struct bf_link **link, const char *name, enum bf_hook hook,
                         "hookopts are required when creating a new bf_link");
     }
 
+    _hookopts = *hookopts;
     _link = calloc(1, sizeof(*_link));
     if (!_link)
         return -ENOMEM;
@@ -244,10 +245,12 @@ static int _bf_link_update_nf(struct bf_link *link, int prog_fd)
 {
     _cleanup_close_ int new_inet_fd = -1;
     _cleanup_close_ int new_inet6_fd = -1;
-    struct bf_hookopts opts = *link->hookopts;
+    struct bf_hookopts opts;
     int r;
 
     assert(link);
+
+    opts = *link->hookopts;
 
     // Attach new program to both inet4 and inet6 using the unused priority
     // This ensures the network is never left unfiltered


### PR DESCRIPTION
Fixes a few locations where we dereferenced a variable before the assert.