### PR TITLE
lib: chain: disable rules with incompatible same-layer matchers

### DIFF
--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -6,6 +6,7 @@
 #include "bpfilter/chain.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -14,6 +15,7 @@
 #include "bpfilter/hook.h"
 #include "bpfilter/list.h"
 #include "bpfilter/logger.h"
+#include "bpfilter/matcher.h"
 #include "bpfilter/pack.h"
 #include "bpfilter/rule.h"
 #include "bpfilter/set.h"
@@ -58,6 +60,59 @@ static int _bf_rule_references_empty_set(const struct bf_chain *chain,
     return 0;
 }
 
+/**
+ * @brief Check if a rule has matchers on the same layer but different
+ * protocols.
+ *
+ * A rule matching on e.g. both IPv4 source address and IPv6 destination
+ * address can never match a packet (a packet is either IPv4 or IPv6, not
+ * both). Same for layer 4 (e.g. TCP vs UDP). Such rules should be disabled.
+ *
+ * @param rule Rule to check.
+ * @return 0 if no conflict, 1 if the rule contains incompatible matchers, or
+ *         a negative errno value on failure.
+ */
+static int _bf_rule_has_incompatible_matchers(const struct bf_rule *rule)
+{
+    uint32_t layer_hdr_id[_BF_MATCHER_LAYER_MAX];
+
+    assert(rule);
+
+    for (int i = 0; i < _BF_MATCHER_LAYER_MAX; ++i)
+        layer_hdr_id[i] = UINT32_MAX;
+
+    bf_list_foreach (&rule->matchers, matcher_node) {
+        struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
+        const struct bf_matcher_meta *meta;
+
+        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET)
+            continue;
+
+        meta = bf_matcher_get_meta(bf_matcher_get_type(matcher));
+        if (!meta) {
+            return bf_err_r(
+                -ENOENT, "missing bf_matcher_meta for %s",
+                bf_matcher_type_to_str(bf_matcher_get_type(matcher)));
+        }
+        if (meta->layer <= BF_MATCHER_NO_LAYER)
+            continue;
+
+        if (layer_hdr_id[meta->layer] == UINT32_MAX) {
+            layer_hdr_id[meta->layer] = meta->hdr_id;
+            continue;
+        }
+
+        if (layer_hdr_id[meta->layer] != meta->hdr_id) {
+            bf_warn(
+                "rule %u has incompatible matchers on the same layer, rule will be disabled",
+                rule->index);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
 int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
 {
     int r;
@@ -67,8 +122,15 @@ int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
     r = _bf_rule_references_empty_set(chain, rule);
     if (r < 0)
         return r;
-
     rule->disabled = r;
+
+    if (!rule->disabled) {
+        r = _bf_rule_has_incompatible_matchers(rule);
+        if (r < 0)
+            return r;
+
+        rule->disabled = r;
+    }
 
     if (rule->log && !rule->disabled)
         chain->flags |= BF_FLAG(BF_CHAIN_LOG);

--- a/tests/unit/libbpfilter/chain.c
+++ b/tests/unit/libbpfilter/chain.c
@@ -141,6 +141,93 @@ static void mixed_enabled_disabled_log_flag(void **state)
     assert_int_equal(chain->flags & BF_FLAG(BF_CHAIN_LOG), 0);
 }
 
+static void incompatible_matchers_disable_rule(void **state)
+{
+    (void)state;
+
+    // L3 conflict: IPv4 + IPv6 matchers.
+    {
+        _free_bf_chain_ struct bf_chain *chain = NULL;
+        _clean_bf_list_ bf_list rules =
+            bf_list_default(bf_rule_free, bf_rule_pack);
+        struct bf_rule *rule = NULL;
+        uint32_t ip4_addr = 0;
+        uint8_t ip6_addr[16] = {};
+
+        assert_ok(bf_rule_new(&rule));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
+                                      &ip4_addr, sizeof(ip4_addr)));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
+                                      ip6_addr, sizeof(ip6_addr)));
+        assert_ok(bf_list_add_tail(&rules, rule));
+
+        assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
+                               BF_VERDICT_ACCEPT, NULL, &rules));
+        assert_true(rule->disabled);
+    }
+
+    // L4 conflict: TCP + UDP matchers.
+    {
+        _free_bf_chain_ struct bf_chain *chain = NULL;
+        _clean_bf_list_ bf_list rules =
+            bf_list_default(bf_rule_free, bf_rule_pack);
+        struct bf_rule *rule = NULL;
+        uint16_t port = 0;
+
+        assert_ok(bf_rule_new(&rule));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
+                                      &port, sizeof(port)));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ,
+                                      &port, sizeof(port)));
+        assert_ok(bf_list_add_tail(&rules, rule));
+
+        assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
+                               BF_VERDICT_ACCEPT, NULL, &rules));
+        assert_true(rule->disabled);
+    }
+
+    // No conflict: same protocol at same layer (TCP sport + TCP dport).
+    {
+        _free_bf_chain_ struct bf_chain *chain = NULL;
+        _clean_bf_list_ bf_list rules =
+            bf_list_default(bf_rule_free, bf_rule_pack);
+        struct bf_rule *rule = NULL;
+        uint16_t port = 0;
+
+        assert_ok(bf_rule_new(&rule));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
+                                      &port, sizeof(port)));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
+                                      &port, sizeof(port)));
+        assert_ok(bf_list_add_tail(&rules, rule));
+
+        assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
+                               BF_VERDICT_ACCEPT, NULL, &rules));
+        assert_false(rule->disabled);
+    }
+
+    // No conflict: different layers (IPv4 + TCP).
+    {
+        _free_bf_chain_ struct bf_chain *chain = NULL;
+        _clean_bf_list_ bf_list rules =
+            bf_list_default(bf_rule_free, bf_rule_pack);
+        struct bf_rule *rule = NULL;
+        uint32_t ip4_addr = 0;
+        uint16_t port = 0;
+
+        assert_ok(bf_rule_new(&rule));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
+                                      &ip4_addr, sizeof(ip4_addr)));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
+                                      &port, sizeof(port)));
+        assert_ok(bf_list_add_tail(&rules, rule));
+
+        assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
+                               BF_VERDICT_ACCEPT, NULL, &rules));
+        assert_false(rule->disabled);
+    }
+}
+
 static void get_set_by_name(void **state)
 {
     _free_bf_chain_ struct bf_chain *chain = bft_chain_dummy(true);
@@ -159,6 +246,7 @@ int main(void)
         cmocka_unit_test(dump),
         cmocka_unit_test(get_set_from_matcher),
         cmocka_unit_test(mixed_enabled_disabled_log_flag),
+        cmocka_unit_test(incompatible_matchers_disable_rule),
         cmocka_unit_test(get_set_by_name),
     };
 


### PR DESCRIPTION
A rule combining matchers on the same network layer but targeting different protocols (e.g. ip4.saddr + ip6.daddr, or tcp.sport + udp.dport) can never match a packet. Detect these during chain validation and disable the rule instead of generating dead BPF code.