### PR TITLE
tools: make Claude fetch full comment history

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -40,7 +40,10 @@ jobs:
 
                       You can use multiple subagents to parallelize tasks. Each subagent should be told the PR title and description.
 
-                      Use `gh pr view <PR NUMBER> --comments` and `gh pr diff <PR NUMBER> --patch` to access the PR content.
+                      Use `gh pr diff ${{ github.event.pull_request.number }} --patch` to access the PR content.
+                      Use `gh api --paginate repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments` to list top-level comments.
+                      Use `gh api --paginate repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments` to list inline review comments.
+                      Use `gh api --paginate repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews | jq '.[] | select(.body != "" and .body != null)'` to list top-level review comments.
                       You are in repository without that patch applied. Do not apply it.
 
                       For every issue, rate how significant it is. Make sure you are confident in your diagnosis.
@@ -50,10 +53,10 @@ jobs:
                       Instead in the final top-level comment, include a suggestion how to improve CLAUDE.md.
 
                       Provide detailed feedback as PR comments, using inline comments for specific issues.
-                      Use `gh pr comment ${{ github.event.pull_request.number }} --body "..."` for top-level summary. Keep it short.
+                      Use `gh pr comment ${{ github.event.pull_request.number }} --body "..."` for top-level summary. Keep it very short.
                       Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
                       Prefix all your GitHub comments with "Claude: ".
-                      Use `gh pr view <PR NUMBER> --comments` output to make sure you don't comment about the same issue twice.
+                      Use the API comment endpoints above to make sure you don't comment about the same issue twice (check both top-level and inline).
 
                       When linking to code in inline comments, follow the following format precisely, otherwise the Markdown preview
                       won't render correctly: https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.sha }}/README.md#L10-L15


### PR DESCRIPTION
Turns out `gh pr view --comment` doesn't fetch all comments, only the top-level ones. See https://github.com/cli/cli/issues/5788. Let's use API directly, which can give us everything.

Demo: https://github.com/pzmarzly/demo--claude-bot-reviews/pull/8#issuecomment-3952571766
Logs: https://github.com/pzmarzly/demo--claude-bot-reviews/actions/runs/22356103456?pr=8