### PR TITLE
[1/2] Add flavor-specific log codegen callback

### DIFF
--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -66,9 +66,9 @@ set(libbpfilter_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.h               ${CMAKE_CURRENT_SOURCE_DIR}/cgen/jmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/cmp.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/cmp.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/meta.h      ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/meta.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/packet.h    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/packet.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/set.h       ${CMAKE_CURRENT_SOURCE_DIR}/cgen/matcher/set.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/nf.h                ${CMAKE_CURRENT_SOURCE_DIR}/cgen/nf.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/cgen/packet.h            ${CMAKE_CURRENT_SOURCE_DIR}/cgen/packet.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/printer.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/printer.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.h           ${CMAKE_CURRENT_SOURCE_DIR}/cgen/program.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.h         ${CMAKE_CURRENT_SOURCE_DIR}/cgen/prog/link.c

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -19,7 +19,7 @@
 #include <bpfilter/verdict.h>
 
 #include "cgen/matcher/cmp.h"
-#include "cgen/matcher/packet.h"
+#include "cgen/packet.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "cgen/swich.h"
@@ -132,7 +132,7 @@ static int _bf_cgroup_skb_gen_inline_matcher(struct bf_program *program,
         return bf_cmp_value(program, bf_matcher_get_op(matcher),
                             bf_matcher_payload(matcher), 4, BPF_REG_1);
     default:
-        return bf_matcher_generate_packet(program, matcher);
+        return bf_packet_gen_inline_matcher(program, matcher);
     }
 }
 

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -166,4 +166,5 @@ const struct bf_flavor_ops bf_flavor_ops_cgroup_skb = {
     .gen_inline_set_mark = _bf_cgroup_skb_gen_inline_set_mark,
     .get_verdict = _bf_cgroup_skb_get_verdict,
     .gen_inline_matcher = _bf_cgroup_skb_gen_inline_matcher,
+    .gen_inline_log = bf_packet_gen_inline_log,
 };

--- a/src/libbpfilter/cgen/cgroup_sock_addr.c
+++ b/src/libbpfilter/cgen/cgroup_sock_addr.c
@@ -280,9 +280,20 @@ static int _bf_cgroup_sock_addr_get_verdict(enum bf_verdict verdict,
     }
 }
 
+static int _bf_cgroup_sock_addr_gen_inline_log(struct bf_program *program,
+                                               const struct bf_rule *rule)
+{
+    (void)program;
+    (void)rule;
+
+    return bf_err_r(-ENOTSUP,
+                    "logging is not yet supported for cgroup_sock_addr");
+}
+
 const struct bf_flavor_ops bf_flavor_ops_cgroup_sock_addr = {
     .gen_inline_prologue = _bf_cgroup_sock_addr_gen_inline_prologue,
     .gen_inline_epilogue = _bf_cgroup_sock_addr_gen_inline_epilogue,
     .get_verdict = _bf_cgroup_sock_addr_get_verdict,
     .gen_inline_matcher = _bf_cgroup_sock_addr_gen_inline_matcher,
+    .gen_inline_log = _bf_cgroup_sock_addr_gen_inline_log,
 };

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -182,4 +182,5 @@ const struct bf_flavor_ops bf_flavor_ops_nf = {
     .gen_inline_epilogue = _bf_nf_gen_inline_epilogue,
     .get_verdict = _bf_nf_get_verdict,
     .gen_inline_matcher = _bf_nf_gen_inline_matcher,
+    .gen_inline_log = bf_packet_gen_inline_log,
 };

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -24,7 +24,7 @@
 
 #include "cgen/jmp.h"
 #include "cgen/matcher/cmp.h"
-#include "cgen/matcher/packet.h"
+#include "cgen/packet.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "cgen/swich.h"
@@ -149,7 +149,7 @@ static int _bf_nf_gen_inline_matcher(struct bf_program *program,
         return bf_cmp_value(program, bf_matcher_get_op(matcher),
                             bf_matcher_payload(matcher), 4, BPF_REG_1);
     default:
-        return bf_matcher_generate_packet(program, matcher);
+        return bf_packet_gen_inline_matcher(program, matcher);
     }
 }
 

