### PR TITLE
Add NEXT verdict for BPF program chaining

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -362,7 +362,13 @@ With:
 
       ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks operate on socket metadata rather than packet data. Supported matchers: ``meta.l3_proto``, ``meta.l4_proto``, ``meta.probability``, ``meta.dport``, ``ip4.daddr``, ``ip4.dnet``, ``ip4.proto``, ``ip6.daddr``, ``ip6.dnet``, ``udp.dport``. Connect hooks additionally support ``tcp.dport``. Sendmsg hooks additionally support ``ip4.saddr``, ``ip4.snet``, ``ip6.saddr``, and ``ip6.snet``.
 
-  - ``$POLICY``: action taken if no rule matches the packet, either ``ACCEPT`` forward the packet to the kernel, or ``DROP`` to discard it. Note while ``CONTINUE`` is a valid verdict for rules, it is not supported for chain policy.
+  - ``$POLICY``: action taken if no rule matches the packet:
+
+    - ``ACCEPT``: forward the packet to the kernel.
+    - ``DROP``: discard the packet.
+    - ``NEXT``: pass the packet to the next BPF program. For TC hooks, this maps to ``TCX_NEXT``, deferring the decision to the next program in the TCX link. For NF, XDP, and cgroup_skb hooks, ``NEXT`` behaves identically to ``ACCEPT`` since these hooks do not distinguish between "accept" and "pass to next program."
+
+    Note: ``CONTINUE`` and ``REDIRECT`` are not valid chain policies.
 
 ``$OPTIONS`` are hook-specific comma separated key value pairs. A given hook option can only be specified once:
 
@@ -413,13 +419,14 @@ With:
   - ``log``: optional. If set, log the requested protocol headers. ``link`` will log the link (layer 2) header, ``internet`` with log the internet (layer 3) header, and ``transport`` will log the transport (layer 4) header. At least one header type is required. ``log`` is **not** supported by ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks.
   - ``counter``: optional literal. If set, the filter will count the number of events matched by the rule. For packet-based hooks, this includes both the number of packets and the total bytes. For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, this counts the number of socket operations (``connect()`` or ``sendmsg()`` calls).
   - ``mark``: optional, ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. If set, write the packet's marker value. This marker can be used later on in a rule (see ``meta.mark``) or with a TC filter.
-  - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP``, ``CONTINUE``, or ``REDIRECT``.
+  - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP``, ``CONTINUE``, ``NEXT``, or ``REDIRECT``.
     - ``ACCEPT``: forward the packet to the kernel.
     - ``DROP``: discard the packet.
-    - ``CONTINUE``: continue processing subsequent rules.
+    - ``CONTINUE``: continue processing subsequent rules (non-terminal).
+    - ``NEXT``: stop rule processing and pass the packet to the next BPF program. For TC hooks, this returns ``TCX_NEXT``. For NF, XDP, and cgroup_skb hooks, this is equivalent to ``ACCEPT``.
     - ``REDIRECT $IFACE $DIR``: redirect the packet to interface ``$IFACE`` in direction ``$DIR``. ``$IFACE`` can be an interface name (e.g., "eth0") or an interface index (e.g., "2"). ``$DIR`` is either ``in`` for ingress or ``out`` for egress.
 
-In a chain, as soon as a rule matches a packet, its verdict is applied. If the verdict is ``ACCEPT``, ``DROP``, or ``REDIRECT``, the subsequent rules are not processed. Hence, the rules' order matters. If no rule matches the packet, the chain's policy is applied.
+In a chain, as soon as a rule matches a packet, its verdict is applied. If the verdict is ``ACCEPT``, ``DROP``, ``NEXT``, or ``REDIRECT``, the subsequent rules are not processed. Hence, the rules' order matters. If no rule matches the packet, the chain's policy is applied.
 
 Note ``CONTINUE`` means a packet can be counted more than once if multiple rules specify ``CONTINUE`` and ``counter``.
 
@@ -430,6 +437,10 @@ Note ``CONTINUE`` means a packet can be counted more than once if multiple rules
       - ``BF_HOOK_TC_INGRESS``, ``BF_HOOK_TC_EGRESS``: both ``in`` and ``out`` directions are supported.
 
     ``REDIRECT`` is **not** supported by Netfilter (``BF_HOOK_NF_*``), cgroup_skb (``BF_HOOK_CGROUP_SKB_*``), or cgroup_sock_addr (``BF_HOOK_CGROUP_SOCK_ADDR_*``) hooks.
+
+.. note::
+
+    ``NEXT`` has distinct behavior only for TC hooks (``BF_HOOK_TC_INGRESS``, ``BF_HOOK_TC_EGRESS``), where it maps to ``TCX_NEXT`` and defers to the next BPF program in the TCX link. For all other hooks (Netfilter, XDP, cgroup_skb), ``NEXT`` produces the same return code as ``ACCEPT``.
 
 Sets
 ~~~~

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -68,7 +68,7 @@ BF_HOOK_[A-Z0-9_]+ { BEGIN(STATE_HOOK_OPTS); yylval.sval = strdup(yytext); retur
     }
 }
     /* Verdicts */
