### PR TITLE
lib,cli,daemon,tests: rename counter fields to hook-neutral terminology

### DIFF
--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -138,11 +138,11 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
 
     counter = bf_list_node_get_data(policy_counter_node);
     (void)fprintf(stdout, "    counters policy %lu packets %lu bytes; ",
-                  counter->packets, counter->bytes);
+                  counter->count, counter->size);
 
     counter = bf_list_node_get_data(err_counter_node);
-    (void)fprintf(stdout, "error %lu packets %lu bytes\n", counter->packets,
-                  counter->bytes);
+    (void)fprintf(stdout, "error %lu packets %lu bytes\n", counter->count,
+                  counter->size);
 
     // Loop over named sets
     bf_list_foreach (&chain->sets, set_node) {
@@ -271,7 +271,7 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
         if (rule->counters) {
             counter = bf_list_node_get_data(counter_node);
             (void)fprintf(stdout, "        counters %lu packets %lu bytes\n",
-                          counter->packets, counter->bytes);
+                          counter->count, counter->size);
         }
         counter_node = bf_list_node_next(counter_node);
 

--- a/src/bpfilter/bpf/update_counters.bpf.c
+++ b/src/bpfilter/bpf/update_counters.bpf.c
@@ -14,8 +14,8 @@
 
 struct bf_counter
 {
-    __u64 packets;
-    __u64 bytes;
+    __u64 count;
+    __u64 size;
 };
 
 __u8 bf_update_counters(struct bf_runtime *ctx, void *map, __u64 key)
@@ -28,8 +28,8 @@ __u8 bf_update_counters(struct bf_runtime *ctx, void *map, __u64 key)
         return 1;
     }
 
-    counter->packets += 1;
-    counter->bytes += ctx->pkt_size;
+    counter->count += 1;
+    counter->size += ctx->pkt_size;
 
     return 0;
 }

--- a/src/bpfilter/cgen/prog/map.c
+++ b/src/bpfilter/cgen/prog/map.c
@@ -109,8 +109,8 @@ static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
         btf__add_int(kbtf, "u64", 8, 0);
         btf->key_type_id = btf__add_int(kbtf, "u32", 4, 0);
         btf->value_type_id = btf__add_struct(kbtf, "bf_counters", 16);
-        btf__add_field(kbtf, "packets", 1, 0, 0);
-        btf__add_field(kbtf, "bytes", 1, 64, 0);
+        btf__add_field(kbtf, "count", 1, 0, 0);
+        btf__add_field(kbtf, "size", 1, 64, 0);
         break;
     case BF_MAP_TYPE_PRINTER:
     case BF_MAP_TYPE_SET:

--- a/src/bpfilter/xlate/ipt/ipt.c
+++ b/src/bpfilter/xlate/ipt/ipt.c
@@ -539,8 +539,8 @@ static int _bf_ipt_gen_ipt_replace(struct ipt_replace **replace,
                                     "failed to get counters for iptables rule");
                 }
 
-                entry->counters.bcnt = counters.bytes;
-                entry->counters.pcnt = counters.packets;
+                entry->counters.bcnt = counters.size;
+                entry->counters.pcnt = counters.count;
             }
 
             entry = (void *)entry + rule_size;
@@ -556,8 +556,8 @@ static int _bf_ipt_gen_ipt_replace(struct ipt_replace **replace,
                     r, "failed to get policy counters for iptables chain");
             }
 
-            entry->counters.bcnt = counters.bytes;
-            entry->counters.pcnt = counters.packets;
+            entry->counters.bcnt = counters.size;
+            entry->counters.pcnt = counters.count;
         }
 
         entry->target_offset = sizeof(struct ipt_entry);

--- a/src/libbpfilter/counter.c
+++ b/src/libbpfilter/counter.c
@@ -11,8 +11,7 @@
 
 #include "bpfilter/helper.h"
 
