### PR TITLE
lib: helper: fix closep to guard fd < 0 instead of fd == -1

### DIFF
--- a/src/libbpfilter/helper.c
+++ b/src/libbpfilter/helper.c
@@ -22,7 +22,7 @@
 
 void closep(int *fd)
 {
-    if (*fd == -1)
+    if (*fd < 0)
         return;
 
     if (close(*fd))

--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -255,14 +255,16 @@ static inline void freep(void *ptr)
 }
 
 /**
- * Close a file descriptor and set it to -1.
+ * @brief Close a file descriptor and set it to -1.
  *
  * `bpfilter` uses `-1` as neutral value for file descriptor, meaning it
  * doesn't represent an open file yet. Once closed, a file descriptor should
  * be reset to `-1`.
  *
- * `closep` is used to close a file descriptor. If the file descriptor is
- * `-1`, then nothing it done. Otherwise, it is closed and reset to `-1`.
+ * `closep` is used to close a file descriptor. File descriptors with negative
+ * values are ignored (-1 is used for "unset", but will also ignore file
+ * descriptors containing negative errno values). Once closed, `*fd` is set
+ * to `-1`.
  *
  * If the call to `close` fails, a warning is printed, and the file descriptor
  * is assumed to be already closed.


### PR DESCRIPTION
closep() used fd == -1 as the no-op sentinel, but error paths can leave _cleanup_close_ variables at other negative values (e.g. -111 for ECONNREFUSED). This caused spurious EBADF warnings on every daemon-not-running code path. Checking fd < 0 catches all invalid descriptors.