-(ACCEPT|DROP|CONTINUE)   { yylval.sval = strdup(yytext); return VERDICT; }
+(ACCEPT|DROP|CONTINUE|NEXT)   { yylval.sval = strdup(yytext); return VERDICT; }
 REDIRECT                 { BEGIN(STATE_REDIRECT_IFACE); return REDIRECT_TOKEN; }
 <STATE_REDIRECT_IFACE>{
     {int}|[0-9a-zA-Z_-]+ {

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -160,8 +160,8 @@ chain           : CHAIN STRING hook hookopts verdict sets rules
                     _free_bf_list_ bf_list *rules = $7;
                     int r;
 
-                    if ($5 >= _BF_TERMINAL_VERDICT_MAX)
-                        bf_parse_err("'%s' is not supported for chains\n", bf_verdict_to_str($5));
+                    if (!bf_verdict_is_valid_policy($5))
+                        bf_parse_err("'%s' is not a valid chain policy\n", bf_verdict_to_str($5));
 
                     if (bf_chain_new(&chain, name, $3, $5, &ruleset->sets, rules) < 0)
                         bf_parse_err("failed to create a new bf_chain\n");

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -18,7 +18,6 @@
 #include <bpfilter/matcher.h>
 #include <bpfilter/verdict.h>
 
-#include "cgen/cgen.h"
 #include "cgen/matcher/cmp.h"
 #include "cgen/matcher/packet.h"
 #include "cgen/program.h"
@@ -141,7 +140,8 @@ static int _bf_cgroup_skb_gen_inline_matcher(struct bf_program *program,
  * Convert a standard verdict into a return value.
  *
  * @param verdict Verdict to convert. Must be valid.
- * @return Cgroup return code corresponding to the verdict, as an integer.
+ * @param ret_code Cgroup return code. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
  */
 static int _bf_cgroup_skb_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
@@ -149,6 +149,7 @@ static int _bf_cgroup_skb_get_verdict(enum bf_verdict verdict, int *ret_code)
 
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
+    case BF_VERDICT_NEXT:
         *ret_code = 1;
         return 0;
     case BF_VERDICT_DROP:

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -143,12 +143,16 @@ static int _bf_cgroup_skb_gen_inline_matcher(struct bf_program *program,
  * @param verdict Verdict to convert. Must be valid.
  * @return Cgroup return code corresponding to the verdict, as an integer.
  */
-static int _bf_cgroup_skb_get_verdict(enum bf_verdict verdict)
+static int _bf_cgroup_skb_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
+    assert(ret_code);
+
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
-        return 1;
+        *ret_code = 1;
+        return 0;
     case BF_VERDICT_DROP:
+        *ret_code = 0;
         return 0;
     default:
         return -ENOTSUP;

--- a/src/libbpfilter/cgen/cgroup_sock_addr.c
+++ b/src/libbpfilter/cgen/cgroup_sock_addr.c
@@ -259,14 +259,21 @@ _bf_cgroup_sock_addr_gen_inline_matcher(struct bf_program *program,
  * @brief Convert a standard verdict into a return value.
  *
  * @param verdict Verdict to convert. Must be valid.
- * @return Cgroup return code corresponding to the verdict, as an integer.
+ * @param ret_code Cgroup return code. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
  */
-static int _bf_cgroup_sock_addr_get_verdict(enum bf_verdict verdict)
+static int _bf_cgroup_sock_addr_get_verdict(enum bf_verdict verdict,
+                                            int *ret_code)
 {
+    assert(ret_code);
+
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
-        return 1;
+    case BF_VERDICT_NEXT:
+        *ret_code = 1;
+        return 0;
     case BF_VERDICT_DROP:
+        *ret_code = 0;
         return 0;
     default:
         return -ENOTSUP;

--- a/src/libbpfilter/cgen/jmp.h
+++ b/src/libbpfilter/cgen/jmp.h
@@ -20,10 +20,14 @@
  *  {
  *      _clean_bf_jmpctx_ struct bf_jmpctx ctx =
  *          bf_jmpctx_get(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_2, 0, 0));
+ *      int ret;
+ *      int r;
  *
- *      EMIT(program,
- *          BPF_MOV64_IMM(BPF_REG_0, program->runtime.ops->get_verdict(
- *              BF_VERDICT_ACCEPT)));
+ *      r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret);
+ *      if (r)
+ *          return r;
+ *
+ *      EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret));
  *      EMIT(program, BPF_EXIT_INSN());
  *  }
  * @endcode

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -159,13 +159,17 @@ static int _bf_nf_gen_inline_matcher(struct bf_program *program,
  * @param verdict Verdict to convert. Must be valid.
  * @return Netfilter return code corresponding to the verdict, as an integer.
  */
-static int _bf_nf_get_verdict(enum bf_verdict verdict)
+static int _bf_nf_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
+    assert(ret_code);
+
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
-        return NF_ACCEPT;
+        *ret_code = NF_ACCEPT;
+        return 0;
     case BF_VERDICT_DROP:
-        return NF_DROP;
+        *ret_code = NF_DROP;
+        return 0;
     default:
         return -ENOTSUP;
     }

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -157,7 +157,8 @@ static int _bf_nf_gen_inline_matcher(struct bf_program *program,
  * Convert a standard verdict into a return value.
  *
  * @param verdict Verdict to convert. Must be valid.
- * @return Netfilter return code corresponding to the verdict, as an integer.
+ * @param ret_code Netfilter return code. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
  */
 static int _bf_nf_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
@@ -165,6 +166,7 @@ static int _bf_nf_get_verdict(enum bf_verdict verdict, int *ret_code)
 
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
+    case BF_VERDICT_NEXT:
         *ret_code = NF_ACCEPT;
         return 0;
     case BF_VERDICT_DROP:

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -293,6 +293,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
                                      struct bf_rule *rule)
 {
     uint32_t checked_layers = 0;
+    int ret_code;
     int r;
 
     assert(program);
@@ -377,10 +378,10 @@ static int _bf_program_generate_rule(struct bf_program *program,
     switch (rule->verdict) {
     case BF_VERDICT_ACCEPT:
     case BF_VERDICT_DROP:
-        r = program->runtime.ops->get_verdict(rule->verdict);
-        if (r < 0)
+        r = program->runtime.ops->get_verdict(rule->verdict, &ret_code);
+        if (r)
             return r;
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
         EMIT(program, BPF_EXIT_INSN());
         break;
     case BF_VERDICT_REDIRECT:
@@ -582,6 +583,7 @@ int bf_program_emit_fixup_elfstub(struct bf_program *program,
 int bf_program_generate(struct bf_program *program)
 {
     const struct bf_chain *chain = program->runtime.chain;
+    int ret_code;
     int r;
 
     // Save the program's argument into the context.
@@ -629,10 +631,10 @@ int bf_program_generate(struct bf_program *program)
          BPF_MOV32_IMM(BPF_REG_3, bf_program_chain_counter_idx(program)));
     EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
-    r = program->runtime.ops->get_verdict(chain->policy);
-    if (r < 0)
+    r = program->runtime.ops->get_verdict(chain->policy, &ret_code);
+    if (r)
         return r;
-    EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
     EMIT(program, BPF_EXIT_INSN());
 
     r = _bf_program_generate_elfstubs(program);

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -378,6 +378,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
     switch (rule->verdict) {
     case BF_VERDICT_ACCEPT:
     case BF_VERDICT_DROP:
+    case BF_VERDICT_NEXT:
         r = program->runtime.ops->get_verdict(rule->verdict, &ret_code);
         if (r)
             return r;

--- a/src/libbpfilter/cgen/stub.c
+++ b/src/libbpfilter/cgen/stub.c
@@ -47,6 +47,7 @@
 static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
                                     const char *kfunc)
 {
+    int ret_code;
     int r;
 
     assert(program);
@@ -76,10 +77,11 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
         if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create a new dynamic pointer");
 
-        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT);
-        if (r < 0)
+        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
+        if (r)
             return r;
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+
+        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
         EMIT(program, BPF_EXIT_INSN());
     }
 
@@ -102,6 +104,7 @@ int bf_stub_make_ctx_skb_dynptr(struct bf_program *program, int skb_reg)
 
 int bf_stub_parse_l2_ethhdr(struct bf_program *program)
 {
+    int ret_code;
     int r;
 
     assert(program);
@@ -135,10 +138,11 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
         if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L2 dynamic pointer slice");
 
-        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT);
-        if (r < 0)
+        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
+        if (r)
             return r;
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+
+        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
         EMIT(program, BPF_EXIT_INSN());
     }
 
@@ -160,6 +164,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
 int bf_stub_parse_l3_hdr(struct bf_program *program)
 {
     _clean_bf_jmpctx_ struct bf_jmpctx _ = bf_jmpctx_default();
+    int ret_code;
     int r;
 
     assert(program);
@@ -210,10 +215,11 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
         if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L3 dynamic pointer slice");
 
-        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT);
-        if (r < 0)
+        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
+        if (r)
             return r;
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+
+        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
         EMIT(program, BPF_EXIT_INSN());
     }
 
@@ -316,6 +322,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
 int bf_stub_parse_l4_hdr(struct bf_program *program)
 {
     _clean_bf_jmpctx_ struct bf_jmpctx _ = bf_jmpctx_default();
+    int ret_code;
     int r;
 
     assert(program);
@@ -369,10 +376,11 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
         if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L4 dynamic pointer slice");
 
-        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT);
-        if (r < 0)
+        r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
+        if (r)
             return r;
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, r));
+
+        EMIT(program, BPF_MOV64_IMM(BPF_REG_0, ret_code));
         EMIT(program, BPF_EXIT_INSN());
     }
 

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -18,7 +18,6 @@
 #include <bpfilter/matcher.h>
 #include <bpfilter/verdict.h>
 
