### PR TITLE
lib: helper: simplify and extend _BF_APPLY macros

### DIFF
--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -17,65 +17,29 @@ extern const char *strerrordesc_np(int errnum);
 
 #define _BF_APPLY0(t, s, dummy)
 #define _BF_APPLY1(t, s, a) t(a)
-#define _BF_APPLY2(t, s, a, b) t(a) s t(b)
-#define _BF_APPLY3(t, s, a, b, c)                                              \
-    t(a) s t(b)                                                                \
-    s t(c)
-#define _BF_APPLY4(t, s, a, b, c, d)                                           \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)
-#define _BF_APPLY5(t, s, a, b, c, d, e)                                        \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)
-#define _BF_APPLY6(t, s, a, b, c, d, e, f)                                     \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)                                                                     \
-    s t(f)
-#define _BF_APPLY7(t, s, a, b, c, d, e, f, g)                                  \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)                                                                     \
-    s t(f)                                                                     \
-    s t(g)
-#define _BF_APPLY8(t, s, a, b, c, d, e, f, g, h)                               \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)                                                                     \
-    s t(f)                                                                     \
-    s t(g)                                                                     \
-    s t(h)
-#define _BF_APPLY9(t, s, a, b, c, d, e, f, g, h, i)                            \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)                                                                     \
-    s t(f)                                                                     \
-    s t(g)                                                                     \
-    s t(h)                                                                     \
-    s t(i)
-#define _BF_APPLY10(t, s, a, b, c, d, e, f, g, h, i, j)                        \
-    t(a) s t(b)                                                                \
-    s t(c)                                                                     \
-    s t(d)                                                                     \
-    s t(e)                                                                     \
-    s t(f)                                                                     \
-    s t(g)                                                                     \
-    s t(h)                                                                     \
-    s t(i)                                                                     \
-    s t(j)
+#define _BF_APPLY2(t, s, a, ...) t(a) s _BF_APPLY1(t, s, __VA_ARGS__)
+#define _BF_APPLY3(t, s, a, ...) t(a) s _BF_APPLY2(t, s, __VA_ARGS__)
+#define _BF_APPLY4(t, s, a, ...) t(a) s _BF_APPLY3(t, s, __VA_ARGS__)
+#define _BF_APPLY5(t, s, a, ...) t(a) s _BF_APPLY4(t, s, __VA_ARGS__)
+#define _BF_APPLY6(t, s, a, ...) t(a) s _BF_APPLY5(t, s, __VA_ARGS__)
+#define _BF_APPLY7(t, s, a, ...) t(a) s _BF_APPLY6(t, s, __VA_ARGS__)
+#define _BF_APPLY8(t, s, a, ...) t(a) s _BF_APPLY7(t, s, __VA_ARGS__)
+#define _BF_APPLY9(t, s, a, ...) t(a) s _BF_APPLY8(t, s, __VA_ARGS__)
+#define _BF_APPLY10(t, s, a, ...) t(a) s _BF_APPLY9(t, s, __VA_ARGS__)
+#define _BF_APPLY11(t, s, a, ...) t(a) s _BF_APPLY10(t, s, __VA_ARGS__)
+#define _BF_APPLY12(t, s, a, ...) t(a) s _BF_APPLY11(t, s, __VA_ARGS__)
+#define _BF_APPLY13(t, s, a, ...) t(a) s _BF_APPLY12(t, s, __VA_ARGS__)
+#define _BF_APPLY14(t, s, a, ...) t(a) s _BF_APPLY13(t, s, __VA_ARGS__)
+#define _BF_APPLY15(t, s, a, ...) t(a) s _BF_APPLY14(t, s, __VA_ARGS__)
+#define _BF_APPLY16(t, s, a, ...) t(a) s _BF_APPLY15(t, s, __VA_ARGS__)
 
-#define __BF_NUM_ARGS1(dummy, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, x0,     \
-                       ...)                                                    \
+#define __BF_NUM_ARGS1(dummy, x16, x15, x14, x13, x12, x11, x10, x9, x8, x7,   \
+                       x6, x5, x4, x3, x2, x1, x0, ...)                        \
     x0
 #define _BF_NUM_ARGS(...)                                                      \
-    __BF_NUM_ARGS1(dummy, ##__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+    __BF_NUM_ARGS1(dummy, ##__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7,  \
+                   6, 5, 4, 3, 2, 1, 0)
+
 #define ___BF_APPLY_ALL(t, s, n, ...) _BF_APPLY##n(t, s, __VA_ARGS__)
 #define __BF_APPLY_ALL(t, s, n, ...) ___BF_APPLY_ALL(t, s, n, __VA_ARGS__)
 #define _BF_APPLY_ALL(t, s, ...)                                               \
@@ -112,9 +76,9 @@ extern const char *strerrordesc_np(int errnum);
  *
  * @see `BF_FLAGS`
  *
- * @return `1 << n` to be used as a flag.
+ * @return `1ULL << n` to be used as a flag.
  */
-#define BF_FLAG(n) (1 << (n))
+#define BF_FLAG(n) (1ULL << (n))
 
 #define bf_packed __attribute__((packed))
 #define bf_aligned(x) __attribute__((aligned(x)))

--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -113,6 +113,10 @@ enum bf_matcher_type
     _BF_MATCHER_TYPE_MAX,
 };
 
+/// @todo Change `bf_matcher_type` bitmasks to 64 bits.
+static_assert(_BF_MATCHER_TYPE_MAX <= 8 * sizeof(uint32_t),
+              "too many matcher types for uint32_t bitmask");
+
 /**
  * Defines the structure of the payload for bf_matcher's
  * @ref BF_MATCHER_IP4_SADDR and @ref BF_MATCHER_IP4_DADDR types.

--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -31,9 +31,6 @@ int bf_set_new(struct bf_set **set, const char *name, enum bf_matcher_type *key,
     assert(set);
     assert(key);
 
-    static_assert(_BF_MATCHER_TYPE_MAX < 8 * sizeof(uint32_t),
-                  "matcher type bitmask won't fit in 32 bits");
-
     if (n_comps == 0)
         return bf_err_r(-EINVAL, "at least 1 key component is required");
 


### PR DESCRIPTION
- Use recursive chaining where each `_BF_APPLYn` calls `_BF_APPLYn-1`. 
- Extend from a max of 10 arguments to 16 (likely will be necessary for #355).
- Update `BF_FLAG` to use 1ULL to avoid UB when enum values reach 31+ (`bf_matcher` already has 31 values).

Note:
- If we need to support more flags at some point, we may want to look in to the [Swanson Map Macro](https://github.com/swansontec/map-macro/blob/master/README.md). For now, that is probably making things more complicated than they need to be.

Testing:
- CI/Existing tests
- Manual Testing