### PR TITLE
[2/2] Add `CGROUP_SOCK_ADDR` Logging Infrastructure

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -129,14 +129,17 @@ Print a chain.
 ``chain logs``
 ~~~~~~~~~~~~~~
 
-Print a chain's logged packets.
+Print a chain's log entries.
 
-bfcli will print the logged headers as they are published by the chain. Only the headers requested in the ``log`` action will be printed. Hit ``Ctrl+C`` to quit.
+bfcli will print log entries as they are published by the chain. Hit ``Ctrl+C`` to quit.
 
-For each logged packet, bfcli will print the receive timestamp and the packet size, followed by each requested layer (see the ``log`` action below). If one of the requested layer could not be processed by the chain, the corresponding output will be truncated.
+Every log entry begins with a shared header: the receive timestamp, the matching rule's index, and the applied verdict. The remaining fields depend on the hook type:
+
+- For packet-based hooks, the header also includes the matched packet size. It is followed by each requested layer's protocol headers (see the ``log`` action below). If a requested layer could not be processed by the chain, the corresponding output will be truncated.
+- For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, the entry includes destination address, destination port, process ID, and process name. Sendmsg hooks additionally include the source address.
 
 **Options**
-  - ``--name NAME``: name of the chain to print the logged packets for.
+  - ``--name NAME``: name of the chain to print the log entries for.
 
 **Examples**
 
@@ -416,10 +419,10 @@ Rules are defined such as:
 
 With:
   - ``$MATCHER``: zero or more matchers. Matchers are defined later.
-  - ``log``: optional. Logging is not supported by ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks. Two forms are supported:
+  - ``log``: optional. Two forms are supported:
 
     - ``log $HEADERS``: log specific packet headers. ``$HEADERS`` is a comma-separated list of ``link`` (layer 2), ``internet`` (layer 3), and/or ``transport`` (layer 4). Only supported by packet-based hooks (XDP, TC, NF, cgroup_skb).
-    - ``log``: log all available data for the hook type. For packet-based hooks, this is equivalent to ``log link,internet,transport``.
+    - ``log``: log all available data for the hook type. For packet-based hooks, this is equivalent to ``log link,internet,transport``. For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, this records the process ID, process name, destination address, and destination port. Sendmsg hooks additionally include the source address.
   - ``counter``: optional literal. If set, the filter will count the number of events matched by the rule. For packet-based hooks, this includes both the number of packets and the total bytes. For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, this counts the number of socket operations (``connect()`` or ``sendmsg()`` calls).
   - ``mark``: optional, ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. If set, write the packet's marker value. This marker can be used later on in a rule (see ``meta.mark``) or with a TC filter.
   - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP``, ``CONTINUE``, ``NEXT``, or ``REDIRECT``.

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -365,6 +365,8 @@ static void _bf_chain_log_header(const struct bf_log *log)
     struct timespec time;
     char time_str[64];
 
+    assert(log);
+
     // Convert timestamp to readable format
     time.tv_sec = (long)log->ts / BF_TIME_S;
     time.tv_nsec = (long)log->ts % BF_TIME_S;
@@ -372,15 +374,21 @@ static void _bf_chain_log_header(const struct bf_log *log)
     (void)strftime(time_str, sizeof(time_str), "%H:%M:%S",
                    localtime(&time.tv_sec));
 
-    (void)fprintf(
-        stdout,
-        "\n%s[%s.%06ld]%s Rule #%u matched %s%llu bytes%s with verdict %s\n",
-        bf_logger_get_color(BF_COLOR_LIGHT_CYAN, BF_STYLE_NORMAL), time_str,
-        time.tv_nsec / BF_TIME_US,
-        bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), log->rule_id,
-        bf_logger_get_color(BF_COLOR_DEFAULT, BF_STYLE_BOLD), log->pkt.pkt_size,
-        bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),
-        bf_verdict_to_str((enum bf_verdict)log->verdict));
+    (void)fprintf(stdout, "\n%s[%s.%06ld]%s Rule #%u",
+                  bf_logger_get_color(BF_COLOR_LIGHT_CYAN, BF_STYLE_NORMAL),
+                  time_str, time.tv_nsec / BF_TIME_US,
+                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET),
+                  log->rule_id);
+
+    if (log->log_type == BF_LOG_TYPE_PACKET) {
+        (void)fprintf(stdout, " matched %s%llu bytes%s with",
+                      bf_logger_get_color(BF_COLOR_DEFAULT, BF_STYLE_BOLD),
+                      log->pkt.pkt_size,
+                      bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+    }
+
+    (void)fprintf(stdout, " verdict %s\n",
+                  bf_verdict_to_str((enum bf_verdict)log->verdict));
 }
 
 static void _bf_chain_log_l2(const struct bf_log *log)