-#include "cgen/cgen.h"
 #include "cgen/matcher/cmp.h"
 #include "cgen/matcher/packet.h"
 #include "cgen/program.h"
@@ -154,7 +153,8 @@ static int _bf_tc_gen_inline_redirect(struct bf_program *program,
  * Convert a standard verdict into a return value.
  *
  * @param verdict Verdict to convert. Must be valid.
- * @return TC return code corresponding to the verdict, as an integer.
+ * @param ret_code TC return code. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
  */
 static int _bf_tc_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
@@ -166,6 +166,9 @@ static int _bf_tc_get_verdict(enum bf_verdict verdict, int *ret_code)
         return 0;
     case BF_VERDICT_DROP:
         *ret_code = TCX_DROP;
+        return 0;
+    case BF_VERDICT_NEXT:
+        *ret_code = TCX_NEXT;
         return 0;
     default:
         return -ENOTSUP;

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -156,13 +156,17 @@ static int _bf_tc_gen_inline_redirect(struct bf_program *program,
  * @param verdict Verdict to convert. Must be valid.
  * @return TC return code corresponding to the verdict, as an integer.
  */
-static int _bf_tc_get_verdict(enum bf_verdict verdict)
+static int _bf_tc_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
+    assert(ret_code);
+
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
-        return TCX_PASS;
+        *ret_code = TCX_PASS;
+        return 0;
     case BF_VERDICT_DROP:
-        return TCX_DROP;
+        *ret_code = TCX_DROP;
+        return 0;
     default:
         return -ENOTSUP;
     }

--- a/src/libbpfilter/cgen/xdp.c
+++ b/src/libbpfilter/cgen/xdp.c
@@ -107,13 +107,17 @@ static int _bf_xdp_gen_inline_redirect(struct bf_program *program,
     return 0;
 }
 
-static int _bf_xdp_get_verdict(enum bf_verdict verdict)
+static int _bf_xdp_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
+    assert(ret_code);
+
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
-        return XDP_PASS;
+        *ret_code = XDP_PASS;
+        return 0;
     case BF_VERDICT_DROP:
-        return XDP_DROP;
+        *ret_code = XDP_DROP;
+        return 0;
     default:
         return -ENOTSUP;
     }