--- a/src/libbpfilter/cgen/packet.c
+++ b/src/libbpfilter/cgen/packet.c
@@ -14,14 +14,17 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <bpfilter/elfstub.h>
 #include <bpfilter/helper.h>
 #include <bpfilter/logger.h>
 #include <bpfilter/matcher.h>
+#include <bpfilter/rule.h>
 
 #include "cgen/matcher/cmp.h"
 #include "cgen/matcher/meta.h"
 #include "cgen/matcher/set.h"
 #include "cgen/program.h"
+#include "cgen/runtime.h"
 #include "cgen/stub.h"
 #include "filter.h"
 
@@ -354,4 +357,26 @@ int bf_packet_gen_inline_matcher(struct bf_program *program,
         return bf_err_r(-EINVAL, "unknown matcher type %d",
                         bf_matcher_get_type(matcher));
     }
+}
+
+int bf_packet_gen_inline_log(struct bf_program *program,
+                             const struct bf_rule *rule)
+{
+    assert(program);
+    assert(rule);
+
+    EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_2, rule->index));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_3, rule->log));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_4, rule->verdict));
+
+    // Pack l3_proto and l4_proto
+    EMIT(program, BPF_MOV64_REG(BPF_REG_5, BPF_REG_7));
+    EMIT(program, BPF_ALU64_IMM(BPF_LSH, BPF_REG_5, 16));
+    EMIT(program, BPF_ALU64_REG(BPF_OR, BPF_REG_5, BPF_REG_8));
+
+    EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_PKT_LOG);
+
+    return 0;
 }

--- a/src/libbpfilter/cgen/packet.c
+++ b/src/libbpfilter/cgen/packet.c
@@ -3,7 +3,7 @@
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  */
 
-#include "cgen/matcher/packet.h"
+#include "cgen/packet.h"
 
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
@@ -296,8 +296,8 @@ static int _bf_matcher_pkt_generate_ip6_dscp(struct bf_program *program,
     return 0;
 }
 
-int bf_matcher_generate_packet(struct bf_program *program,
-                               const struct bf_matcher *matcher)
+int bf_packet_gen_inline_matcher(struct bf_program *program,
+                                 const struct bf_matcher *matcher)
 {
     const struct bf_matcher_meta *meta;
 

--- a/src/libbpfilter/cgen/packet.h
+++ b/src/libbpfilter/cgen/packet.h
@@ -23,5 +23,5 @@ struct bf_program;
  * @param matcher Matcher to generate code for. Can't be NULL.
  * @return 0 on success, negative errno on error.
  */
-int bf_matcher_generate_packet(struct bf_program *program,
-                               const struct bf_matcher *matcher);
+int bf_packet_gen_inline_matcher(struct bf_program *program,
+                                 const struct bf_matcher *matcher);

--- a/src/libbpfilter/cgen/packet.h
+++ b/src/libbpfilter/cgen/packet.h
@@ -7,6 +7,7 @@
 
 struct bf_matcher;
 struct bf_program;
+struct bf_rule;
 
 /**
  * @brief Generate bytecode for a packet-based matcher.
@@ -25,3 +26,16 @@ struct bf_program;
  */
 int bf_packet_gen_inline_matcher(struct bf_program *program,
                                  const struct bf_matcher *matcher);
+
+/**
+ * @brief Generate bytecode for packet-based rule logging.
+ *
+ * Sets up registers and calls the packet log ELF stub. Shared by all
+ * packet-based flavors (TC, NF, XDP, cgroup_skb).
+ *
+ * @param program Program being generated. Can't be NULL.
+ * @param rule Rule whose log action to generate. Can't be NULL.
+ * @return 0 on success, negative errno on error.
+ */
+int bf_packet_gen_inline_log(struct bf_program *program,
+                             const struct bf_rule *rule);

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -289,6 +289,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
     assert(program);
     assert(rule);
     assert(program->runtime.ops->gen_inline_matcher);
+    assert(program->runtime.ops->gen_inline_log);
 
     if (rule->disabled)
         return 0;
@@ -343,18 +344,9 @@ static int _bf_program_generate_rule(struct bf_program *program,
     }
 
     if (rule->log) {
-        EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
-        EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_2, rule->index));
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_3, rule->log));
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_4, rule->verdict));
-
-        // Pack l3_proto and l4_proto
-        EMIT(program, BPF_MOV64_REG(BPF_REG_5, BPF_REG_7));
-        EMIT(program, BPF_ALU64_IMM(BPF_LSH, BPF_REG_5, 16));
-        EMIT(program, BPF_ALU64_REG(BPF_OR, BPF_REG_5, BPF_REG_8));
-
-        EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_PKT_LOG);
+        r = program->runtime.ops->gen_inline_log(program, rule);
+        if (r)
+            return r;
     }
 
     if (rule->counters) {

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -182,4 +182,5 @@ const struct bf_flavor_ops bf_flavor_ops_tc = {
     .gen_inline_redirect = _bf_tc_gen_inline_redirect,
     .get_verdict = _bf_tc_get_verdict,
     .gen_inline_matcher = _bf_tc_gen_inline_matcher,
+    .gen_inline_log = bf_packet_gen_inline_log,
 };

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -19,7 +19,7 @@
 #include <bpfilter/verdict.h>
 
 #include "cgen/matcher/cmp.h"
-#include "cgen/matcher/packet.h"
+#include "cgen/packet.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "filter.h"
@@ -115,7 +115,7 @@ static int _bf_tc_gen_inline_matcher(struct bf_program *program,
         return bf_cmp_value(program, bf_matcher_get_op(matcher),
                             bf_matcher_payload(matcher), 4, BPF_REG_0);
     default:
-        return bf_matcher_generate_packet(program, matcher);
+        return bf_packet_gen_inline_matcher(program, matcher);
     }
 }
 

