### PR TITLE
daemon: cgen: fix ip6 dscp matcher byte order on little-endian

### DIFF
--- a/src/bpfilter/cgen/matcher/ip6.c
+++ b/src/bpfilter/cgen/matcher/ip6.c
@@ -310,6 +310,7 @@ static int _bf_matcher_generate_ip6_dscp(struct bf_program *program,
      * Load 2 bytes, mask with 0x0ff0, compare against dscp << 4. */
 
     EMIT(program, BPF_LDX_MEM(BPF_H, BPF_REG_1, BPF_REG_6, 0));
+    EMIT(program, BPF_ENDIAN(BPF_TO_BE, BPF_REG_1, 16));
     EMIT(program, BPF_ALU64_IMM(BPF_AND, BPF_REG_1, 0x0ff0));
 
     EMIT_FIXUP_JMP_NEXT_RULE(


### PR DESCRIPTION
Currently, the `ip6.dscp` does not work on little-endian hosts. `BPF_LDX_MEM(BPF_H)` performs a host-endian 16-bit load. The mask `0x0ff0` and comparison value (`dscp << 4`) assume big-endian register layout, so on little-endian hosts (x86-64) the matcher extracts the version field and flow label bits instead of the traffic class.

Add `BPF_ENDIAN(BPF_TO_BE)` after the halfword load to convert the register to big-endian before masking. This is a no-op on big-endian hosts and a byte-swap on little-endian, making the codegen correct on all architectures.

## Testing
- Caught this while adding a new comprehensive test suite (will publish soon)
- Manual testing on x86 machine