--- a/src/libbpfilter/cgen/xdp.c
+++ b/src/libbpfilter/cgen/xdp.c
@@ -107,12 +107,20 @@ static int _bf_xdp_gen_inline_redirect(struct bf_program *program,
     return 0;
 }
 
+/**
+ * Convert a standard verdict into a return value.
+ *
+ * @param verdict Verdict to convert. Must be valid.
+ * @param ret_code XDP return code. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
 static int _bf_xdp_get_verdict(enum bf_verdict verdict, int *ret_code)
 {
     assert(ret_code);
 
     switch (verdict) {
     case BF_VERDICT_ACCEPT:
+    case BF_VERDICT_NEXT:
         *ret_code = XDP_PASS;
         return 0;
     case BF_VERDICT_DROP:

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -185,8 +185,8 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
     assert(chain && name);
     if (hook >= _BF_HOOK_MAX)
         return bf_err_r(-EINVAL, "unknown hook type");
-    if (policy >= _BF_TERMINAL_VERDICT_MAX)
-        return bf_err_r(-EINVAL, "unknown policy type");
+    if (!bf_verdict_is_valid_policy(policy))
+        return bf_err_r(-EINVAL, "invalid policy '%s'", bf_verdict_to_str(policy));
 
     _chain = malloc(sizeof(*_chain));
     if (!_chain)
@@ -240,7 +240,7 @@ int bf_chain_new_from_pack(struct bf_chain **chain, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_chain.hook");
 
-    r = bf_rpack_kv_enum(node, "policy", &policy, 0, _BF_TERMINAL_VERDICT_MAX);
+    r = bf_rpack_kv_enum(node, "policy", &policy, 0, _BF_VERDICT_MAX);
     if (r)
         return bf_rpack_key_err(r, "bf_chain.policy");
 

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -186,7 +186,8 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
     if (hook >= _BF_HOOK_MAX)
         return bf_err_r(-EINVAL, "unknown hook type");
     if (!bf_verdict_is_valid_policy(policy))
-        return bf_err_r(-EINVAL, "invalid policy '%s'", bf_verdict_to_str(policy));
+        return bf_err_r(-EINVAL, "invalid policy '%s'",
+                        bf_verdict_to_str(policy));
 
     _chain = malloc(sizeof(*_chain));
     if (!_chain)

--- a/src/libbpfilter/include/bpfilter/flavor.h
+++ b/src/libbpfilter/include/bpfilter/flavor.h
@@ -121,10 +121,12 @@ struct bf_flavor_ops
      * stop further packet processing. Non-terminal verdicts do not need return
      * codes and therefore do not need to be handled by get_verdict().
      *
-     * @return Flavor-specific verdict for `verdict`, or a negative errno
-     * value on failure.
+     * @param verdict Verdict to convert. Must be a terminal verdict.
+     * @param ret_code On success, set to the flavor-specific BPF return code.
+     *        Can't be NULL.
+     * @return 0 on success, or negative errno value on failure.
      */
