### PR TITLE
daemon: cgen: use float for meta.probability matcher

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -539,7 +539,7 @@ Meta
       - ``meta.probability``
       - ``eq``
       - ``$PROBABILITY``
-      - ``$PROBABILITY`` is a valid decimal percentage value (i.e., within [0%, 100%]).
+      - ``$PROBABILITY`` is a floating-point percentage value (i.e., within [0%, 100%], e.g., "50%" or "33.33%").
     * - :rspan:`1` Mark
       - :rspan:`1` ``meta.mark``
       - ``eq``

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -32,7 +32,6 @@
 %s STATE_MATCHER_META_FLOW_HASH
 %s STATE_MATCHER_L4_PROTO
 %s STATE_MATCHER_META_PROBA
-%s STATE_MATCHER_META_FLOW_PROBA
 %s STATE_MATCHER_IPV4_ADDR
 %s STATE_MATCHER_IP4_NET
 %s STATE_MATCHER_IP4_DSCP
@@ -155,17 +154,8 @@ ip6\.nexthdr    { BEGIN(STATE_MATCHER_L4_PROTO); yylval.sval = strdup(yytext); r
 }
 
 meta\.probability  { BEGIN(STATE_MATCHER_META_PROBA); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
+meta\.flow_probability { BEGIN(STATE_MATCHER_META_PROBA); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_META_PROBA>{
-    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
-    {int}% {
-        BEGIN(INITIAL);
-        yylval.sval = strdup(yytext);
-        return RAW_PAYLOAD;
-    }
-}
-
-meta\.flow_probability { BEGIN(STATE_MATCHER_META_FLOW_PROBA); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
-<STATE_MATCHER_META_FLOW_PROBA>{
     (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {float}% {
         BEGIN(INITIAL);

--- a/src/bpfilter/cgen/matcher/meta.c
+++ b/src/bpfilter/cgen/matcher/meta.c
@@ -67,13 +67,13 @@ static int
 _bf_matcher_generate_meta_probability(struct bf_program *program,
                                       const struct bf_matcher *matcher)
 {
-    uint8_t proba = *(uint8_t *)bf_matcher_payload(matcher);
+    float proba = *(float *)bf_matcher_payload(matcher);
 
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_get_prandom_u32));
     EMIT_FIXUP_JMP_NEXT_RULE(
         program,
         BPF_JMP_IMM(BPF_JGT, BPF_REG_0,
-                    (uint32_t)((uint64_t)UINT32_MAX * (proba / 100.0)), 0));
+                    (uint32_t)((double)UINT32_MAX * (proba / 100.0)), 0));
 
     return 0;
 }

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -377,36 +377,6 @@ static int _bf_parse_probability(enum bf_matcher_type type,
     assert(payload);
     assert(raw_payload);
 
-    unsigned long proba;
-    char *endptr;
-
-    proba = strtoul(raw_payload, &endptr, BF_BASE_10);
-    if (endptr[0] == '%' && endptr[1] == '\0' && proba <= 100) {
-        *(uint8_t *)payload = (uint8_t)proba;
-        return 0;
-    }
-
-    bf_err(
-        "\"%s %s\" expects a valid decimal percentage value (i.e., within [0%%, 100%%]), not '%s'",
-        bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
-
-    return -EINVAL;
-}
-
-void _bf_print_probability(const void *payload)
-{
-    assert(payload);
-
-    (void)fprintf(stdout, "%" PRIu8 "%%", *(uint8_t *)payload);
-}
-
-static int _bf_parse_flow_probability(enum bf_matcher_type type,
-                                      enum bf_matcher_op op, void *payload,
-                                      const char *raw_payload)
-{
-    assert(payload);
-    assert(raw_payload);
-
     double proba;
     char *endptr;
 
@@ -424,7 +394,7 @@ static int _bf_parse_flow_probability(enum bf_matcher_type type,
     return -EINVAL;
 }
 
-static void _bf_print_flow_probability(const void *payload)
+void _bf_print_probability(const void *payload)
 {
     assert(payload);
 
@@ -928,7 +898,7 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .layer = BF_MATCHER_NO_LAYER,
             .ops =
                 {
-                    BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
+                    BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(float),
                                    _bf_parse_probability,
                                    _bf_print_probability),
                 },
@@ -971,8 +941,8 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(float),
-                                   _bf_parse_flow_probability,
-                                   _bf_print_flow_probability),
+                                   _bf_parse_probability,
+                                   _bf_print_probability),
                 },
         },
     [BF_MATCHER_IP4_SADDR] =

--- a/tests/e2e/matchers/meta_probability.sh
+++ b/tests/e2e/matchers/meta_probability.sh
@@ -5,10 +5,16 @@
 bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 0% counter DROP"
 bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 50% counter DROP"
 bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 100% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 33.33% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 0.1% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 99.99% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 50.0% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 0.00% counter DROP"
+bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 100.00% counter DROP"
 
 (! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 0 counter DROP")
 (! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq -10% counter DROP")
 (! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 1000 counter DROP")
 (! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 1000% counter DROP")
-(! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 15.5% counter DROP")
+(! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq 100.01% counter DROP")
 (! bfcli ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule meta.probability eq teapot counter DROP")

--- a/tests/unit/libbpfilter/matcher.c
+++ b/tests/unit/libbpfilter/matcher.c
@@ -554,7 +554,7 @@ static void meta_probability(void **state)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
                                       BF_MATCHER_EQ, "0%"));
     assert_non_null(matcher);
-    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
+    assert_true(*(float *)bf_matcher_payload(matcher) == 0.0f);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
@@ -562,7 +562,7 @@ static void meta_probability(void **state)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
                                       BF_MATCHER_EQ, "50%"));
     assert_non_null(matcher);
-    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 50);
+    assert_true(*(float *)bf_matcher_payload(matcher) == 50.0f);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
@@ -570,7 +570,25 @@ static void meta_probability(void **state)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
                                       BF_MATCHER_EQ, "100%"));
     assert_non_null(matcher);
-    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 100);
+    assert_true(*(float *)bf_matcher_payload(matcher) == 100.0f);
+    bf_matcher_dump(matcher, &prefix);
+    bf_matcher_free(&matcher);
+
+    // Test with floating-point value
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
+                                      BF_MATCHER_EQ, "33.33%"));
+    assert_non_null(matcher);
+    assert_true(*(float *)bf_matcher_payload(matcher) > 33.32f);
+    assert_true(*(float *)bf_matcher_payload(matcher) < 33.34f);
+    bf_matcher_dump(matcher, &prefix);
+    bf_matcher_free(&matcher);
+
+    // Test with small floating-point value
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
+                                      BF_MATCHER_EQ, "0.1%"));
+    assert_non_null(matcher);
+    assert_true(*(float *)bf_matcher_payload(matcher) > 0.09f);
+    assert_true(*(float *)bf_matcher_payload(matcher) < 0.11f);
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -583,6 +601,10 @@ static void meta_probability_invalid(void **state)
     // Test with value over 100%
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
                                        BF_MATCHER_EQ, "101%"));
+
+    // Test with value slightly over 100%
+    assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
+                                       BF_MATCHER_EQ, "100.01%"));
 
     // Test without % sign
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,


### PR DESCRIPTION
Unify meta.probability and meta.flow_probability to share the same floating-point parsing and printing logic, replacing the integer-only code path. This allows meta.probability to accept fractional percentages (e.g., "33.33%") and removes duplicate parser/printer functions.