### PR TITLE
tools: claude: remove restriction for draft PRs

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -28,7 +28,6 @@ jobs:
               uses: actions/checkout@v6
 
             - uses: anthropics/claude-code-action@v1
-              if: github.event.pull_request.draft == false
               env:
                   ANTHROPIC_BASE_URL: https://openrouter.ai/api
               with:


### PR DESCRIPTION
I took this `github.event.pull_request.draft` check from the AI review workflow we were using before (`/code-review:code-review`).

But it may be useful to iterate on your PR with the help of Claude review bot, while keeping it hidden from review queue at the same time. AI review can easily add a few iteration loops when making a PR.

Let's remove this one line.