### PR TITLE
tools: claude: temporarily pin older version of claude-code-action

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -27,7 +27,8 @@ jobs:
             - name: Checkout upstream repository
               uses: actions/checkout@v6
 
-            - uses: anthropics/claude-code-action@v1
+            # TODO(@pzmarzly): Unpin once https://github.com/anthropics/claude-code-action/issues/1013 is fixed.
+            - uses: anthropics/claude-code-action@v1.0.66
               env:
                   ANTHROPIC_BASE_URL: https://openrouter.ai/api
               with:


### PR DESCRIPTION
Latest Claude is broken: https://github.com/anthropics/claude-code-action/issues/1013

I'll monitor that thread and remove the pin once it's fixed.

NOTE: With pull_request_target, workflow definition is taken from target branch, not source, so this PR will have red signal.

Demo: https://github.com/pzmarzly/demo--claude-bot-reviews/actions/runs/22709516659/job/65843898737?pr=8