### PR TITLE
build: add packages for `make doc` to nix

### DIFF
--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -1,7 +1,7 @@
 Build from sources
 ==================
 
-This document describes the process to build ``bpfilter`` from sources. While ``bpfilter`` can be built on most systems, a recent (6.6+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon. ``bpfilter`` officially supports Fedora 40+, CentOS Stream 9+, and Ubuntu 24.04+. There is also a nix flake which supports all the make targets except for ``doc``.
+This document describes the process to build ``bpfilter`` from sources. While ``bpfilter`` can be built on most systems, a recent (6.6+) Linux kernel is required with ``libbpf`` 1.2+ to run the ``bpfilter`` daemon. ``bpfilter`` officially supports Fedora 40+, CentOS Stream 9+, and Ubuntu 24.04+. There is also a nix flake which supports all the make targets.
 
 If you want to perform a full build of ``bpfilter`` (including all test tests, code check, benchmarks, and documentation), the following dependencies are required:
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768564909,
-        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
+        "lastModified": 1772433332,
+        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
+        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -79,18 +79,13 @@
               lcov
 
               # Documentation
-              # TODO: this (`make doc`) is still broken but should be fixed when linuxdoc is added to nixpkgs
               doxygen
               python3
               python3Packages.sphinx
-              # python3Packages.breathe
-              # python3Packages.furo
-              # python3Packages.linuxdoc
-              # python3Packages.gitpython
-              # python3Packages.scapy
-              # python3Packages.python-dateutil
-              # python3Packages.setuptools
-              # glibcLocales
+              python3Packages.breathe
+              python3Packages.furo
+              python3Packages.linuxdoc
+              python3Packages.setuptools
             ];
 
             shellHook = ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/486778 was merged 🎉

Updated `flake.lock` with `nix flake update`, so the missing package `python3Packages.linuxdoc` is available

I noticed that I was able to build (and read documentation) without needing all required packages
Are they really required ? (do we NEED `glibcLocales` in PATH ? `shellHook` seems enough to build)