### PR TITLE
lib: matcher: widen matcher type bitmask assert to 64 bits

### DIFF
--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -113,9 +113,8 @@ enum bf_matcher_type
     _BF_MATCHER_TYPE_MAX,
 };
 
-/// @todo Change `bf_matcher_type` bitmasks to 64 bits.
-static_assert(_BF_MATCHER_TYPE_MAX <= 8 * sizeof(uint32_t),
-              "too many matcher types for uint32_t bitmask");
+static_assert(_BF_MATCHER_TYPE_MAX <= 8 * sizeof(uint64_t),
+              "too many matcher types for uint64_t bitmask");
 
 /**
  * Defines the structure of the payload for bf_matcher's

--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -26,7 +26,7 @@ int bf_set_new(struct bf_set **set, const char *name, enum bf_matcher_type *key,
                size_t n_comps)
 {
     _free_bf_set_ struct bf_set *_set = NULL;
-    uint32_t mask = 0;
+    uint64_t mask = 0;
 
     assert(set);
     assert(key);


### PR DESCRIPTION
With 30 matcher types defined, the uint32_t bitmask guard only has 2 slots remaining. Widen the static_assert to uint64_t to allow the enum to grow beyond 32 values. BF_FLAG() already uses 1ULL, so no other changes are needed.

Closes: https://github.com/facebook/bpfilter/issues/443