@@ -576,17 +584,107 @@ static void _bf_chain_log_l4(const struct bf_log *log)
     }
 }
 
+static void _bf_chain_log_sock_addr(const struct bf_log *log)
+{
+    char src_addr[INET6_ADDRSTRLEN];
+    char dst_addr[INET6_ADDRSTRLEN];
+    const char *protocol;
+    const char *label = NULL;
+    const char *color = NULL;
+    const char *l4_label;
+    int family = 0;
+
+    assert(log);
+
+    protocol = bf_ipproto_to_str(log->l4_proto);
+
+    if (log->l3_proto == ETH_P_IP) {
+        family = AF_INET;
+        label = "IPv4";
+        color = bf_logger_get_color(BF_COLOR_CYAN, BF_STYLE_BOLD);
+    } else if (log->l3_proto == ETH_P_IPV6) {
+        family = AF_INET6;
+        label = "IPv6";
+        color = bf_logger_get_color(BF_COLOR_LIGHT_CYAN, BF_STYLE_BOLD);
+    }
+
+    if (label) {
+        bool has_saddr =
+            log->sock_addr.captured_fields & BF_LOG_SOCK_ADDR_SADDR;
+
+        inet_ntop(family, log->sock_addr.daddr, dst_addr, sizeof(dst_addr));
+
+        if (has_saddr) {
+            inet_ntop(family, log->sock_addr.saddr, src_addr, sizeof(src_addr));
+            (void)fprintf(
+                stdout, "  %-10s: %s%s%s → %s%s%s", label, color, src_addr,
+                bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET), color,
+                dst_addr, bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+        } else {
+            (void)fprintf(stdout, "  %-10s: → %s%s%s", label, color, dst_addr,
+                          bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+        }
+
+        if (protocol) {
+            (void)fprintf(
+                stdout, " [%s%s%s]\n",
+                bf_logger_get_color(BF_COLOR_LIGHT_MAGENTA, BF_STYLE_BOLD),
+                protocol, bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+        } else {
+            (void)fprintf(stdout, " [proto=%u]\n", log->l4_proto);
+        }
+    } else {
+        (void)fprintf(stdout, "  Internet  : <unknown protocol 0x%04x>\n",
+                      log->l3_proto);
+    }
+
+    switch (log->l4_proto) {
+    case IPPROTO_TCP:
+        l4_label = "TCP";
+        break;
+    case IPPROTO_UDP:
+        l4_label = "UDP";
+        break;
+    default:
+        l4_label = "Transport";
+        break;
+    }
+
+    (void)fprintf(stdout, "  %-10s: → %s%-5u%s\n", l4_label,
+                  bf_logger_get_color(BF_COLOR_LIGHT_YELLOW, BF_STYLE_BOLD),
+                  log->sock_addr.dport,
+                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+
+    (void)fprintf(stdout, "  PID       : %s%u%s\n",
+                  bf_logger_get_color(BF_COLOR_LIGHT_YELLOW, BF_STYLE_BOLD),
+                  log->sock_addr.pid,
+                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+
+    (void)fprintf(stdout, "  Process   : %s%.*s%s\n",
+                  bf_logger_get_color(BF_COLOR_LIGHT_GREEN, BF_STYLE_BOLD),
+                  BF_COMM_LEN, log->sock_addr.comm,
+                  bf_logger_get_color(BF_COLOR_RESET, BF_STYLE_RESET));
+}
+
 void bfc_print_log(const struct bf_log *log)
 {
-    if (log->log_type != BF_LOG_TYPE_PACKET)
-        return;
+    assert(log);
 
     _bf_chain_log_header(log);
 
-    if (log->pkt.req_headers & (1 << BF_LOG_OPT_LINK))
-        _bf_chain_log_l2(log);
-    if (log->pkt.req_headers & (1 << BF_LOG_OPT_INTERNET))
-        _bf_chain_log_l3(log);
-    if (log->pkt.req_headers & (1 << BF_LOG_OPT_TRANSPORT))
-        _bf_chain_log_l4(log);
+    switch (log->log_type) {
+    case BF_LOG_TYPE_PACKET:
+        if (log->pkt.req_headers & (1 << BF_LOG_OPT_LINK))
+            _bf_chain_log_l2(log);
+        if (log->pkt.req_headers & (1 << BF_LOG_OPT_INTERNET))
+            _bf_chain_log_l3(log);
+        if (log->pkt.req_headers & (1 << BF_LOG_OPT_TRANSPORT))
+            _bf_chain_log_l4(log);
+        break;
+    case BF_LOG_TYPE_SOCK_ADDR:
+        _bf_chain_log_sock_addr(log);
+        break;
+    default:
+        break;
+    }
 }

--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -115,6 +115,7 @@ bf_target_add_elfstubs(libbpfilter
         "update_counters"
         "pkt_log"
         "flow_hash"
+        "sock_addr_log"
 )
 
 target_compile_definitions(libbpfilter

--- a/src/libbpfilter/bpf/sock_addr_log.bpf.c
+++ b/src/libbpfilter/bpf/sock_addr_log.bpf.c
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
+#include <linux/bpf.h>
+
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
+
+#include "cgen/runtime.h"
+
+__u8 bf_sock_addr_log(struct bf_runtime *ctx, __u32 rule_id, __u32 verdict,
+                      __u32 l3_l4_proto, __u8 captured_fields)
+{
+    const struct bf_runtime_sock_addr *sock_addr = (const void *)ctx->scratch;
+    struct bf_log *log;
+    __u16 l3_proto = (__u16)(l3_l4_proto >> 16);
+    __u8 l4_proto = (__u8)l3_l4_proto;
+
+    log = bpf_ringbuf_reserve(ctx->log_map, sizeof(struct bf_log), 0);
+    if (!log) {
+        bpf_printk("failed to reserve %d bytes in ringbuf",
+                   sizeof(struct bf_log));
+        return 1;
+    }
+
+    log->ts = bpf_ktime_get_ns();
+    log->rule_id = rule_id;
+    log->verdict = verdict;
+    log->l3_proto = bpf_ntohs(l3_proto);
+    log->l4_proto = l4_proto;
+    log->log_type = BF_LOG_TYPE_SOCK_ADDR;
+
+    log->sock_addr.pid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+    bpf_get_current_comm(log->sock_addr.comm, sizeof(log->sock_addr.comm));
+
+    if (captured_fields & BF_LOG_SOCK_ADDR_SADDR) {
+        __builtin_memcpy(log->sock_addr.saddr, sock_addr->saddr,
+                         sizeof(sock_addr->saddr));
+    }
+    __builtin_memcpy(log->sock_addr.daddr, sock_addr->daddr,
+                     sizeof(sock_addr->daddr));
+
+    log->sock_addr.dport = sock_addr->dport;
+    log->sock_addr.captured_fields = captured_fields;
+
+    bpf_ringbuf_submit(log, 0);
+
+    return 0;
+}

--- a/src/libbpfilter/cgen/cgroup_sock_addr.c
+++ b/src/libbpfilter/cgen/cgroup_sock_addr.c
@@ -15,9 +15,12 @@
 #include <sys/socket.h>
 
 #include <bpfilter/chain.h>
+#include <bpfilter/elfstub.h>
 #include <bpfilter/flavor.h>
+#include <bpfilter/hook.h>
 #include <bpfilter/logger.h>
 #include <bpfilter/matcher.h>
+#include <bpfilter/rule.h>
 #include <bpfilter/runtime.h>
 #include <bpfilter/set.h>
 #include <bpfilter/verdict.h>
@@ -26,6 +29,7 @@
 #include "cgen/matcher/meta.h"
 #include "cgen/matcher/set.h"
 #include "cgen/program.h"
+#include "cgen/runtime.h"
 #include "cgen/stub.h"
 #include "cgen/swich.h"
 #include "filter.h"
@@ -134,6 +138,48 @@ static int _bf_cgroup_sock_addr_load_field(struct bf_program *program,
             EMIT(program, BPF_ALU64_IMM(BPF_LSH, reg + 2, 32));
             EMIT(program, BPF_ALU64_REG(BPF_OR, reg + 1, reg + 2));
         }
+        break;
+    default:
+        return -EINVAL;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Store a register value at an offset from `BPF_REG_10`.
+ *
+ * Counterpart to `_bf_cgroup_sock_addr_load_field`. For 16-byte stores,
+ * `reg` holds the low 8 bytes and `reg + 1` the high 8 bytes, matching
+ * the layout produced by `_bf_cgroup_sock_addr_load_field`.
+ *
+ * @param program Program to emit into. Can't be NULL.
+ * @param offset Byte offset from `BPF_REG_10`.
+ * @param size Field size in bytes: 1, 2, 4, 8, or 16.
+ * @param reg BPF register holding the value to store.
+ * @return 0 on success, negative errno on error.
+ */
+static int _bf_cgroup_sock_addr_store_field(struct bf_program *program,
+                                            int offset, size_t size, int reg)
+{
+    assert(program);
+
+    switch (size) {
+    case 1:
+        EMIT(program, BPF_STX_MEM(BPF_B, BPF_REG_10, reg, offset));
+        break;
+    case 2:
+        EMIT(program, BPF_STX_MEM(BPF_H, BPF_REG_10, reg, offset));
+        break;
+    case 4:
+        EMIT(program, BPF_STX_MEM(BPF_W, BPF_REG_10, reg, offset));
+        break;
+    case 8:
+        EMIT(program, BPF_STX_MEM(BPF_DW, BPF_REG_10, reg, offset));
+        break;
+    case 16:
+        EMIT(program, BPF_STX_MEM(BPF_DW, BPF_REG_10, reg, offset));
+        EMIT(program, BPF_STX_MEM(BPF_DW, BPF_REG_10, reg + 1, offset + 8));
         break;
     default:
         return -EINVAL;
@@ -393,11 +439,91 @@ static int _bf_cgroup_sock_addr_get_verdict(enum bf_verdict verdict,
 static int _bf_cgroup_sock_addr_gen_inline_log(struct bf_program *program,
                                                const struct bf_rule *rule)
 {
-    (void)program;
-    (void)rule;
+    uint8_t captured_fields = 0;
+    bool has_saddr = false;
+    size_t addr_size = 0;
+    size_t saddr_off = 0;
+    size_t daddr_off = 0;
+    int r;
 
-    return bf_err_r(-ENOTSUP,
-                    "logging is not yet supported for cgroup_sock_addr");
+    assert(program);
+    assert(rule);
+
+    // Zero the staging area: connect hooks have no source address,
+    // and IPv4 hooks only write 4 of the 16 address bytes.
+    for (int i = 0; i < (int)sizeof(struct bf_runtime_sock_addr); i += 8)
+        EMIT(program, BPF_ST_MEM(BPF_DW, BPF_REG_10, BF_PROG_SCR_OFF(i), 0));
+
+    switch (program->runtime.chain->hook) {
+    case BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4:
+        has_saddr = true;
+        saddr_off = offsetof(struct bpf_sock_addr, msg_src_ip4);
+        __attribute__((fallthrough));
+    case BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4:
+        addr_size = 4;
+        daddr_off = offsetof(struct bpf_sock_addr, user_ip4);
+        break;
+    case BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6:
+        has_saddr = true;
+        saddr_off = offsetof(struct bpf_sock_addr, msg_src_ip6);
+        __attribute__((fallthrough));
+    case BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6:
+        addr_size = 16;
+        daddr_off = offsetof(struct bpf_sock_addr, user_ip6);
+        break;
+    default:
+        return bf_err_r(-ENOTSUP, "unexpected hook: %s",
+                        bf_hook_to_str(program->runtime.chain->hook));
+    }
+
+    if (has_saddr) {
+        captured_fields |= BF_LOG_SOCK_ADDR_SADDR;
+        r = _bf_cgroup_sock_addr_load_field(program, saddr_off, addr_size,
+                                            BPF_REG_1);
+        if (r)
+            return r;
+        r = _bf_cgroup_sock_addr_store_field(
+            program,
+            BF_PROG_SCR_OFF(offsetof(struct bf_runtime_sock_addr, saddr)),
+            addr_size, BPF_REG_1);
+        if (r)
+            return r;
+    }
+
+    r = _bf_cgroup_sock_addr_load_field(program, daddr_off, addr_size,
+                                        BPF_REG_1);
+    if (r)
+        return r;
+    r = _bf_cgroup_sock_addr_store_field(
+        program, BF_PROG_SCR_OFF(offsetof(struct bf_runtime_sock_addr, daddr)),
+        addr_size, BPF_REG_1);
+    if (r)
+        return r;
+
+    /* Destination port: valid for all cgroup_sock_addr hooks.
+     * user_port is __be32; BSWAP 16 converts to host order. */
+    r = _bf_cgroup_sock_addr_load_field(
+        program, offsetof(struct bpf_sock_addr, user_port), 4, BPF_REG_1);
+    if (r)
+        return r;
+    EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
+    r = _bf_cgroup_sock_addr_store_field(
+        program, BF_PROG_SCR_OFF(offsetof(struct bf_runtime_sock_addr, dport)),
+        2, BPF_REG_1);
+    if (r)
+        return r;
+
+    EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_2, rule->index));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_3, rule->verdict));
+    EMIT(program, BPF_MOV64_REG(BPF_REG_4, BPF_REG_7));
+    EMIT(program, BPF_ALU64_IMM(BPF_LSH, BPF_REG_4, 16));
+    EMIT(program, BPF_ALU64_REG(BPF_OR, BPF_REG_4, BPF_REG_8));
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_5, captured_fields));
+    EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_SOCK_ADDR_LOG);
+
+    return 0;
 }
 
 const struct bf_flavor_ops bf_flavor_ops_cgroup_sock_addr = {

--- a/src/libbpfilter/cgen/runtime.h
+++ b/src/libbpfilter/cgen/runtime.h
@@ -40,7 +40,35 @@
  */
 #define BF_PROG_SCR_OFF(index)                                                 \
     (-(int)sizeof(struct bf_runtime) +                                         \
-     (int)offsetof(struct bf_runtime, scratch) + (index))
+     (int)offsetof(struct bf_runtime, scratch) + (int)(index))
+
+/**
+ * @brief Pre-read socket address fields for `cgroup_sock_addr` logging.
+ *
+ * The BPF verifier restricts which `bpf_sock_addr` context fields a program
+ * can access based on its attach type (e.g. `msg_src_ip4` is only valid for
+ * `UDP4_SENDMSG`, `user_ip4` only for IPv4 hooks). Because the `sock_addr_log`
+ * ELF stub is shared across all hook types, it cannot read these fields
+ * directly.
+ *
+ * Instead, the per-hook inline codegen pre-reads the permitted fields into
+ * this struct before calling the stub. The stub then copies from here into
+ * the log entry, avoiding any restricted context access.
+ */
+struct bf_runtime_sock_addr
+{
+    /** Source address (IPv4: first 4 bytes, IPv6: all 16). */
+    __u8 bf_aligned(8) saddr[16];
+
+    /** Destination address (IPv4: first 4 bytes, IPv6: all 16). */
+    __u8 bf_aligned(8) daddr[16];
+
+    /** Destination port in host byte order. */
+    __u16 bf_aligned(8) dport;
+};
+
+static_assert(sizeof(struct bf_runtime_sock_addr) <= 64,
+              "bf_runtime_sock_addr must fit in the scratch area");
 
 /**
  * @brief Runtime stack layout for the generated BPF programs.

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -170,10 +170,12 @@ int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
         rule->disabled = r;
     }
 
-    if (rule->log &&
+    if (rule->log && rule->log != BF_LOG_OPT_DEFAULT &&
         bf_hook_to_flavor(chain->hook) == BF_FLAVOR_CGROUP_SOCK_ADDR) {
-        return bf_err_r(-ENOTSUP, "logging is not supported by %s",
-                        bf_hook_to_str(chain->hook));
+        return bf_err_r(
+            -ENOTSUP,
+            "per-field log options are not supported by %s, use 'log'",
+            bf_hook_to_str(chain->hook));
     }
 
     if (rule->log && !rule->disabled)

--- a/src/libbpfilter/include/bpfilter/elfstub.h
+++ b/src/libbpfilter/include/bpfilter/elfstub.h
@@ -153,6 +153,23 @@ enum bf_elfstub_id
      */
     BF_ELFSTUB_FLOW_HASH,
 
+    /**
+     * Log socket address metadata to a ring buffer.
+     *
+     * `__u8 bf_sock_addr_log(struct bf_runtime *ctx, __u32 rule_id, __u32 verdict, __u32 l3_l4_proto, __u8 captured_fields)`
+     *
+     * **Parameters**
+     * - `ctx`: address of the `bf_runtime` context of the program.
+     * - `rule_id`: id of the matched rule.
+     * - `verdict`: verdict of the matched rule.
+     * - `l3_l4_proto`: layer 3 and layer 4 protocols packed (l3 << 16 | l4).
+     * - `captured_fields`: bitmask of conditional fields captured in the
+     *   log entry (see `BF_LOG_SOCK_ADDR_*`).
+     *
+     * **Return** 0 on success, or 1 on error.
+     */
+    BF_ELFSTUB_SOCK_ADDR_LOG,
+
     _BF_ELFSTUB_MAX,
 };
 

