### PR TITLE
tools: claude: switch to OpenRouter API

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -24,10 +24,12 @@ jobs:
 
             - uses: anthropics/claude-code-action@v1
               if: github.event.pull_request.draft == false
+              env:
+                  ANTHROPIC_BASE_URL: https://openrouter.ai/api
               with:
-                  # Anthropic auth
-                  # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-                  claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+                  # Anthropic/OpenRouter auth
+                  anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                  # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
 
                   # Prompt


### PR DESCRIPTION
Following https://openrouter.ai/docs/guides/guides/claude-code-integration#github-action guide.

Before, I had it attached to my Claude subscription. It was unreliable (what if I quit?), annoying (it ate most of my weekly usage limits), and unclear ToS-wise.

Tested in https://github.com/pzmarzly/demo--claude-bot-reviews repo.