### PR TITLE
tests: e2e: add syscall wrappers in setuserns

### DIFF
--- a/tests/e2e/setuserns.c
+++ b/tests/e2e/setuserns.c
@@ -3,22 +3,56 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include <features.h>
+
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 36)
+#include <sys/mount.h>
+#else
 #include <linux/mount.h>
 
-#include <argp.h>
 #include <asm/unistd.h>
+#endif
+
+#include <argp.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
 
 #include "bpfilter/helper.h"
 #include "bpfilter/logger.h"
+
+/* glibc < 2.36 doesn't provide fsopen/fsconfig/fsmount/move_mount wrappers,
+ * use raw syscall() instead. */
+#if !defined(__GLIBC_PREREQ) || !__GLIBC_PREREQ(2, 36)
+static inline int fsopen(const char *fsname, unsigned int flags)
+{
+    return (int)syscall(__NR_fsopen, fsname, flags);
+}
+
+static inline int fsconfig(int fd, unsigned int cmd, const char *key,
+                           const char *value, int aux)
+{
+    return (int)syscall(__NR_fsconfig, fd, cmd, key, value, aux);
+}
+
+static inline int fsmount(int fd, unsigned int flags, unsigned int attr_flags)
+{
+    return (int)syscall(__NR_fsmount, fd, flags, attr_flags);
+}
+
+static inline int move_mount(int from_dirfd, const char *from_pathname,
+                             int to_dirfd, const char *to_pathname,
+                             unsigned int flags)
+{
+    return (int)syscall(__NR_move_mount, from_dirfd, from_pathname, to_dirfd,
+                        to_pathname, flags);
+}
+#endif
 
 #define CMD_LEN 64
 static char cmd[CMD_LEN];


### PR DESCRIPTION
Currently, the [docs](https://bpfilter.io/developers/build.html#build-from-sources) say "`bpfilter` officially supports Fedora 40+, CentOS Stream 9+, and Ubuntu 24.04+". However, Centos Stream 9 ships with [glibc version 2.34](https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/), which does not support several of the syscall wrappers used in `setuserns.c` (ex. [`fsopen` requires 2.36](https://man7.org/linux//man-pages/man2/fsopen.2.html)). This leads to the following build failure when running `make -C build e2e` on machines with glibc version <2.36:

```
[ 39%] Building C object tests/e2e/CMakeFiles/setuserns.dir/setuserns.c.o
In file included from /home/ystein/projects/bpfilter/tests/e2e/setuserns.c:6:
/usr/include/sys/mount.h:35:3: error: expected identifier before numeric constant
   35 |   MS_RDONLY = 1,                /* Mount read-only.  */
      |   ^~~~~~~~~
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c: In function ‘do_in’:
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c:192:16: warning: implicit declaration of function ‘fsopen’; did you mean ‘fdopen’? [-Wimplicit-function-declaration]
  192 |     bpffs_fd = fsopen("bpf", 0);
      |                ^~~~~~
      |                fdopen
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c:204:9: warning: implicit declaration of function ‘move_mount’ [-Wimplicit-function-declaration]
  204 |     r = move_mount(mount_fd, "", AT_FDCWD, opts->bpffs_mount_path,
      |         ^~~~~~~~~~
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c: In function ‘do_out’:
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c:251:9: warning: implicit declaration of function ‘fsconfig’; did you mean ‘fscanf’? [-Wimplicit-function-declaration]
  251 |     r = fsconfig(bpffs_fd, FSCONFIG_SET_STRING, "delegate_cmds", "any", 0);
      |         ^~~~~~~~
      |         fscanf
/home/ystein/projects/bpfilter/tests/e2e/setuserns.c:271:14: warning: implicit declaration of function ‘fsmount’; did you mean ‘umount’? [-Wimplicit-function-declaration]
  271 |     mnt_fd = fsmount(bpffs_fd, 0, 0);
      |              ^~~~~~~
      |              umount
```

To fix this, we'll create our own wrappers that call `syscall()` directly. There is also a header conflict, so we can remove `sys/mount.h` to fix that.

(My current workflow has been to store this as a patch and use `git apply` whenever I want to run `make -C build e2e`, so this should make that much simpler. Open to other ideas though if anyone has.)

Note:
- Whenever we enforce Centos Stream 10+, we can remove these and use the glibc wrappers.