-int bf_counter_new(struct bf_counter **counter, uint64_t packets,
-                   uint64_t bytes)
+int bf_counter_new(struct bf_counter **counter, uint64_t count, uint64_t size)
 {
     _cleanup_free_ struct bf_counter *_counter = NULL;
 
@@ -22,8 +21,8 @@ int bf_counter_new(struct bf_counter **counter, uint64_t packets,
     if (!_counter)
         return -ENOMEM;
 
-    _counter->bytes = bytes;
-    _counter->packets = packets;
+    _counter->count = count;
+    _counter->size = size;
 
     *counter = TAKE_PTR(_counter);
 
@@ -41,13 +40,13 @@ int bf_counter_new_from_pack(struct bf_counter **counter, bf_rpack_node_t node)
     if (r)
         return r;
 
-    r = bf_rpack_kv_u64(node, "packets", &_counter->packets);
+    r = bf_rpack_kv_u64(node, "count", &_counter->count);
     if (r)
-        return bf_rpack_key_err(r, "bf_counter.packets");
+        return bf_rpack_key_err(r, "bf_counter.count");
 
-    r = bf_rpack_kv_u64(node, "bytes", &_counter->bytes);
+    r = bf_rpack_kv_u64(node, "size", &_counter->size);
     if (r)
-        return bf_rpack_key_err(r, "bf_counter.bytes");
+        return bf_rpack_key_err(r, "bf_counter.size");
 
     *counter = TAKE_PTR(_counter);
 
@@ -69,8 +68,8 @@ int bf_counter_pack(const struct bf_counter *counter, bf_wpack_t *pack)
     assert(counter);
     assert(pack);
 
-    bf_wpack_kv_u64(pack, "packets", counter->packets);
-    bf_wpack_kv_u64(pack, "bytes", counter->bytes);
+    bf_wpack_kv_u64(pack, "count", counter->count);
+    bf_wpack_kv_u64(pack, "size", counter->size);
 
     return bf_wpack_is_valid(pack) ? 0 : -EINVAL;
 }

--- a/src/libbpfilter/include/bpfilter/counter.h
+++ b/src/libbpfilter/include/bpfilter/counter.h
@@ -15,15 +15,16 @@
  *
  * Counters assigned to each rule.
  *
- * @var bf_counter::packets
- *  Number of packets gone through a rule.
- * @var bf_counter::bytes
- *  Number of bytes gone through a rule.
+ * @var bf_counter::count
+ *  Number of events gone through a rule (e.g. packets for packet hooks,
+ *  operations for non-packet hooks).
+ * @var bf_counter::size
+ *  Accumulated size in bytes. Always 0 for non-packet hooks.
  */
 struct bf_counter
 {
-    uint64_t packets;
-    uint64_t bytes;
+    uint64_t count;
+    uint64_t size;
 };
 
 #define _free_bf_counter_ __attribute__((__cleanup__(bf_counter_free)))
@@ -35,12 +36,11 @@ struct bf_counter
  * owned by the caller.
  *
  * @param counter Output pointer for the new @ref bf_counter. Can't be NULL.
- * @param packets Initial packet count.
- * @param bytes   Initial byte count.
+ * @param count Initial event count.
+ * @param size  Initial accumulated size.
  * @return 0 on success, negative errno on error.
  */
-int bf_counter_new(struct bf_counter **counter, uint64_t packets,
-                   uint64_t bytes);
+int bf_counter_new(struct bf_counter **counter, uint64_t count, uint64_t size);
 
 /**
  * @brief Allocate and initialize a new counter from serialized data.

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -225,7 +225,7 @@ bool bft_list_eq(const bf_list *lhs, const bf_list *rhs, bft_list_eq_cb cb)
 
 bool bft_counter_eq(const struct bf_counter *lhs, const struct bf_counter *rhs)
 {
-    return lhs->packets == rhs->packets && lhs->bytes == rhs->bytes;
+    return lhs->count == rhs->count && lhs->size == rhs->size;
 }
 
 bool bft_set_eq(const struct bf_set *lhs, const struct bf_set *rhs)

--- a/tests/unit/libbpfilter/counter.c
+++ b/tests/unit/libbpfilter/counter.c
@@ -11,8 +11,8 @@
 #include "fake.h"
 #include "test.h"
 
-#define BFT_COUNTER_PKTS 4
-#define BFT_COUNTER_BYTES 3190
+#define BFT_COUNTER_COUNT 4
+#define BFT_COUNTER_SIZE 3190
 
 static void new_and_free(void **state)
 {
@@ -21,16 +21,16 @@ static void new_and_free(void **state)
     (void)state;
 
     // Free counters manually
-    assert_ok(bf_counter_new(&counter, BFT_COUNTER_PKTS, BFT_COUNTER_BYTES));
-    assert_int_equal(counter->packets, BFT_COUNTER_PKTS);
-    assert_int_equal(counter->bytes, BFT_COUNTER_BYTES);
+    assert_ok(bf_counter_new(&counter, BFT_COUNTER_COUNT, BFT_COUNTER_SIZE));
+    assert_int_equal(counter->count, BFT_COUNTER_COUNT);
+    assert_int_equal(counter->size, BFT_COUNTER_SIZE);
     bf_counter_free(&counter);
     assert_null(counter);
 
     // Free counters using the cleanup attribute
-    assert_ok(bf_counter_new(&counter, BFT_COUNTER_PKTS, BFT_COUNTER_BYTES));
-    assert_int_equal(counter->packets, BFT_COUNTER_PKTS);
-    assert_int_equal(counter->bytes, BFT_COUNTER_BYTES);
+    assert_ok(bf_counter_new(&counter, BFT_COUNTER_COUNT, BFT_COUNTER_SIZE));
+    assert_int_equal(counter->count, BFT_COUNTER_COUNT);
+    assert_int_equal(counter->size, BFT_COUNTER_SIZE);
 }
 
 static void pack_and_unpack(void **state)
@@ -46,7 +46,7 @@ static void pack_and_unpack(void **state)
     (void)state;
 
     // Pack the source counter
-    assert_ok(bf_counter_new(&source, BFT_COUNTER_PKTS, BFT_COUNTER_BYTES));
+    assert_ok(bf_counter_new(&source, BFT_COUNTER_COUNT, BFT_COUNTER_SIZE));
     assert_ok(bf_wpack_new(&wpack));
     bf_wpack_open_object(wpack, "counter");
     assert_ok(bf_counter_pack(source, wpack));
@@ -66,7 +66,7 @@ static void unpack_error(void **state)
     (void)state;
 
     {
-        // Missing `packets` field
+        // Missing `size` field
 
         _free_bf_counter_ struct bf_counter *destination = NULL;
         _free_bf_wpack_ bf_wpack_t *wpack = NULL;
@@ -75,7 +75,7 @@ static void unpack_error(void **state)
         size_t data_len;
 
         assert_ok(bf_wpack_new(&wpack));
-        bf_wpack_kv_u64(wpack, "packets", BFT_COUNTER_PKTS);
+        bf_wpack_kv_u64(wpack, "count", BFT_COUNTER_COUNT);
         assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
 
         assert_ok(bf_rpack_new(&rpack, data, data_len));
@@ -84,7 +84,7 @@ static void unpack_error(void **state)
     }
 
     {
-        // Missing `bytes` field
+        // Missing `count` field
 
         _free_bf_counter_ struct bf_counter *destination = NULL;
         _free_bf_wpack_ bf_wpack_t *wpack = NULL;
@@ -93,7 +93,7 @@ static void unpack_error(void **state)
         size_t data_len;
 
         assert_ok(bf_wpack_new(&wpack));
-        bf_wpack_kv_u64(wpack, "bytes", BFT_COUNTER_BYTES);
+        bf_wpack_kv_u64(wpack, "size", BFT_COUNTER_SIZE);
         assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
 
         assert_ok(bf_rpack_new(&rpack, data, data_len));


### PR DESCRIPTION
Non-functional change. This renaming enables a wider number of flavors, such as `BPF_PROG_TYPE_CGROUP_SOCK_ADDR` (#355), which doesn't operate on packets.

Note:
- This will break serialized state (with the recent refactoring #426, and upcoming changes #382, now is probably a good time for this)