-    int (*get_verdict)(enum bf_verdict verdict);
+    int (*get_verdict)(enum bf_verdict verdict, int *ret_code);
 
     /**
      * @brief Generate bytecode for a matcher. Required for all flavors.

--- a/src/libbpfilter/include/bpfilter/verdict.h
+++ b/src/libbpfilter/include/bpfilter/verdict.h
@@ -44,17 +44,15 @@ int bf_redirect_dir_from_str(const char *str, enum bf_redirect_dir *dir);
  */
 enum bf_verdict
 {
-    /** Terminal verdicts that stop further packet processing. */
-    /** Accept the packet. */
+    /** Accept the packet. Terminal. */
     BF_VERDICT_ACCEPT,
-    /** Drop the packet. */
+    /** Drop the packet. Terminal. */
     BF_VERDICT_DROP,
-    /** Non-terminal verdicts that allow further packet processing. */
-    /** Continue processing the next rule. */
+    /** Continue processing the next rule. Non-terminal. */
     BF_VERDICT_CONTINUE,
-    /** Redirect the packet to another interface. */
+    /** Redirect the packet to another interface. Terminal. */
     BF_VERDICT_REDIRECT,
-    /** Pass the packet to the next BPF program.
+    /** Pass the packet to the next BPF program. Terminal.
      *
      * For TC, this maps to TCX_NEXT which defers to the next program in
      * the TCX link. For NF, XDP, and cgroup_skb, NEXT maps to the same

--- a/src/libbpfilter/include/bpfilter/verdict.h
+++ b/src/libbpfilter/include/bpfilter/verdict.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <stdbool.h>
+
 /**
  * Redirect direction for the REDIRECT verdict.
  */
@@ -36,7 +38,9 @@ int bf_redirect_dir_from_str(const char *str, enum bf_redirect_dir *dir);
 
 /**
  * Verdict to apply for a rule or chain.
- * Chains can only use terminal verdicts, rules can use all verdicts.
+ *
+ * Only some verdicts are valid as chain policies (see
+ * `bf_verdict_is_valid_policy`). Rules can use all verdicts.
  */
 enum bf_verdict
 {
@@ -50,8 +54,14 @@ enum bf_verdict
     BF_VERDICT_CONTINUE,
     /** Redirect the packet to another interface. */
     BF_VERDICT_REDIRECT,
+    /** Pass the packet to the next BPF program.
+     *
+     * For TC, this maps to TCX_NEXT which defers to the next program in
+     * the TCX link. For NF, XDP, and cgroup_skb, NEXT maps to the same
+     * return code as ACCEPT since these hooks do not distinguish between
+     * "accept" and "pass to next program." */
+    BF_VERDICT_NEXT,
     _BF_VERDICT_MAX,
-    _BF_TERMINAL_VERDICT_MAX = BF_VERDICT_REDIRECT,
 };
 
 /**
@@ -70,3 +80,15 @@ const char *bf_verdict_to_str(enum bf_verdict verdict);
  * @return 0 on success, or negative errno value on error.
  */
 int bf_verdict_from_str(const char *str, enum bf_verdict *verdict);
+
+/**
+ * Check if a verdict is valid as a chain policy.
+ *
+ * Only ACCEPT, DROP, and NEXT are valid chain policies. CONTINUE is
+ * non-terminal and cannot be a default action. REDIRECT requires per-rule
+ * parameters (interface, direction) so it cannot be a policy either.
+ *
+ * @param verdict Verdict to check.
+ * @return true if the verdict is valid as a chain policy, false otherwise.
+ */
+bool bf_verdict_is_valid_policy(enum bf_verdict verdict);

--- a/src/libbpfilter/verdict.c
+++ b/src/libbpfilter/verdict.c
@@ -40,10 +40,8 @@ int bf_redirect_dir_from_str(const char *str, enum bf_redirect_dir *dir)
 }
 
 static const char *_bf_verdict_strs[] = {
-    [BF_VERDICT_ACCEPT] = "ACCEPT",
-    [BF_VERDICT_DROP] = "DROP",
-    [BF_VERDICT_REDIRECT] = "REDIRECT",
-    [BF_VERDICT_CONTINUE] = "CONTINUE",
+    [BF_VERDICT_ACCEPT] = "ACCEPT",     [BF_VERDICT_DROP] = "DROP",
+    [BF_VERDICT_REDIRECT] = "REDIRECT", [BF_VERDICT_CONTINUE] = "CONTINUE",
     [BF_VERDICT_NEXT] = "NEXT",
 };
 static_assert_enum_mapping(_bf_verdict_strs, _BF_VERDICT_MAX);

--- a/src/libbpfilter/verdict.c
+++ b/src/libbpfilter/verdict.c
@@ -44,6 +44,7 @@ static const char *_bf_verdict_strs[] = {
     [BF_VERDICT_DROP] = "DROP",
     [BF_VERDICT_REDIRECT] = "REDIRECT",
     [BF_VERDICT_CONTINUE] = "CONTINUE",
+    [BF_VERDICT_NEXT] = "NEXT",
 };
 static_assert_enum_mapping(_bf_verdict_strs, _BF_VERDICT_MAX);
 
@@ -67,4 +68,16 @@ int bf_verdict_from_str(const char *str, enum bf_verdict *verdict)
     }
 
     return -EINVAL;
+}
+
+bool bf_verdict_is_valid_policy(enum bf_verdict verdict)
+{
+    switch (verdict) {
+    case BF_VERDICT_ACCEPT:
+    case BF_VERDICT_DROP:
+    case BF_VERDICT_NEXT:
+        return true;
+    default:
+        return false;
+    }
 }

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -138,6 +138,7 @@ bf_add_e2e_shell_test(e2e rules/icmp_tc.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/icmp_xdp.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/log.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/mark.sh ROOT)
+bf_add_e2e_shell_test(e2e rules/next_tc.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/redirect.sh ROOT)
 
 bf_add_e2e_shell_test(e2e hooks/cgroup_sock_addr_connect4.sh ROOT)
