### PR TITLE
lib: logger: replace -abs() with ternary in log code macro

### DIFF
--- a/src/libbpfilter/include/bpfilter/logger.h
+++ b/src/libbpfilter/include/bpfilter/logger.h
@@ -120,7 +120,7 @@ enum bf_log_level
                           _bf_logger_prefix_fmt_args(level, color),            \
                           ##__VA_ARGS__, bf_strerror(code));                   \
         }                                                                      \
-        -abs(code);                                                            \
+        (code) < 0 ? (code) : -(code);                                         \
     })
 
 #define bf_err_r(code, fmt, ...)                                               \


### PR DESCRIPTION
clang-analyzer can't reason through abs() (a library function call), so it treats -abs(code) as potentially 0. This causes false positive NullDereference warnings at call sites that check the return value of bf_err_r() to determine whether an out-parameter was written.

Replace with an equivalent ternary expression that the analyzer can evaluate statically.