### PR TITLE
Add DSCP class-name keyword support

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -632,6 +632,12 @@ IPv4
       - :rspan:`1` ``$PROTOCOL``
       - :rspan:`1` ``$PROTOCOL`` must be a transport layer protocol name (e.g. "ICMP", case insensitive), or a valid decimal or hexadecimal `internet protocol number`_.
     * - ``not``
+    * - :rspan:`1` DSCP
+      - :rspan:`1` ``ip4.dscp``
+      - ``eq``
+      - :rspan:`1` ``$DSCP``
+      - :rspan:`1` ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
+    * - ``not``
 
 
 IPv6
@@ -675,8 +681,14 @@ IPv6
     * - :rspan:`1` Next header
       - :rspan:`1` ``ip6.nexthdr``
       - ``eq``
-      - :rspan:`3` ``$NEXT_HEADER``
-      - :rspan:`3` ``$NEXT_HEADER`` is a transport layer protocol name (e.g. "ICMP", case insensitive), an IPv6 extension header name, or a valid decimal or hexadecimal `internet protocol number`_.
+      - :rspan:`1` ``$NEXT_HEADER``
+      - :rspan:`1` ``$NEXT_HEADER`` is a transport layer protocol name (e.g. "ICMP", case insensitive), an IPv6 extension header name, or a valid decimal or hexadecimal `internet protocol number`_.
+    * - ``not``
+    * - :rspan:`1` DSCP
+      - :rspan:`1` ``ip6.dscp``
+      - ``eq``
+      - :rspan:`1` ``$DSCP``
+      - :rspan:`1` ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
     * - ``not``
 
 .. tip::
@@ -839,4 +851,5 @@ ICMPv6
 .. _ICMP type value: https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-types
 .. _ICMP code value: https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml#icmp-parameters-codes
 .. _ICMPv6 type value: https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-2