--- a/src/libbpfilter/include/bpfilter/runtime.h
+++ b/src/libbpfilter/include/bpfilter/runtime.h
@@ -134,6 +134,9 @@ struct bf_log_pkt
     bf_aligned(8) __u8 l4hdr[BF_L4_SLICE_LEN];
 };
 
+/** Source address field was captured. */
+#define BF_LOG_SOCK_ADDR_SADDR (1U << 0)
+
 /**
  * @brief Socket address log payload fields (cgroup_sock_addr).
  */
@@ -144,6 +147,9 @@ struct bf_log_sock_addr
 
     /** Destination port in host byteorder. */
     __u16 dport;
+
+    /** Bitmask of conditional fields captured in this log entry. */
+    __u8 captured_fields;
 
     /** Process name. */
     bf_aligned(8) __u8 comm[BF_COMM_LEN];

--- a/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
@@ -2,6 +2,14 @@
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 
+# Bare log accepted for sock_addr hooks
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.dport eq 9990 log counter DROP"
+
+# Per-field log options rejected for sock_addr hooks
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.dport eq 9990 log internet,transport counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.dport eq 9990 log link counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.dport eq 9990 log link,internet,transport counter DROP")
+
 # Supported matchers
 ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.l3_proto eq ipv4 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule meta.l4_proto eq tcp counter DROP"