@@ -146,6 +147,8 @@ bf_add_e2e_shell_test(e2e hooks/cgroup_sock_addr_sendmsg4.sh ROOT)
 bf_add_e2e_shell_test(e2e hooks/cgroup_sock_addr_sendmsg6.sh ROOT)
 
 bf_add_e2e_shell_test(e2e rulesets/rulesets.sh ROOT)
+
+bf_add_e2e_c_test(verdicts/next.cpp)
 
 bf_add_e2e_c_test(matchers/icmp_code.cpp)
 bf_add_e2e_c_test(matchers/icmp_type.cpp)

--- a/tests/e2e/rules/next_tc.sh
+++ b/tests/e2e/rules/next_tc.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")"/../e2e_test_util.sh
+
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+}
+
+make_sandbox
+
+# --- NEXT as chain policy (single chain) ---
+# Without a next program in the TCX link, NEXT allows the packet through.
+ping -c 1 -W 0.1 ${NS_IP_ADDR}
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain pol_next BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} NEXT"
+ping -c 1 -W 0.1 ${NS_IP_ADDR}
+${FROM_NS} ${BFCLI} ruleset flush
+
+# --- NEXT is terminal (stops rule evaluation) ---
+# First rule matches ICMP and returns NEXT.
+# Second rule also matches ICMP with a counter and returns DROP.
+# NEXT is terminal: second rule is never evaluated, counter stays 0, ping
+# succeeds (TCX_NEXT with no next program passes the packet).
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain next_term BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter NEXT \
+     rule ip4.proto icmp counter DROP"
+ping -c 1 -W 0.1 ${NS_IP_ADDR}
+test "$(get_counter next_term 0)" = "1"
+test "$(get_counter next_term 1)" = "0"
+${FROM_NS} ${BFCLI} ruleset flush
+
+# --- TC ingress: NEXT defers to the next program ---
+# Two chains on the same TC_INGRESS hook. Chain A returns NEXT for ICMP,
+# deferring to chain B which drops the packet.
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_next_a BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter NEXT"
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_next_b BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter DROP"
+test "$(get_counter ing_next_a 0)" = "0"
+test "$(get_counter ing_next_b 0)" = "0"
+(! ping -c 1 -W 0.1 ${NS_IP_ADDR})
+test "$(get_counter ing_next_a 0)" = "1"
+test "$(get_counter ing_next_b 0)" = "1"
+${FROM_NS} ${BFCLI} ruleset flush
+
+# --- TC ingress: ACCEPT does NOT defer to the next program ---
+# Same setup but chain A uses ACCEPT. TCX_PASS bypasses chain B entirely.
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_accept_a BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter ACCEPT"
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_accept_b BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter DROP"
+test "$(get_counter ing_accept_a 0)" = "0"
+test "$(get_counter ing_accept_b 0)" = "0"
+ping -c 1 -W 0.1 ${NS_IP_ADDR}
+test "$(get_counter ing_accept_a 0)" = "1"
+test "$(get_counter ing_accept_b 0)" = "0"
+${FROM_NS} ${BFCLI} ruleset flush
+
+# --- TC ingress: NEXT policy defers to the next program ---
+# Chain A has NEXT as default policy (no matching rules), deferring all
+# packets to chain B.
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_pol_next BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} NEXT"
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain ing_pol_drop BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter DROP"
+test "$(get_counter ing_pol_drop 0)" = "0"
+(! ping -c 1 -W 0.1 ${NS_IP_ADDR})
+test "$(get_counter ing_pol_drop 0)" = "1"
+${FROM_NS} ${BFCLI} ruleset flush
+
+# --- TC egress: NEXT defers to the next program ---
+# Same multi-chain test on the egress path. The ICMP echo reply is
+# intercepted on its way out of the namespace.
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain egr_next_a BF_HOOK_TC_EGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter NEXT"
+${FROM_NS} ${BFCLI} chain set --from-str \
+    "chain egr_next_b BF_HOOK_TC_EGRESS{ifindex=${NS_IFINDEX}} ACCEPT \
+     rule ip4.proto icmp counter DROP"
+test "$(get_counter egr_next_a 0)" = "0"
+test "$(get_counter egr_next_b 0)" = "0"
+(! ping -c 1 -W 0.1 ${NS_IP_ADDR})
+test "$(get_counter egr_next_a 0)" = "1"
+test "$(get_counter egr_next_b 0)" = "1"
+${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/verdicts/next.cpp
+++ b/tests/e2e/verdicts/next.cpp
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2026 Meta Platforms, Inc. and affiliates.
+ */
+
+#include "Chain.hpp"
+#include "Matcher.hpp"
+#include "Rule.hpp"
+#include "test.hpp"
+
+extern "C" {
+#include <bpfilter/bpfilter.h>
+#include <bpfilter/ctx.h>
+#include <bpfilter/logger.h>
+}
+
+/* All hooks that support BPF_PROG_TEST_RUN (excludes BF_FLAVOR_CGROUP_SOCK_ADDR). */
+static constexpr enum bf_hook kTestableHooks[] = {
+    BF_HOOK_XDP,
+    BF_HOOK_TC_INGRESS,
+    BF_HOOK_TC_EGRESS,
+    BF_HOOK_NF_PRE_ROUTING,
+    BF_HOOK_NF_LOCAL_IN,
+    BF_HOOK_NF_FORWARD,
+    BF_HOOK_NF_LOCAL_OUT,
+    BF_HOOK_NF_POST_ROUTING,
+    BF_HOOK_CGROUP_SKB_INGRESS,
+    BF_HOOK_CGROUP_SKB_EGRESS,
+};
+
+/**
+ * Verify NEXT as a rule verdict returns the flavor-specific NEXT return code
+ * when the rule matches, and falls through to chain policy on non-match.
+ *
+ * Chain policy is DROP. A rule matches TCP packets and returns NEXT. TCP
+ * packets must yield the hook's NEXT return code; UDP packets, which do not
+ * match, must yield DROP.
+ */
+static void next_rule_verdict(void **state)
+{
+    (void)state;
+
+    for (auto hook: kTestableHooks) {
+        assert_int_equal(0, bf_ruleset_flush());
+
+        // IPPROTO_TCP = 6
+        BFT_CHAIN_SET(
+            bf::Chain("test_next", hook, BF_VERDICT_DROP) << bf::Rule(
+                BF_VERDICT_NEXT, false, {},
+                {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
+
+        bft_assert_prog_run("test_next", hook,
+                            bft::Ethernet() / bft::IPv4 {} / bft::TCP {},
+                            bft_hook_next(hook));
+
+        bft_assert_prog_run("test_next", hook,
+                            bft::Ethernet() / bft::IPv4 {} / bft::UDP {},
+                            bft_hook_drop(hook));
+    }
+}
+
+/**
+ * Verify NEXT as chain policy returns the flavor-specific NEXT return code
+ * when no rule matches the packet.
+ *
+ * Chain policy is NEXT. A rule matches TCP packets and returns DROP. TCP
+ * packets must yield DROP; UDP packets, which do not match any rule, must
+ * fall through to the NEXT policy.
+ */
+static void next_policy(void **state)
+{
+    (void)state;
+
+    for (auto hook: kTestableHooks) {
+        assert_int_equal(0, bf_ruleset_flush());
+
+        // IPPROTO_TCP = 6
+        BFT_CHAIN_SET(
+            bf::Chain("test_next", hook, BF_VERDICT_NEXT) << bf::Rule(
+                BF_VERDICT_DROP, false, {},
+                {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
+
+        bft_assert_prog_run("test_next", hook,
+                            bft::Ethernet() / bft::IPv4 {} / bft::TCP {},
+                            bft_hook_drop(hook));
+
+        bft_assert_prog_run("test_next", hook,
+                            bft::Ethernet() / bft::IPv4 {} / bft::UDP {},
+                            bft_hook_next(hook));
+    }
+}
+
+/**
+ * Verify NEXT is terminal: when a rule fires NEXT, subsequent rules are not
+ * evaluated.
+ *
+ * Two TCP-matching rules are installed on TC_INGRESS: rule 0 has a counter
+ * and returns NEXT, rule 1 has a counter and returns DROP. After one TCP
+ * packet, rule 0's counter must be 1 and rule 1's counter must stay 0.
+ */
+static void next_is_terminal(void **state)
+{
+    (void)state;
+
+    // IPPROTO_TCP = 6
+    BFT_CHAIN_SET(
+        bf::Chain("test_next_term", BF_HOOK_TC_INGRESS, BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_NEXT, true, {},
+                    {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})})
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
+
+    bft_assert_prog_run("test_next_term", BF_HOOK_TC_INGRESS,
+                        bft::Ethernet() / bft::IPv4 {} / bft::TCP {},
+                        bft_hook_next(BF_HOOK_TC_INGRESS));
+
+    bft_assert_counter_eq("test_next_term", 0, 1, -1);
+    bft_assert_counter_eq("test_next_term", 1, 0, -1);
+}
+
+int main()
+{
+    int r = bf_ctx_setup(false, "/sys/fs/bpf", 0);
+    if (r != 0) {
+        bf_err("failed to setup bpfilter context: %s", strerror(-r));
+        return 1;
+    }
+
+    const std::vector<CMUnitTest> tests = {
+        cmocka_unit_test_setup_teardown(next_rule_verdict,
+                                        bft_matcher_test_setup,
+                                        bft_matcher_test_teardown),
+        cmocka_unit_test_setup_teardown(next_policy, bft_matcher_test_setup,
+                                        bft_matcher_test_teardown),
+        cmocka_unit_test_setup_teardown(next_is_terminal,
+                                        bft_matcher_test_setup,
+                                        bft_matcher_test_teardown),
+    };
+
+    r = _cmocka_run_group_tests("NEXT verdict", tests.data(), tests.size(),
+                                nullptr, nullptr);
+    bf_ctx_teardown();
+    return r;
+}

--- a/tests/harness/test.cpp
+++ b/tests/harness/test.cpp
@@ -71,10 +71,11 @@ void bft_assert_prog_run(const char *chain_name, enum bf_hook hook,
 
 namespace
 {
-// TCX_PASS/TCX_DROP are enum values in linux/bpf.h, but may conflict with
-// the C++ compilation depending on kernel headers version. Use literals.
+// TCX_PASS/TCX_DROP/TCX_NEXT are enum values in linux/bpf.h, but may conflict
+// with the C++ compilation depending on kernel headers version. Use literals.
 constexpr int kTcxPass = 0;
 constexpr int kTcxDrop = 2;
+constexpr int kTcxNext = -1;
 
 static int _bft_verdict(enum bf_hook hook, enum bf_verdict verdict)
 {
@@ -102,6 +103,23 @@ int bft_hook_accept(enum bf_hook hook)
 int bft_hook_drop(enum bf_hook hook)
 {
     return _bft_verdict(hook, BF_VERDICT_DROP);
+}
+
+int bft_hook_next(enum bf_hook hook)
+{
+    switch (bf_hook_to_flavor(hook)) {
+    case BF_FLAVOR_TC:
+        return kTcxNext;
+    case BF_FLAVOR_XDP:
+        return XDP_PASS;
+    case BF_FLAVOR_NF:
+        return NF_ACCEPT;
+    case BF_FLAVOR_CGROUP_SKB: // fallthrough
+    case BF_FLAVOR_CGROUP_SOCK_ADDR:
+        return 1;
+    default:
+        return -ENOTSUP;
+    }
 }
 
 int bft_matcher_test_setup(void **state)

--- a/tests/harness/test.h
+++ b/tests/harness/test.h
@@ -168,3 +168,14 @@ int bft_hook_accept(enum bf_hook hook);
  * @return The flavor-specific drop verdict (e.g. XDP_DROP, NF_DROP).
  */
 int bft_hook_drop(enum bf_hook hook);
+
+/**
+ * @brief Return the BPF "next" return value for the given hook.
+ *
+ * Maps BF_VERDICT_NEXT to its flavor-specific return code: TCX_NEXT (-1) for
+ * TC, XDP_PASS for XDP, NF_ACCEPT for NF, and 1 for cgroup_skb.
+ *
+ * @param hook Hook to query.
+ * @return The flavor-specific next verdict.
+ */
+int bft_hook_next(enum bf_hook hook);

--- a/tests/unit/libbpfilter/chain.c
+++ b/tests/unit/libbpfilter/chain.c
@@ -228,6 +228,22 @@ static void incompatible_matchers_disable_rule(void **state)
     }
 }
 
+static void policy_validation(void **state)
+{
+    _free_bf_chain_ struct bf_chain *chain = NULL;
+
+    (void)state;
+
+    assert_ok(bf_chain_new(&chain, "next", BF_HOOK_TC_EGRESS, BF_VERDICT_NEXT,
+                           NULL, NULL));
+    bf_chain_free(&chain);
+
+    assert_err(bf_chain_new(&chain, "bad", BF_HOOK_TC_EGRESS,
+                            BF_VERDICT_CONTINUE, NULL, NULL));
+    assert_err(bf_chain_new(&chain, "bad", BF_HOOK_TC_EGRESS,
+                            BF_VERDICT_REDIRECT, NULL, NULL));
+}
+
 static void get_set_by_name(void **state)
 {
     _free_bf_chain_ struct bf_chain *chain = bft_chain_dummy(true);
@@ -247,6 +263,7 @@ int main(void)
         cmocka_unit_test(get_set_from_matcher),
         cmocka_unit_test(mixed_enabled_disabled_log_flag),
         cmocka_unit_test(incompatible_matchers_disable_rule),
+        cmocka_unit_test(policy_validation),
         cmocka_unit_test(get_set_by_name),
     };
 

--- a/tests/unit/libbpfilter/verdict.c
+++ b/tests/unit/libbpfilter/verdict.c
@@ -16,6 +16,19 @@ static void to_from_str(void **state)
                             _BF_VERDICT_MAX);
 }
 
+static void is_valid_policy(void **state)
+{
+    (void)state;
+
+    assert_true(bf_verdict_is_valid_policy(BF_VERDICT_ACCEPT));
+    assert_true(bf_verdict_is_valid_policy(BF_VERDICT_DROP));
+    assert_true(bf_verdict_is_valid_policy(BF_VERDICT_NEXT));
+    assert_false(bf_verdict_is_valid_policy(BF_VERDICT_CONTINUE));
+    assert_false(bf_verdict_is_valid_policy(BF_VERDICT_REDIRECT));
+    assert_false(bf_verdict_is_valid_policy(_BF_VERDICT_MAX));
+    assert_false(bf_verdict_is_valid_policy(-1));
+}
+
 static void redirect_dir_to_from_str(void **state)
 {
     (void)state;
@@ -33,6 +46,7 @@ int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(to_from_str),
+        cmocka_unit_test(is_valid_policy),
         cmocka_unit_test(redirect_dir_to_from_str),
     };
 


### PR DESCRIPTION
Add a new BF_VERDICT_NEXT terminal verdict, meaning "pass to the next BPF program.".

On TC, this maps to TCX_NEXT which defers packet processing to the next program in the TCX link, distinct from TCX_PASS which accepts the packet and bypasses subsequent programs.
For NF, XDP, and cgroup_skb, NEXT maps to the same return code as ACCEPT since these hooks don't distinguish between the two.