+.. _DSCP class name: https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml
 .. _ICMPv6 code value: https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.xhtml#icmpv6-parameters-3

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -209,7 +209,7 @@ ip4\.dnet       { BEGIN(STATE_MATCHER_IP4_NET); yylval.sval = strdup(yytext); re
 ip4\.dscp       { BEGIN(STATE_MATCHER_IP4_DSCP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP4_DSCP>{
     (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
-    {int} {
+    {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
         return RAW_PAYLOAD;
@@ -239,7 +239,7 @@ ip6\.(s|d)net       { BEGIN(STATE_MATCHER_IP6_NET); yylval.sval = strdup(yytext)
 ip6\.dscp           { BEGIN(STATE_MATCHER_IP6_DSCP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP6_DSCP>{
     (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
-    {int} {
+    {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
         return RAW_PAYLOAD;

--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -424,6 +424,9 @@ int bf_ethertype_from_str(const char *str, uint16_t *ethertype);
 const char *bf_ipproto_to_str(uint8_t ipproto);
 int bf_ipproto_from_str(const char *str, uint8_t *ipproto);
 
+const char *bf_dscp_class_to_str(uint8_t dscp);
+int bf_dscp_class_from_str(const char *str, uint8_t *dscp);
+
 const char *bf_icmp_type_to_str(uint8_t type);
 int bf_icmp_type_from_str(const char *str, uint8_t *type);
 

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -737,6 +737,9 @@ static int _bf_parse_dscp(enum bf_matcher_type type, enum bf_matcher_op op,
     assert(payload);
     assert(raw_payload);
 
+    if (!bf_dscp_class_from_str(raw_payload, payload))
+        return 0;
+
     if (!_bf_strtoul(raw_payload, &value) && value <= BF_DSCP_MAX) {
         *(uint8_t *)payload = (uint8_t)value;
         return 0;
@@ -744,15 +747,22 @@ static int _bf_parse_dscp(enum bf_matcher_type type, enum bf_matcher_op op,
 
     return bf_err_r(
         -EINVAL,
-        "\"%s %s\" expects a DSCP value (0-63) in decimal or hexadecimal notation, not '%s'",
+        "\"%s %s\" expects a DSCP value (0-63, decimal/hex) or class name, not '%s'",
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
 static void _bf_print_dscp(const void *payload)
 {
+    const char *name;
+
     assert(payload);
 
-    (void)fprintf(stdout, "%" PRIu8, *(uint8_t *)payload);
+    name = bf_dscp_class_to_str(*(uint8_t *)payload);
+
+    if (name)
+        (void)fprintf(stdout, "%s", name);
+    else
+        (void)fprintf(stdout, "%" PRIu8, *(uint8_t *)payload);
 }
 
 static int _bf_parse_icmpv6_type(enum bf_matcher_type type,
@@ -1658,6 +1668,46 @@ int bf_ipproto_from_str(const char *str, uint8_t *ipproto)
     for (size_t i = 0; i <= UINT8_MAX; ++i) {
         if (bf_streq_i(str, _bf_ipproto_strs[i])) {
             *ipproto = (uint8_t)i;
+            return 0;
+        }
+    }
+
+    return -EINVAL;
+}
+
+/* DSCP class name to codepoint mapping, based on the IANA DSCP
+ * registry (https://www.iana.org/assignments/dscp-registry).
+ * BE is an alias for CS0. */
+static const struct
+{
+    const char *name;
+    uint8_t dscp;
+} _bf_dscp_classes[] = {
+    {"cs0", 0},   {"cs1", 8},          {"cs2", 16},  {"cs3", 24},  {"cs4", 32},
+    {"cs5", 40},  {"cs6", 48},         {"cs7", 56},  {"af11", 10}, {"af12", 12},
+    {"af13", 14}, {"af21", 18},        {"af22", 20}, {"af23", 22}, {"af31", 26},
+    {"af32", 28}, {"af33", 30},        {"af41", 34}, {"af42", 36}, {"af43", 38},
+    {"ef", 46},   {"voice-admit", 44}, {"le", 1},    {"nqb", 45},  {"be", 0},
+};
+
+const char *bf_dscp_class_to_str(uint8_t dscp)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(_bf_dscp_classes); ++i) {
+        if (_bf_dscp_classes[i].dscp == dscp)
+            return _bf_dscp_classes[i].name;
+    }
+
+    return NULL;
+}
+
+int bf_dscp_class_from_str(const char *str, uint8_t *dscp)
+{
+    assert(str);
+    assert(dscp);
+
+    for (size_t i = 0; i < ARRAY_SIZE(_bf_dscp_classes); ++i) {
+        if (bf_streq_i(str, _bf_dscp_classes[i].name)) {
+            *dscp = _bf_dscp_classes[i].dscp;
             return 0;
         }
     }

--- a/tests/e2e/parsing/ip4_dscp.sh
+++ b/tests/e2e/parsing/ip4_dscp.sh
@@ -19,6 +19,17 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq invalid counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq 0x40 counter DROP")
 
+# Test valid class name keywords
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq ef counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp not cs1 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq AF21 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp not BE counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq voice-admit counter DROP"
+
+# Test invalid class name keywords (should fail)
+(! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq cs8 counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp eq AF14 counter DROP")
+
 # Test with 'not' operator
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp not 0 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.dscp not 16 counter DROP"

--- a/tests/e2e/parsing/ip6_dscp.sh
+++ b/tests/e2e/parsing/ip6_dscp.sh
@@ -20,6 +20,17 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq -0x01 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq 0x40 counter DROP")
 
+# Test valid class name keywords
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq ef counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp not cs1 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq AF21 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp not BE counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq voice-admit counter DROP"
+
+# Test invalid class name keywords (should fail)
+(! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq cs8 counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp eq AF14 counter DROP")
+
 # Test valid decimal values with 'not' operator
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp not 0 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.dscp not 46 counter DROP"

--- a/tests/unit/libbpfilter/matcher.c
+++ b/tests/unit/libbpfilter/matcher.c
@@ -381,6 +381,43 @@ static void ipproto_conversions(void **state)
     assert_err(bf_ipproto_from_str("invalid", &ipproto));
 }
 
+static void dscp_class_conversions(void **state)
+{
+    uint8_t dscp;
+
+    (void)state;
+
+    // Test to_str for known classes
+    assert_string_equal(bf_dscp_class_to_str(0), "cs0");
+    assert_string_equal(bf_dscp_class_to_str(46), "ef");
+
+    // Test to_str for values without a named class
+    assert_null(bf_dscp_class_to_str(63));
+    assert_null(bf_dscp_class_to_str(64));
+
+    // Test from_str
+    assert_ok(bf_dscp_class_from_str("ef", &dscp));
+    assert_int_equal(dscp, 46);
+
+    assert_ok(bf_dscp_class_from_str("af21", &dscp));
+    assert_int_equal(dscp, 18);
+
+    // Test BE alias and case insensitivity
+    assert_ok(bf_dscp_class_from_str("BE", &dscp));
+    assert_int_equal(dscp, 0);
+
+    assert_ok(bf_dscp_class_from_str("Af11", &dscp));
+    assert_int_equal(dscp, 10);
+
+    assert_ok(bf_dscp_class_from_str("VOICE-ADMIT", &dscp));
+    assert_int_equal(dscp, 44);
+
+    // Test invalid
+    assert_err(bf_dscp_class_from_str("cs8", &dscp));
+    assert_err(bf_dscp_class_from_str("af14", &dscp));
+    assert_err(bf_dscp_class_from_str("invalid", &dscp));
+}
+
 static void icmp_type_conversions(void **state)
 {
     uint8_t type;
@@ -1111,6 +1148,20 @@ static void ip6_dscp(void **state)
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
+    // Test with class name keyword
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
+                                      BF_MATCHER_EQ, "ef"));
+    assert_non_null(matcher);
+    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
+    bf_matcher_free(&matcher);
+
+    // Test with BE alias (case insensitive)
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
+                                      BF_MATCHER_EQ, "BE"));
+    assert_non_null(matcher);
+    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
+    bf_matcher_free(&matcher);
+
     // Test print function via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
                                       BF_MATCHER_EQ, "0x20"));
@@ -1130,9 +1181,9 @@ static void ip6_dscp_invalid(void **state)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
                                        BF_MATCHER_EQ, "64"));
 
-    // Test with invalid string
+    // Test with invalid class name
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                       BF_MATCHER_EQ, "not_a_number"));
+                                       BF_MATCHER_EQ, "cs8"));
 
     // Test with negative value
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
@@ -1573,6 +1624,20 @@ static void ip4_dscp(void **state)
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
+    // Test ip4.dscp with class name keyword
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
+                                      BF_MATCHER_EQ, "ef"));
+    assert_non_null(matcher);
+    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
+    bf_matcher_free(&matcher);
+
+    // Test ip4.dscp with BE alias (case insensitive)
+    assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
+                                      BF_MATCHER_EQ, "BE"));
+    assert_non_null(matcher);
+    assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
+    bf_matcher_free(&matcher);
+
     // Test ip4.dscp print function
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
                                       BF_MATCHER_EQ, "0x3f"));
@@ -1588,6 +1653,10 @@ static void ip4_dscp(void **state)
     // Test ip4.dscp with invalid hex value (> 0x3f)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
                                        BF_MATCHER_EQ, "0x40"));
