### PR TITLE
tests: e2e: reduce background traffic noise in chain_update_set

### DIFF
--- a/tests/e2e/cli/chain_update_set.sh
+++ b/tests/e2e/cli/chain_update_set.sh
@@ -209,6 +209,7 @@ ${FROM_NS} bfcli chain set --from-str "chain test_xdp BF_HOOK_XDP{ifindex=${NS_I
         10.0.0.1
     }
     rule
+        ip4.proto icmp
         (ip4.saddr) in blocked_ips
         counter
         DROP


### PR DESCRIPTION
chain_update_set.sh uses pings and rule counters to validate sets are updated as expected. Because the matcher is wide, we sometime fails the test due to background traffic on the NIC. Limit the rule to the existing matchers + `ip4.proto icmp` to catch on ping traffic.