### PR TITLE
cli: chain: use chain->name in update error messages instead of opts->name

### DIFF
--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -240,10 +240,10 @@ int bfc_chain_update(const struct bfc_opts *opts)
     if (!opts->dry_run) {
         r = bf_chain_update(chain);
         if (r == -ENOENT)
-            return bf_err_r(r, "chain '%s' not found", opts->name);
+            return bf_err_r(r, "chain '%s' not found", chain->name);
         if (r == -ENOLINK)
             return bf_err_r(r, "chain '%s' is not attached to a hook",
-                            opts->name);
+                            chain->name);
         if (r)
             return bf_err_r(r, "unknown error");
     } else {


### PR DESCRIPTION
When --name is omitted and --from-str is used, opts->name is NULL. The -ENOENT and -ENOLINK error messages in bfc_chain_update() used opts->name, producing "chain '(null)' not found". Using chain->name (always populated by the parser) shows the correct name.