@@ -65,7 +73,7 @@ get_counter() {
 }
 
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 counter DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 log counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
 test "$(get_counter c 0)" = "1"
 

--- a/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
@@ -83,7 +83,7 @@ get_counter() {
 }
 
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 counter DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 log counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
 test "$(get_counter c 0)" = "1"
 

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
@@ -66,7 +66,7 @@ get_counter() {
 }
 
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 counter DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 log counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
 test "$(get_counter c 0)" = "1"
 

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
@@ -70,7 +70,7 @@ get_counter() {
 }
 
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 counter DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 log counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
 test "$(get_counter c 0)" = "1"
 

--- a/tests/unit/libbpfilter/chain.c
+++ b/tests/unit/libbpfilter/chain.c
@@ -5,6 +5,8 @@
 
 #include <bpfilter/chain.h>
 #include <bpfilter/core/list.h>
+#include <bpfilter/helper.h>
+#include <bpfilter/hook.h>
 #include <bpfilter/pack.h>
 #include <bpfilter/rule.h>
 #include <bpfilter/runtime.h>
@@ -321,6 +323,42 @@ static void set_component_unsupported_hook(void **state)
                            BF_VERDICT_ACCEPT, &sets, &rules));
 }
 
+static void sock_addr_log_flag(void **state)
+{
+    _free_bf_chain_ struct bf_chain *chain = NULL;
+    _clean_bf_list_ bf_list rules = bf_list_default(bf_rule_free, bf_rule_pack);
+    struct bf_rule *r0 = NULL;
+
+    (void)state;
+
+    assert_ok(bf_rule_new(&r0));
+    r0->log = BF_LOG_OPT_DEFAULT;
+    assert_ok(bf_list_add_tail(&rules, r0));
+
+    assert_ok(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,
+                           BF_VERDICT_ACCEPT, NULL, &rules));
+
+    assert_false(r0->disabled);
+    assert_int_not_equal(chain->flags & BF_FLAG(BF_CHAIN_LOG), 0);
+}
+
+static void invalid_log_opts_for_hook(void **state)
+{
+    (void)state;
+
+    // Per-field log options on a sock_addr hook
+    _free_bf_chain_ struct bf_chain *chain = NULL;
+    _clean_bf_list_ bf_list rules = bf_list_default(bf_rule_free, bf_rule_pack);
+    struct bf_rule *r0 = NULL;
+
+    assert_ok(bf_rule_new(&r0));
+    r0->log = BF_FLAG(BF_LOG_OPT_LINK);
+    assert_ok(bf_list_add_tail(&rules, r0));
+
+    assert_err(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,
+                            BF_VERDICT_ACCEPT, NULL, &rules));
+}
+
 static void get_set_by_name(void **state)
 {
     _free_bf_chain_ struct bf_chain *chain = bft_chain_dummy(true);
@@ -340,6 +378,8 @@ int main(void)
         cmocka_unit_test(get_set_from_matcher),
         cmocka_unit_test(mixed_enabled_disabled_log_flag),
         cmocka_unit_test(incompatible_matchers_disable_rule),
+        cmocka_unit_test(sock_addr_log_flag),
+        cmocka_unit_test(invalid_log_opts_for_hook),
         cmocka_unit_test(policy_validation),
         cmocka_unit_test(set_component_unsupported_hook),
         cmocka_unit_test(get_set_by_name),


### PR DESCRIPTION
Stack:
- #485
- #486
- #517
- -> #491

### Summary

This adds the remaining infrastructure to go from the hard-coded packet-specific logging to a flavor-specific logging approach that makes it easy to enable logging for `CGROUP_SOCK_ADDR`:

```
BEFORE                                  AFTER

program.c (hardcoded log emission)      program.c (callback dispatch)
──────────────────────────────────      ────────────────────────────────  
if rule->log:                           if rule->log:
  setup R1-R5 for packet headers          ops->gen_inline_log(program, rule)
  EMIT_FIXUP_ELFSTUB(PKT_LOG)

chain.c:                                Packet flavors (XDP, TC, NF, cgroup_skb)
  cgroup_sock_addr? → -ENOTSUP          ────────────────────────────────  
                                        bf_packet_gen_inline_log():
                                          R1=ctx, R2=rule_id, R3=log_opts,
                                          R4=verdict, R5=packed_protos
                                          → ELFSTUB_PKT_LOG

                                        cgroup_sock_addr.c
                                        ──────────────────────────────── 
                                        gen_inline_log():
                                          R1=ctx, R2=rule_id, R3=verdict,
                                          R4=packed_protos
                                          → ELFSTUB_SOCK_ADDR_LOG
```

We add a new `sock_addr_log` ELF stub, a `gen_inline_log` callback (see #486), CLI formatting for socket log entries, and per-hook log option validation (e.g. `BF_LOG_OPT_LINK` is rejected on socket hooks, `BF_LOG_OPT_PID` is rejected on packet hooks). It also introduces two new log options, `BF_LOG_OPT_PID` and `BF_LOG_OPT_COMM`, which use the `bpf_get_current_pid_tgid()` and `bpf_get_current_comm()` helper calls in the stub.

One of the challenges here is that the BPF verifier restricts which `bpf_sock_addr` context fields a program can access based on its attach type. For example, `msg_src_ip4` is only valid for SENDMSG4 and `user_ip4` is only valid for IPv4 hooks. The verifier checks all code paths statically regardless of runtime reachability, so a shared ELF stub compiled once and linked into all hook types cannot read these fields directly. To solve this, the per-hook inline codegen in the prologue copies the permitted fields into a new `_bf_runtime_sock_addr` struct on the BPF stack, and the stub copies from there into the log entry. The copying is done once per program invocation, guarded by the existing `BF_CHAIN_LOG` flag, so programs without logging rules pay zero cost.

Adding `_bf_runtime_sock_addr` to bf_runtime increases the stack frame for all flavors by 40 bytes (with alignment), but the struct remains well within the BPF 512-byte stack limit.

### Testing
- Manual testing, example `sendmsg6` log:
<img width="381" height="95" alt="Screenshot 2026-04-16 at 8 37 20 PM" src="https://github.com/user-attachments/assets/c233ec94-07b9-40b5-a7c9-41af23444f64" />


## Note
- As mentioned above, the verifier doesn't allow accessing certain paths (ex. `connect4` reading `msg_src_ip6`), so we'll need to add it to the stack frame, similar to how we do with packets. This leads to a new question - we really should have different `bf_runtime` for packet flavors and `CGROUP_SOCK_ADDR` given how different they are and the different data they use (can be done in a similar type of way we did it in `bf_log`, sharing common fields and then using a union). However, I don't think know is the right time to make this invasive change when a less invasive approach works, albeit in a less clean/proper way. Imo we can add this as a follow-up.

Closes #356, #357
