### PR TITLE
tools: switch Claude CI from "tag mode" to "agent mode"

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -50,7 +50,7 @@ jobs:
                       Instead in the final top-level comment, include a suggestion how to improve CLAUDE.md.
 
                       Provide detailed feedback as PR comments, using inline comments for specific issues.
-                      Use `mcp__github_comment__update_claude_comment` for top-level feedback. Keep it short.
+                      Use `gh pr comment ${{ github.event.pull_request.number }} --body "..."` for top-level summary. Keep it short.
                       Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
                       Prefix all your GitHub comments with "Claude: ".
                       Use `gh pr view <PR NUMBER> --comments` output to make sure you don't comment about the same issue twice.
@@ -63,15 +63,15 @@ jobs:
                       --allowedTools "
                         Read,Write,Edit,MultiEdit,LS,Grep,Glob,
                         Bash(cat:*),Bash(test:*),Bash(printf:*),Bash(jq:*),Bash(head:*),Bash(git:*),Bash(gh:*),
-                        mcp__github_comment__update_claude_comment,
                         mcp__github_inline_comment__create_inline_comment,
                         "
 
                   # Run even when triggered by 3rd party developer's PR
                   allowed_non_write_users: "*"
 
-                  # Make in-progress comment, then update it
-                  track_progress: true
+                  # This requires "tag mode", which is currently bugged:
+                  # https://github.com/anthropics/claude-code-action/issues/939
+                  track_progress: false
 
                   # Enable access to other GH Actions outputs
                   additional_permissions: |


### PR DESCRIPTION
`track_progress: true` enables "tag mode", which has much more advanced harness than the plain "agent mode". It does more than just creating a comment on startup. One of the thing it does is gathering PR context - which is broken for cross-repo PRs (unless the branch names are the same). See https://github.com/anthropics/claude-code-action/issues/939.

We have two options:
- Revert to `anthropics/claude-code-action@v1.0.48`, which supported gathering cross-repo PR context.
- Disable "tag mode" by disabling `track_progress` for now.

I prefer option 2, it's not clear how long it will take Anthropic to fix that issue, and I'd rather not stay on unsupported version for too long.

Once upstream bug is fixed, we can revert this commit.