--- a/src/libbpfilter/cgen/xdp.c
+++ b/src/libbpfilter/cgen/xdp.c
@@ -14,7 +14,7 @@
 #include <bpfilter/logger.h>
 #include <bpfilter/verdict.h>
 
-#include "cgen/matcher/packet.h"
+#include "cgen/packet.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "filter.h"
@@ -136,5 +136,5 @@ const struct bf_flavor_ops bf_flavor_ops_xdp = {
     .gen_inline_epilogue = _bf_xdp_gen_inline_epilogue,
     .gen_inline_redirect = _bf_xdp_gen_inline_redirect,
     .get_verdict = _bf_xdp_get_verdict,
-    .gen_inline_matcher = bf_matcher_generate_packet,
+    .gen_inline_matcher = bf_packet_gen_inline_matcher,
 };

--- a/src/libbpfilter/cgen/xdp.c
+++ b/src/libbpfilter/cgen/xdp.c
@@ -137,4 +137,5 @@ const struct bf_flavor_ops bf_flavor_ops_xdp = {
     .gen_inline_redirect = _bf_xdp_gen_inline_redirect,
     .get_verdict = _bf_xdp_get_verdict,
     .gen_inline_matcher = bf_packet_gen_inline_matcher,
+    .gen_inline_log = bf_packet_gen_inline_log,
 };

--- a/src/libbpfilter/include/bpfilter/flavor.h
+++ b/src/libbpfilter/include/bpfilter/flavor.h
@@ -11,6 +11,7 @@
 
 struct bf_matcher;
 struct bf_program;
+struct bf_rule;
 
 /**
  * @file flavor.h
@@ -137,6 +138,19 @@ struct bf_flavor_ops
      */
     int (*gen_inline_matcher)(struct bf_program *program,
                               const struct bf_matcher *matcher);
+
+    /**
+     * @brief Generate bytecode for rule logging.
+     *
+     * Each flavor controls its own register setup and ELF stub selection.
+     * Required for all flavors.
+     *
+     * @param program Program being generated. Can't be NULL.
+     * @param rule Rule whose log action to generate. Can't be NULL.
+     * @return 0 on success, or negative errno on error.
+     */
+    int (*gen_inline_log)(struct bf_program *program,
+                          const struct bf_rule *rule);
 };
 
 /**


### PR DESCRIPTION
Gave `stack-pr` a try, but it doesn't allow for multi-commit PR's :(

Stack:
- #485
- -> #486
- #491

### Summary

The main goal here is to add a callback that gives flavors the ability to more finely control the logging process. This will enable us to easily use a new `CGROUP_SOCK_ADDR` elf-stub.

### Notes
- Moves `cgen/matcher/packet.{c,h}` to `cgen/packet.{c,h}`. It was a mistake to put this here in the first place as packet-based flavors can share more than matcher codegen. We correct the placement now.
- Once again, no functional change. This moves a file around and add a callback.
