### PR TITLE
tests: fuzzing improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,7 @@ jobs:
         run: ctest --test-dir $GITHUB_WORKSPACE/build -L e2e --verbose
 
       - name: Run fuzzing tests
-        run: ctest --test-dir $GITHUB_WORKSPACE/build -L fuzzing --verbose
+        run: ctest --test-dir $GITHUB_WORKSPACE/build -R '^fuzzing\.parser\.60$' --verbose
       - name: Upload fuzzer findings
         uses: actions/upload-artifact@v4
         if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ if (NOT ${NO_DOCS})
 endif ()
 
 if (NOT ${NO_TESTS})
-    set(CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+    set(CMAKE_CTEST_ARGUMENTS "--output-on-failure;--label-exclude;fuzzing")
     enable_testing()
     add_subdirectory(tests)
 endif ()

--- a/doc/developers/build.rst
+++ b/doc/developers/build.rst
@@ -103,7 +103,8 @@ A full configuration (without any part disabled) will provide the following targ
 
 - ``core``, ``bpfilter``, ``libbpfilter``, ``bfcli``: the ``bpfilter`` binaries.
 - ``test_bin``: build the binaries needed to run the tests (below).
-- ``test``: run all the tests. This command will run ``unit``, ``check``, ``e2e``, ``fuzzing``, and ``integration`` targets. See :doc:`tests` for more information.
+- ``test``: run all the tests. This command will run ``unit``, ``check``, ``e2e``, and ``integration`` targets. See :doc:`tests` for more information.
+- ``fuzzing``: fuzz the CLI parser indefinitely. Use ``fuzzing_quick`` for a quick, 60-second fuzzing session.
 - ``check``: run ``clang-tidy`` and ``clang-format`` against the source files.
 - ``benchmarks``: run the benchmarks on ``bpfilter``.
 

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB_RECURSE libbpfilter_fuzz_srcs
     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.h     ${CMAKE_SOURCE_DIR}/src/libbpfilter/*.c
 )
 
-add_executable(fuzz_parser
+add_executable(fuzz_parser EXCLUDE_FROM_ALL
     ${CMAKE_CURRENT_SOURCE_DIR}/fuzz_parser.c
     ${CMAKE_SOURCE_DIR}/src/bfcli/helper.c
     ${CMAKE_SOURCE_DIR}/src/bfcli/ruleset.c
@@ -57,7 +57,7 @@ add_dependencies(fuzz_parser bfcli_parser bfcli_lexer)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/corpus)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/findings)
 
-add_test(NAME "fuzzing.parser"
+add_test(NAME "fuzzing.parser.60"
     COMMAND $<TARGET_FILE:fuzz_parser>
         -artifact_prefix=${CMAKE_CURRENT_BINARY_DIR}/findings/
         -max_total_time=60
@@ -70,13 +70,36 @@ add_test(NAME "fuzzing.parser"
         ${CMAKE_CURRENT_SOURCE_DIR}/corpus
 )
 
-set_tests_properties("fuzzing.parser" PROPERTIES
+set_tests_properties("fuzzing.parser.60" PROPERTIES
+    LABELS "fuzzing"
+    ENVIRONMENT "ROOT_DIR=${CMAKE_SOURCE_DIR};BUILD_DIR=${CMAKE_BINARY_DIR};GEN_INC_DIR=${lib_gen_inc_dir}/include"
+)
+
+add_custom_target(fuzzing_quick
+    COMMAND ${CMAKE_CTEST_COMMAND} --verbose -R "^fuzzing\\.parser\\.60$$"
+    DEPENDS fuzz_parser
+    COMMENT "Running fuzzing tests (60s)"
+)
+
+add_test(NAME "fuzzing.parser.infinite"
+    COMMAND $<TARGET_FILE:fuzz_parser>
+        -artifact_prefix=${CMAKE_CURRENT_BINARY_DIR}/findings/
+        -print_final_stats=1
+        -only_ascii=1
+        -close_fd_mask=3
+        -dict=${CMAKE_CURRENT_SOURCE_DIR}/keywords.dict
+        -max_len=16384
+        ${CMAKE_CURRENT_BINARY_DIR}/corpus
+        ${CMAKE_CURRENT_SOURCE_DIR}/corpus
+)
+
+set_tests_properties("fuzzing.parser.infinite" PROPERTIES
     LABELS "fuzzing"
     ENVIRONMENT "ROOT_DIR=${CMAKE_SOURCE_DIR};BUILD_DIR=${CMAKE_BINARY_DIR};GEN_INC_DIR=${lib_gen_inc_dir}/include"
 )
 
 add_custom_target(fuzzing
-    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -L fuzzing
+    COMMAND ${CMAKE_CTEST_COMMAND} --verbose -R "^fuzzing\\.parser\\.infinite$$"
     DEPENDS fuzz_parser
-    COMMENT "Running fuzzing tests"
+    COMMENT "Running fuzzing tests (indefinitely)"
 )


### PR DESCRIPTION
Multiple improvements to the fuzzing logic:
- Remove the fuzzing binary from the `make all` target
- Rename `fuzzing` to `fuzzing_quick` for 60 seconds fuzzing
- Add `fuzzing` target to fuzz the parser indefinitely