+
+    // Test ip4.dscp with invalid class name
+    assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
+                                       BF_MATCHER_EQ, "cs8"));
 
     // Test ip4.dscp with invalid string
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
@@ -1738,6 +1807,7 @@ int main(void)
         cmocka_unit_test(tcp_flag_conversions),
         cmocka_unit_test(ethertype_conversions),
         cmocka_unit_test(ipproto_conversions),
+        cmocka_unit_test(dscp_class_conversions),
         cmocka_unit_test(icmp_type_conversions),
         cmocka_unit_test(icmpv6_type_conversions),
         cmocka_unit_test(get_meta),


### PR DESCRIPTION
As mentioned in #383, add support for DSCP class name keywords in `ip4.dscp` and `ip6.dscp` matchers. Instead of requiring users to memorize numeric DSCP codepoints, rules can now use standard class names:
```
ip4.dscp eq ef
ip6.dscp not cs1
ip4.dscp eq af21
```

Supported keywords follow the [IANA DSCP registry](https://www.iana.org/assignments/dscp-registry/dscp-registry.xhtml) and match iptables conventions (see [`dscp_helper.c`](https://git.netfilter.org/iptables/tree/extensions/dscp_helper.c)):
- CS0–CS7 (Class Selector)
- AF11–AF43 (Assured Forwarding)
- EF (Expedited Forwarding)
- BE (Best Effort, alias for CS0)

Keywords are case-insensitive. Numeric values (0–63, decimal or hex) continue to work as before.

### Testing
- Unit + e2e tests
- Manual Testing