### PR TITLE
Add `CGROUP_SOCK_ADDR` Set Support

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -360,7 +360,7 @@ With:
 
   .. note::
 
-      ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks operate on socket metadata rather than packet data. Supported matchers: ``meta.l3_proto``, ``meta.l4_proto``, ``meta.probability``, ``meta.dport``, ``ip4.daddr``, ``ip4.dnet``, ``ip4.proto``, ``ip6.daddr``, ``ip6.dnet``, ``udp.dport``. Connect hooks additionally support ``tcp.dport``. Sendmsg hooks additionally support ``ip4.saddr``, ``ip4.snet``, ``ip6.saddr``, and ``ip6.snet``.
+      ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks operate on socket metadata rather than packet data. Supported matchers: ``meta.l3_proto``, ``meta.l4_proto``, ``meta.probability``, ``meta.dport``, ``ip4.daddr``, ``ip4.dnet``, ``ip4.proto``, ``ip6.daddr``, ``ip6.dnet``, ``udp.dport``. Connect hooks additionally support ``tcp.dport``. Sendmsg hooks additionally support ``ip4.saddr``, ``ip4.snet``, ``ip6.saddr``, and ``ip6.snet``. Sets are supported with the same per-component restrictions: each set key component must be a matcher supported by the chain's hook. Note that ``meta.dport`` and ``meta.sport`` are not supported in sets.
 
   - ``$POLICY``: action taken if no rule matches the packet:
 
@@ -667,16 +667,21 @@ IPv6
       - Operator
       - Payload
       - Notes
-    * - :rspan:`1` Source address
-      - :rspan:`1` ``ip6.saddr``
+    * - :rspan:`2` Source address
+      - :rspan:`2` ``ip6.saddr``
       - ``eq``
-      - :rspan:`3` ``$ADDR``
-      - :rspan:`3` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported). To filter on an IPv6 network (using an IPv6 address and a subnet mask), see ``ip6.snet`` or ``ip6.dnet``.
+      - :rspan:`1` ``$ADDR``
+      - :rspan:`5` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported). To filter on an IPv6 network (using an IPv6 address and a subnet mask), see ``ip6.snet`` or ``ip6.dnet``.
     * - ``not``
-    * - :rspan:`1` Destination address
-      - :rspan:`1` ``ip6.daddr``
+    * - ``in``
+      - ``{$ADDR[,...]}``
+    * - :rspan:`2` Destination address
+      - :rspan:`2` ``ip6.daddr``
       - ``eq``
+      - :rspan:`1` ``$ADDR``
     * - ``not``
+    * - ``in``
+      - ``{$ADDR[,...]}``
     * - :rspan:`2` Source network
       - :rspan:`2` ``ip6.snet``
       - ``eq``

--- a/src/libbpfilter/cgen/cgroup_sock_addr.c
+++ b/src/libbpfilter/cgen/cgroup_sock_addr.c
@@ -14,15 +14,19 @@
 #include <stdint.h>
 #include <sys/socket.h>
 
+#include <bpfilter/chain.h>
 #include <bpfilter/flavor.h>
 #include <bpfilter/logger.h>
 #include <bpfilter/matcher.h>
 #include <bpfilter/runtime.h>
+#include <bpfilter/set.h>
 #include <bpfilter/verdict.h>
 
 #include "cgen/matcher/cmp.h"
 #include "cgen/matcher/meta.h"
+#include "cgen/matcher/set.h"
 #include "cgen/program.h"
+#include "cgen/stub.h"
 #include "cgen/swich.h"
 #include "filter.h"
 
@@ -204,6 +208,110 @@ static int _bf_cgroup_sock_addr_generate_port(struct bf_program *program,
                         bf_matcher_payload(matcher), 2, BPF_REG_1);
 }
 
+static ssize_t _bf_cgroup_sock_addr_ctx_offset(enum bf_matcher_type type)
+{
+    switch (type) {
+    case BF_MATCHER_IP4_SADDR:
+    case BF_MATCHER_IP4_SNET:
+        return offsetof(struct bpf_sock_addr, msg_src_ip4);
+    case BF_MATCHER_IP4_DADDR:
+    case BF_MATCHER_IP4_DNET:
+        return offsetof(struct bpf_sock_addr, user_ip4);
+    case BF_MATCHER_IP6_SADDR:
+    case BF_MATCHER_IP6_SNET:
+        return offsetof(struct bpf_sock_addr, msg_src_ip6);
+    case BF_MATCHER_IP6_DADDR:
+    case BF_MATCHER_IP6_DNET:
+        return offsetof(struct bpf_sock_addr, user_ip6);
+    case BF_MATCHER_IP4_PROTO:
+        return offsetof(struct bpf_sock_addr, protocol);
+    case BF_MATCHER_TCP_DPORT:
+    case BF_MATCHER_UDP_DPORT:
+        return offsetof(struct bpf_sock_addr, user_port);
+    default:
+        return -ENOTSUP;
+    }
+}
+
+static int _bf_cgroup_sock_addr_generate_set(struct bf_program *program,
+                                             const struct bf_matcher *matcher)
+{
+    const struct bf_set *set;
+    size_t offset = 0;
+    int r;
+
+    assert(program);
+    assert(matcher);
+
+    set = bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
+    if (!set) {
+        return bf_err_r(-ENOENT, "set #%u not found in %s",
+                        *(uint32_t *)bf_matcher_payload(matcher),
+                        program->runtime.chain->name);
+    }
+
+    if (set->use_trie) {
+        const struct bf_matcher_meta *meta = bf_matcher_get_meta(set->key[0]);
+        ssize_t ctx_off = _bf_cgroup_sock_addr_ctx_offset(set->key[0]);
+
+        if (!meta) {
+            return bf_err_r(-EINVAL, "missing meta for set component '%s'",
+                            bf_matcher_type_to_str(set->key[0]));
+        }
+
+        if (ctx_off < 0) {
+            return bf_err_r(
+                (int)ctx_off,
+                "set component '%s' not supported for cgroup_sock_addr",
+                bf_matcher_type_to_str(set->key[0]));
+        }
+
+        return bf_set_generate_trie_lookup(program, matcher, (size_t)ctx_off,
+                                           meta->hdr_payload_size);
+    }
+
+    for (size_t i = 0; i < set->n_comps; ++i) {
+        enum bf_matcher_type type = set->key[i];
+        const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
+        ssize_t ctx_off = _bf_cgroup_sock_addr_ctx_offset(type);
+
+        if (!meta) {
+            return bf_err_r(-EINVAL, "missing meta for set component '%s'",
+                            bf_matcher_type_to_str(type));
+        }
+
+        if (ctx_off < 0) {
+            return bf_err_r(
+                (int)ctx_off,
+                "set component '%s' not supported for cgroup_sock_addr",
+                bf_matcher_type_to_str(type));
+        }
+
+        /* The BPF verifier enforces specific ctx access widths on
+         * `bpf_sock_addr` fields. `bf_stub_load()` reads
+         * `meta->hdr_payload_size` bytes from ctx:
+         *   - Ports (`hdr_payload_size == 2`): `user_port` is a 4-byte
+         *     `__u32`, but the 2-byte narrow read is accepted and rewritten
+         *     to the NBO port value.
+         *   - Protocol (`hdr_payload_size == 1`): only 4-byte reads are
+         *     allowed, so a 1-byte `bf_stub_load()` would be rejected. Reuse
+         *     `BPF_REG_8`, which the prologue loaded with a 4-byte read. */
+        if (type == BF_MATCHER_IP4_PROTO) {
+            EMIT(program, BPF_STX_MEM(BPF_B, BPF_REG_10, BPF_REG_8,
+                                      BF_PROG_SCR_OFF(offset)));
+        } else {
+            r = bf_stub_load(program, (size_t)ctx_off, meta->hdr_payload_size,
+                             BF_PROG_SCR_OFF(offset));
+            if (r)
+                return r;
+        }
+
+        offset += meta->hdr_payload_size;
+    }
+
+    return bf_set_generate_map_lookup(program, matcher, BF_PROG_SCR_OFF(0));
+}
+
 static int
 _bf_cgroup_sock_addr_gen_inline_matcher(struct bf_program *program,
                                         const struct bf_matcher *matcher)
@@ -248,6 +356,8 @@ _bf_cgroup_sock_addr_gen_inline_matcher(struct bf_program *program,
     case BF_MATCHER_TCP_DPORT:
     case BF_MATCHER_UDP_DPORT:
         return _bf_cgroup_sock_addr_generate_port(program, matcher);
+    case BF_MATCHER_SET:
+        return _bf_cgroup_sock_addr_generate_set(program, matcher);
     default:
         return bf_err_r(-ENOTSUP,
                         "matcher '%s' not supported for cgroup_sock_addr",

--- a/src/libbpfilter/cgen/matcher/set.c
+++ b/src/libbpfilter/cgen/matcher/set.c
@@ -5,9 +5,7 @@
 
 #include "cgen/matcher/set.h"
 
-#include <bpfilter/chain.h>
 #include <bpfilter/matcher.h>
-#include <bpfilter/set.h>
 
 #include "cgen/program.h"
 #include "cgen/stub.h"
@@ -48,58 +46,4 @@ int bf_set_generate_trie_lookup(struct bf_program *program,
         return r;
 
     return bf_set_generate_map_lookup(program, matcher, BF_PROG_SCR_OFF(4));
-}
-
-int bf_matcher_generate_set(struct bf_program *program,
-                            const struct bf_matcher *matcher)
-{
-    assert(program);
-    assert(matcher);
-
-    const struct bf_set *set =
-        bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
-    size_t offset = 0;
-    int r;
-
-    if (!set) {
-        return bf_err_r(-ENOENT, "set #%u not found in %s",
-                        *(uint32_t *)bf_matcher_payload(matcher),
-                        program->runtime.chain->name);
-    }
-
-    if (set->use_trie) {
-        const struct bf_matcher_meta *meta = bf_matcher_get_meta(set->key[0]);
-
-        r = bf_stub_load_header(program, meta, BPF_REG_6);
-        if (r)
-            return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
-
-        return bf_set_generate_trie_lookup(
-            program, matcher, meta->hdr_payload_offset, meta->hdr_payload_size);
-    }
-
-    // Generate the bytecode to build the set key
-    for (size_t i = 0; i < set->n_comps; ++i) {
-        enum bf_matcher_type type = set->key[i];
-        const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
-
-        if (!meta) {
-            return bf_err_r(-ENOENT, "meta for '%s' not found",
-                            bf_matcher_type_to_str(type));
-        }
-
-        r = bf_stub_load_header(program, meta, BPF_REG_6);
-        if (r)
-            return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
-
-        r = bf_stub_stx_payload(program, meta, offset);
-        if (r) {
-            return bf_err_r(r,
-                            "failed to generate bytecode to load packet data");
-        }
-
-        offset += meta->hdr_payload_size;
-    }
-
-    return bf_set_generate_map_lookup(program, matcher, 0);
 }

--- a/src/libbpfilter/cgen/matcher/set.c
+++ b/src/libbpfilter/cgen/matcher/set.c
@@ -70,31 +70,12 @@ int bf_matcher_generate_set(struct bf_program *program,
     if (set->use_trie) {
         const struct bf_matcher_meta *meta = bf_matcher_get_meta(set->key[0]);
 
-        r = bf_stub_rule_check_protocol(program, meta);
-        if (r)
-            return bf_err_r(r, "failed to check for protocol");
-
         r = bf_stub_load_header(program, meta, BPF_REG_6);
         if (r)
             return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
 
         return bf_set_generate_trie_lookup(
             program, matcher, meta->hdr_payload_offset, meta->hdr_payload_size);
-    }
-
-    // Ensure the packet uses the required protocols
-    for (size_t i = 0; i < set->n_comps; ++i) {
-        enum bf_matcher_type type = set->key[i];
-        const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
-
-        if (!meta) {
-            return bf_err_r(-ENOENT, "meta for '%s' not found",
-                            bf_matcher_type_to_str(type));
-        }
-
-        r = bf_stub_rule_check_protocol(program, meta);
-        if (r)
-            return bf_err_r(r, "failed to check for protocol");
     }
 
     // Generate the bytecode to build the set key

--- a/src/libbpfilter/cgen/matcher/set.c
+++ b/src/libbpfilter/cgen/matcher/set.c
@@ -12,70 +12,42 @@
 #include "cgen/program.h"
 #include "cgen/stub.h"
 
-static int _bf_matcher_generate_set_trie(struct bf_program *program,
-                                         const struct bf_matcher *matcher)
+int bf_set_generate_map_lookup(struct bf_program *program,
+                               const struct bf_matcher *matcher, int key_offset)
 {
     assert(program);
     assert(matcher);
 
-    const struct bf_set *set =
-        bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
-    enum bf_matcher_type type = set->key[0];
-    const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
-    int r;
-
-    if (!set) {
-        return bf_err_r(-ENOENT, "set #%u not found in %s",
-                        *(uint32_t *)bf_matcher_payload(matcher),
-                        program->runtime.chain->name);
-    }
-
-    r = bf_stub_rule_check_protocol(program, meta);
-    if (r)
-        return bf_err_r(r, "failed to check for protocol");
-
-    r = bf_stub_load_header(program, meta, BPF_REG_6);
-    if (r)
-        return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
-
-    if (BF_FLAG(type) & (BF_FLAGS(BF_MATCHER_IP4_SNET, BF_MATCHER_IP4_DNET))) {
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_1, 32));
-        EMIT(program,
-             BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(4)));
-        EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_6,
-                                  meta->hdr_payload_offset));
-        EMIT(program,
-             BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(8)));
-    } else if (BF_FLAG(type) &
-               (BF_FLAGS(BF_MATCHER_IP6_SNET, BF_MATCHER_IP6_DNET))) {
-        EMIT(program, BPF_MOV64_IMM(BPF_REG_1, 128));
-        EMIT(program,
-             BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(4)));
-
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_6,
-                                  meta->hdr_payload_offset));
-        EMIT(program,
-             BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(8)));
-
-        EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_6,
-                                  meta->hdr_payload_offset + 8));
-        EMIT(program,
-             BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(16)));
-    } else {
-        return bf_err_r(-EINVAL,
-                        "set key '%s' (%d) should not use a LPM trie map",
-                        bf_matcher_type_to_str(type), type);
-    }
-
     EMIT_LOAD_SET_FD_FIXUP(program, BPF_REG_1,
                            *(uint32_t *)bf_matcher_payload(matcher));
     EMIT(program, BPF_MOV64_REG(BPF_REG_2, BPF_REG_10));
-    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, BF_PROG_SCR_OFF(4)));
+    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, key_offset));
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_map_lookup_elem));
 
     // Jump to the next rule if map_lookup_elem returned 0
     EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
+
     return 0;
+}
+
+int bf_set_generate_trie_lookup(struct bf_program *program,
+                                const struct bf_matcher *matcher,
+                                size_t src_offset, size_t addr_size)
+{
+    int r;
+
+    assert(program);
+    assert(matcher);
+
+    EMIT(program, BPF_MOV64_IMM(BPF_REG_1, (uint32_t)(addr_size * 8)));
+    EMIT(program,
+         BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_1, BF_PROG_SCR_OFF(4)));
+
+    r = bf_stub_load(program, src_offset, addr_size, BF_PROG_SCR_OFF(8));
+    if (r)
+        return r;
+
+    return bf_set_generate_map_lookup(program, matcher, BF_PROG_SCR_OFF(4));
 }
 
 int bf_matcher_generate_set(struct bf_program *program,
@@ -95,8 +67,20 @@ int bf_matcher_generate_set(struct bf_program *program,
                         program->runtime.chain->name);
     }
 
-    if (set->use_trie)
-        return _bf_matcher_generate_set_trie(program, matcher);
+    if (set->use_trie) {
+        const struct bf_matcher_meta *meta = bf_matcher_get_meta(set->key[0]);
+
+        r = bf_stub_rule_check_protocol(program, meta);
+        if (r)
+            return bf_err_r(r, "failed to check for protocol");
+
+        r = bf_stub_load_header(program, meta, BPF_REG_6);
+        if (r)
+            return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
+
+        return bf_set_generate_trie_lookup(
+            program, matcher, meta->hdr_payload_offset, meta->hdr_payload_size);
+    }
 
     // Ensure the packet uses the required protocols
     for (size_t i = 0; i < set->n_comps; ++i) {
@@ -136,14 +120,5 @@ int bf_matcher_generate_set(struct bf_program *program,
         offset += meta->hdr_payload_size;
     }
 
-    EMIT_LOAD_SET_FD_FIXUP(program, BPF_REG_1,
-                           *(uint32_t *)bf_matcher_payload(matcher));
-    EMIT(program, BPF_MOV64_REG(BPF_REG_2, BPF_REG_10));
-    EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, BF_PROG_SCR_OFF(0)));
-    EMIT(program, BPF_EMIT_CALL(BPF_FUNC_map_lookup_elem));
-
-    // Jump to the next rule if map_lookup_elem returned 0
-    EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
-
-    return 0;
+    return bf_set_generate_map_lookup(program, matcher, 0);
 }

--- a/src/libbpfilter/cgen/matcher/set.h
+++ b/src/libbpfilter/cgen/matcher/set.h
@@ -46,6 +46,3 @@ int bf_set_generate_map_lookup(struct bf_program *program,
 int bf_set_generate_trie_lookup(struct bf_program *program,
                                 const struct bf_matcher *matcher,
                                 size_t src_offset, size_t addr_size);
-
-int bf_matcher_generate_set(struct bf_program *program,
-                            const struct bf_matcher *matcher);

--- a/src/libbpfilter/cgen/matcher/set.h
+++ b/src/libbpfilter/cgen/matcher/set.h
@@ -5,8 +5,47 @@
 
 #pragma once
 
+#include <stddef.h>
+
 struct bf_matcher;
 struct bf_program;
+
+/**
+ * @brief Generate the map-lookup sequence shared by all set codegen paths.
+ *
+ * Emits: load set FD, compute key pointer, call `bpf_map_lookup_elem`,
+ * jump to next rule if the lookup returns NULL.
+ *
+ * @param program Program to emit into. Can't be NULL.
+ * @param matcher Set matcher (carries the set index in its payload).
+ *        Can't be NULL.
+ * @param key_offset Byte offset from `R10` (stack pointer) where the key
+ *        starts. Use `BF_PROG_SCR_OFF()` for scratch area offsets.
+ * @return 0 on success, or negative errno on error.
+ */
+int bf_set_generate_map_lookup(struct bf_program *program,
+                               const struct bf_matcher *matcher,
+                               int key_offset);
+
+/**
+ * @brief Generate a complete LPM trie key and map lookup.
+ *
+ * Writes prefixlen (`addr_size * 8`) at `scratch[4]`, copies `addr_size` bytes
+ * from `R6 + src_offset` to `scratch[8]` via `bf_stub_load`, then calls
+ * `bf_set_generate_map_lookup` with key at `scratch[4]`.
+ *
+ * `R6` must already point to the base of the data (header pointer for
+ * packet flavors, ctx pointer for `cgroup_sock_addr`).
+ *
+ * @param program Program to emit into. Can't be NULL.
+ * @param matcher Set matcher (carries the set index). Can't be NULL.
+ * @param src_offset Byte offset from `R6` where the address starts.
+ * @param addr_size Size of the address in bytes (4 for IPv4, 16 for IPv6).
+ * @return 0 on success, or negative errno on error.
+ */
+int bf_set_generate_trie_lookup(struct bf_program *program,
+                                const struct bf_matcher *matcher,
+                                size_t src_offset, size_t addr_size);
 
 int bf_matcher_generate_set(struct bf_program *program,
                             const struct bf_matcher *matcher);

--- a/src/libbpfilter/cgen/packet.c
+++ b/src/libbpfilter/cgen/packet.c
@@ -14,11 +14,13 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <bpfilter/chain.h>
 #include <bpfilter/elfstub.h>
 #include <bpfilter/helper.h>
 #include <bpfilter/logger.h>
 #include <bpfilter/matcher.h>
 #include <bpfilter/rule.h>
+#include <bpfilter/set.h>
 
 #include "cgen/matcher/cmp.h"
 #include "cgen/matcher/meta.h"
@@ -299,6 +301,64 @@ static int _bf_matcher_pkt_generate_ip6_dscp(struct bf_program *program,
     return 0;
 }
 
+static int _bf_matcher_pkt_generate_set(struct bf_program *program,
+                                        const struct bf_matcher *matcher)
+{
+    const struct bf_set *set;
+    size_t offset = 0;
+    int r;
+
+    assert(program);
+    assert(matcher);
+
+    set = bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
+    if (!set) {
+        return bf_err_r(-ENOENT, "set #%u not found in %s",
+                        *(uint32_t *)bf_matcher_payload(matcher),
+                        program->runtime.chain->name);
+    }
+
+    if (set->use_trie) {
+        const struct bf_matcher_meta *meta = bf_matcher_get_meta(set->key[0]);
+
+        if (!meta) {
+            return bf_err_r(-EINVAL, "missing meta for '%s'",
+                            bf_matcher_type_to_str(set->key[0]));
+        }
+
+        r = bf_stub_load_header(program, meta, BPF_REG_6);
+        if (r)
+            return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
+
+        return bf_set_generate_trie_lookup(
+            program, matcher, meta->hdr_payload_offset, meta->hdr_payload_size);
+    }
+
+    for (size_t i = 0; i < set->n_comps; ++i) {
+        enum bf_matcher_type type = set->key[i];
+        const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
+
+        if (!meta) {
+            return bf_err_r(-EINVAL, "missing meta for '%s'",
+                            bf_matcher_type_to_str(type));
+        }
+
+        r = bf_stub_load_header(program, meta, BPF_REG_6);
+        if (r)
+            return bf_err_r(r, "failed to load protocol header into BPF_REG_6");
+
+        r = bf_stub_stx_payload(program, meta, offset);
+        if (r) {
+            return bf_err_r(r,
+                            "failed to generate bytecode to load packet data");
+        }
+
+        offset += meta->hdr_payload_size;
+    }
+
+    return bf_set_generate_map_lookup(program, matcher, BF_PROG_SCR_OFF(0));
+}
+
 int bf_packet_gen_inline_matcher(struct bf_program *program,
                                  const struct bf_matcher *matcher)
 {
@@ -352,7 +412,7 @@ int bf_packet_gen_inline_matcher(struct bf_program *program,
     case BF_MATCHER_IP6_DSCP:
         return _bf_matcher_pkt_generate_ip6_dscp(program, matcher, meta);
     case BF_MATCHER_SET:
-        return bf_matcher_generate_set(program, matcher);
+        return _bf_matcher_pkt_generate_set(program, matcher);
     default:
         return bf_err_r(-EINVAL, "unknown matcher type %d",
                         bf_matcher_get_type(matcher));

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -279,12 +279,40 @@ static int _bf_program_fixup(struct bf_program *program,
     return 0;
 }
 
+static int _bf_program_check_proto(struct bf_program *program,
+                                   enum bf_matcher_type type,
+                                   uint32_t *checked_layers)
+{
+    const struct bf_matcher_meta *meta;
+
+    assert(program);
+    assert(checked_layers);
+
+    meta = bf_matcher_get_meta(type);
+    if (!meta)
+        return bf_err_r(-EINVAL, "missing meta for matcher type %d", type);
+
+    if (*checked_layers & BF_FLAG(meta->layer))
+        return 0;
+
+    if (meta->layer == BF_MATCHER_LAYER_2 ||
+        meta->layer == BF_MATCHER_LAYER_3 ||
+        meta->layer == BF_MATCHER_LAYER_4) {
+        int r = bf_stub_rule_check_protocol(program, meta);
+        if (r)
+            return r;
+        *checked_layers |= BF_FLAG(meta->layer);
+    }
+
+    return 0;
+}
+
 static int _bf_program_generate_rule(struct bf_program *program,
                                      struct bf_rule *rule)
 {
     uint32_t checked_layers = 0;
     int ret_code;
-    int r;
+    int r = 0;
 
     assert(program);
     assert(rule);
@@ -296,28 +324,27 @@ static int _bf_program_generate_rule(struct bf_program *program,
 
     bf_list_foreach (&rule->matchers, matcher_node) {
         struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
-        const struct bf_matcher_meta *meta =
-            bf_matcher_get_meta(bf_matcher_get_type(matcher));
 
-        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET)
-            continue;
+        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET) {
+            const struct bf_set *set =
+                bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
 
-        if (!meta) {
-            return bf_err_r(-EINVAL, "missing meta for matcher type %d",
-                            bf_matcher_get_type(matcher));
+            if (!set) {
+                return bf_err_r(-ENOENT, "rule %u references non-existent set",
+                                rule->index);
+            }
+
+            for (size_t i = 0; i < set->n_comps && !r; ++i) {
+                r = _bf_program_check_proto(program, set->key[i],
+                                            &checked_layers);
+            }
+        } else {
+            r = _bf_program_check_proto(program, bf_matcher_get_type(matcher),
+                                        &checked_layers);
         }
 
-        if (checked_layers & BF_FLAG(meta->layer))
-            continue;
-
-        if (meta->layer == BF_MATCHER_LAYER_2 ||
-            meta->layer == BF_MATCHER_LAYER_3 ||
-            meta->layer == BF_MATCHER_LAYER_4) {
-            r = bf_stub_rule_check_protocol(program, meta);
-            if (r)
-                return r;
-            checked_layers |= BF_FLAG(meta->layer);
-        }
+        if (r)
+            return r;
     }
 
     bf_list_foreach (&rule->matchers, matcher_node) {

--- a/src/libbpfilter/cgen/stub.c
+++ b/src/libbpfilter/cgen/stub.c
@@ -439,40 +439,50 @@ int bf_stub_load_header(struct bf_program *program,
     return 0;
 }
 
+int bf_stub_load(struct bf_program *program, size_t src_offset, size_t size,
+                 int dst_offset)
+{
+    size_t src_off = src_offset;
+    int dst_off = dst_offset;
+    size_t remaining_size = size;
+
+    assert(program);
+
+    while (remaining_size) {
+        int bpf_size = BPF_B;
+        size_t copy_bytes = 1;
+
+        if (BF_ALIGNED_64(src_off) && BF_ALIGNED_64(dst_off) &&
+            remaining_size >= 8) {
+            bpf_size = BPF_DW;
+            copy_bytes = 8;
+        } else if (BF_ALIGNED_32(src_off) && BF_ALIGNED_32(dst_off) &&
+                   remaining_size >= 4) {
+            bpf_size = BPF_W;
+            copy_bytes = 4;
+        } else if (BF_ALIGNED_16(src_off) && BF_ALIGNED_16(dst_off) &&
+                   remaining_size >= 2) {
+            bpf_size = BPF_H;
+            copy_bytes = 2;
+        }
+
+        EMIT(program, BPF_LDX_MEM(bpf_size, BPF_REG_1, BPF_REG_6, src_off));
+        EMIT(program, BPF_STX_MEM(bpf_size, BPF_REG_10, BPF_REG_1, dst_off));
+
+        remaining_size -= copy_bytes;
+        src_off += copy_bytes;
+        dst_off += (int)copy_bytes;
+    }
+
+    return 0;
+}
+
 int bf_stub_stx_payload(struct bf_program *program,
                         const struct bf_matcher_meta *meta, size_t offset)
 {
     assert(program);
     assert(meta);
 
-    size_t remaining_size = meta->hdr_payload_size;
-    size_t src_offset = 0;
-    size_t dst_offset = offset;
-
-    while (remaining_size) {
-        int bpf_size = BPF_B;
-        size_t copy_bytes = 1;
-
-        if (BF_ALIGNED_64(offset) && remaining_size >= 8) {
-            bpf_size = BPF_DW;
-            copy_bytes = 8;
-        } else if (BF_ALIGNED_32(offset) && remaining_size >= 4) {
-            bpf_size = BPF_W;
-            copy_bytes = 4;
-        } else if (BF_ALIGNED_16(offset) && remaining_size >= 2) {
-            bpf_size = BPF_H;
-            copy_bytes = 2;
-        }
-
-        EMIT(program, BPF_LDX_MEM(bpf_size, BPF_REG_1, BPF_REG_6,
-                                  meta->hdr_payload_offset + src_offset));
-        EMIT(program, BPF_STX_MEM(bpf_size, BPF_REG_10, BPF_REG_1,
-                                  BF_PROG_SCR_OFF(dst_offset)));
-
-        remaining_size -= copy_bytes;
-        src_offset += copy_bytes;
-        dst_offset += copy_bytes;
-    }
-
-    return 0;
+    return bf_stub_load(program, meta->hdr_payload_offset,
+                        meta->hdr_payload_size, BF_PROG_SCR_OFF(offset));
 }

--- a/src/libbpfilter/cgen/stub.h
+++ b/src/libbpfilter/cgen/stub.h
@@ -117,5 +117,22 @@ int bf_stub_rule_check_protocol(struct bf_program *program,
 int bf_stub_load_header(struct bf_program *program,
                         const struct bf_matcher_meta *meta, int reg);
 
+/**
+ * @brief Copy bytes from `R6 + src_offset` to `R10 + dst_offset`.
+ *
+ * The access size per iteration is determined by checking alignment of both
+ * source and destination offsets (both advance each iteration), picking the
+ * largest width where both are aligned and remaining >= width.
+ *
+ * @param program Program to emit the instructions into. Can't be NULL.
+ * @param src_offset Byte offset from `R6` to start reading from.
+ * @param size Number of bytes to copy.
+ * @param dst_offset Byte offset from `R10` (stack pointer) to write to. Use
+ *        `BF_PROG_SCR_OFF()` for scratch area offsets.
+ * @return 0 on success, or negative error value on error.
+ */
+int bf_stub_load(struct bf_program *program, size_t src_offset, size_t size,
+                 int dst_offset);
+
 int bf_stub_stx_payload(struct bf_program *program,
                         const struct bf_matcher_meta *meta, size_t offset);

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -61,6 +61,40 @@ static int _bf_rule_references_empty_set(const struct bf_chain *chain,
 }
 
 /**
+ * @brief Check a single matcher type against per-layer header tracking.
+ *
+ * @param type Matcher type to check.
+ * @param layer_hdr_id Per-layer header ID tracking array.
+ * @return 0 if compatible, 1 if incompatible, negative errno on error.
+ */
+static int _bf_rule_check_layer(enum bf_matcher_type type,
+                                uint32_t layer_hdr_id[_BF_MATCHER_LAYER_MAX])
+{
+    const struct bf_matcher_meta *meta;
+
+    assert(layer_hdr_id);
+
+    meta = bf_matcher_get_meta(type);
+    if (!meta) {
+        return bf_err_r(-EINVAL, "missing meta for '%s'",
+                        bf_matcher_type_to_str(type));
+    }
+
+    if (meta->layer <= BF_MATCHER_NO_LAYER)
+        return 0;
+
+    if (layer_hdr_id[meta->layer] == UINT32_MAX) {
+        layer_hdr_id[meta->layer] = meta->hdr_id;
+        return 0;
+    }
+
+    if (layer_hdr_id[meta->layer] != meta->hdr_id)
+        return 1;
+
+    return 0;
+}
+
+/**
  * @brief Check if a rule has matchers on the same layer but different
  * protocols.
  *
@@ -68,14 +102,17 @@ static int _bf_rule_references_empty_set(const struct bf_chain *chain,
  * address can never match a packet (a packet is either IPv4 or IPv6, not
  * both). Same for layer 4 (e.g. TCP vs UDP). Such rules should be disabled.
  *
+ * @param chain Chain containing the sets list.
  * @param rule Rule to check.
  * @return 0 if no conflict, 1 if the rule contains incompatible matchers, or
  *         a negative errno value on failure.
  */
-static int _bf_rule_has_incompatible_matchers(const struct bf_rule *rule)
+static int _bf_rule_has_incompatible_matchers(const struct bf_chain *chain,
+                                              const struct bf_rule *rule)
 {
     uint32_t layer_hdr_id[_BF_MATCHER_LAYER_MAX];
 
+    assert(chain);
     assert(rule);
 
     for (int i = 0; i < _BF_MATCHER_LAYER_MAX; ++i)
@@ -83,26 +120,27 @@ static int _bf_rule_has_incompatible_matchers(const struct bf_rule *rule)
 
     bf_list_foreach (&rule->matchers, matcher_node) {
         struct bf_matcher *matcher = bf_list_node_get_data(matcher_node);
-        const struct bf_matcher_meta *meta;
+        int r = 0;
 
-        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET)
-            continue;
+        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET) {
+            const struct bf_set *set =
+                bf_chain_get_set_for_matcher(chain, matcher);
 
-        meta = bf_matcher_get_meta(bf_matcher_get_type(matcher));
-        if (!meta) {
-            return bf_err_r(
-                -ENOENT, "missing bf_matcher_meta for %s",
-                bf_matcher_type_to_str(bf_matcher_get_type(matcher)));
+            if (!set) {
+                return bf_err_r(-ENOENT, "rule %u references non-existent set",
+                                rule->index);
+            }
+
+            for (size_t i = 0; i < set->n_comps && !r; ++i)
+                r = _bf_rule_check_layer(set->key[i], layer_hdr_id);
+        } else {
+            r = _bf_rule_check_layer(bf_matcher_get_type(matcher),
+                                     layer_hdr_id);
         }
-        if (meta->layer <= BF_MATCHER_NO_LAYER)
-            continue;
 
-        if (layer_hdr_id[meta->layer] == UINT32_MAX) {
-            layer_hdr_id[meta->layer] = meta->hdr_id;
-            continue;
-        }
-
-        if (layer_hdr_id[meta->layer] != meta->hdr_id) {
+        if (r < 0)
+            return r;
+        if (r) {
             bf_warn(
                 "rule %u has incompatible matchers on the same layer, rule will be disabled",
                 rule->index);
@@ -125,7 +163,7 @@ int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
     rule->disabled = r;
 
     if (!rule->disabled) {
-        r = _bf_rule_has_incompatible_matchers(rule);
+        r = _bf_rule_has_incompatible_matchers(chain, rule);
         if (r < 0)
             return r;
 
@@ -169,6 +207,34 @@ int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
                 -ENOTSUP, "matcher %s is not compatible with %s",
                 bf_matcher_type_to_str(bf_matcher_get_type(matcher)),
                 bf_hook_to_str(chain->hook));
+        }
+
+        if (bf_matcher_get_type(matcher) == BF_MATCHER_SET) {
+            const struct bf_set *set =
+                bf_chain_get_set_for_matcher(chain, matcher);
+
+            if (!set) {
+                return bf_err_r(-ENOENT, "rule %u references non-existent set",
+                                rule->index);
+            }
+
+            for (size_t i = 0; i < set->n_comps; ++i) {
+                const struct bf_matcher_meta *comp_meta =
+                    bf_matcher_get_meta(set->key[i]);
+
+                if (!comp_meta) {
+                    return bf_err_r(-EINVAL,
+                                    "missing meta for set component '%s'",
+                                    bf_matcher_type_to_str(set->key[i]));
+                }
+
+                if (comp_meta->unsupported_hooks & BF_FLAG(chain->hook)) {
+                    return bf_err_r(-ENOTSUP,
+                                    "set component '%s' not compatible with %s",
+                                    bf_matcher_type_to_str(set->key[i]),
+                                    bf_hook_to_str(chain->hook));
+                }
+            }
         }
     }
 

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -1309,7 +1309,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
     [BF_MATCHER_SET] =
         {
             .layer = BF_MATCHER_NO_LAYER,
-            .unsupported_hooks = BF_FLAGS(_BF_HOOKS_CGROUP_SOCK_ADDR_ALL),
         },
 };
 

--- a/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
@@ -36,6 +36,16 @@ ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_C
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule ip6.daddr eq ::1 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule ip6.dnet eq 2001:db8::/32 counter DROP")
 
+# Supported sets
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (ip4.daddr) in { 1.1.1.1; 2.2.2.2 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (ip4.dnet) in { 192.168.1.0/24; 10.0.0.0/8 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (tcp.dport) in { 80; 443 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (ip4.daddr, tcp.dport) in { 1.1.1.1, 80; 2.2.2.2, 443 } counter DROP"
+
+# Unsupported set components
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (ip4.saddr) in { 1.1.1.1 } counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT rule (tcp.sport) in { 80 } counter DROP")
+
 make_sandbox
 
 CGROUP_PATH=/sys/fs/cgroup/bftest_${_TEST_NAME}
@@ -50,65 +60,91 @@ udp4_connect() {
     ${FROM_NS} bash -c "echo \$\$ > ${CGROUP_PATH}/cgroup.procs && echo > /dev/udp/$1/$2" 2>/dev/null
 }
 
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+}
+
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.l4_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq tcp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq tcp counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
 udp4_connect ${HOST_IP_ADDR} 9990
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.probability
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport eq
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 counter DROP"
 (! udp4_connect ${HOST_IP_ADDR} 9990)
 udp4_connect ${HOST_IP_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport range
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 counter DROP"
 (! udp4_connect ${HOST_IP_ADDR} 9990)
 (! udp4_connect ${HOST_IP_ADDR} 9995)
 udp4_connect ${HOST_IP_ADDR} 9996
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "2"
 
 # ip4.daddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.daddr eq ${HOST_IP_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.daddr eq ${HOST_IP_ADDR} counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.dnet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.dnet eq 10.0.0.0/8 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.dnet eq 10.0.0.0/8 counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.proto eq tcp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.proto eq tcp counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
 udp4_connect ${HOST_IP_ADDR} 9990
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # tcp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule tcp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule tcp.dport eq 9990 counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)
 udp4_connect ${HOST_IP_ADDR} 9990
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # udp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 counter DROP"
 (! udp4_connect ${HOST_IP_ADDR} 9990)
 udp4_connect ${HOST_IP_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # Default policy DROP with explicit ACCEPT rule
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 ACCEPT"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 counter ACCEPT"
 udp4_connect ${HOST_IP_ADDR} 9990
 (! udp4_connect ${HOST_IP_ADDR} 9991)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
+
+# ip4.daddr hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.daddr) in { ${HOST_IP_ADDR} } counter DROP"
+(! udp4_connect ${HOST_IP_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# ip4.dnet trie set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.dnet) in { 10.0.0.0/8 } counter DROP"
+(! udp4_connect ${HOST_IP_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# ip4.proto hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.proto) in { tcp } counter DROP"
+(! tcp4_connect ${HOST_IP_ADDR} 9990)
+udp4_connect ${HOST_IP_ADDR} 9990
+test "$(get_counter c 0)" = "1"
+
+# (ip4.daddr, udp.dport) multi-component hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.daddr, udp.dport) in { ${HOST_IP_ADDR}, 9990 } counter DROP"
+(! udp4_connect ${HOST_IP_ADDR} 9990)
+udp4_connect ${HOST_IP_ADDR} 9991
+test "$(get_counter c 0)" = "1"

--- a/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
@@ -32,6 +32,15 @@ ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_C
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule ip4.dnet eq 10.0.0.0/8 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule ip4.proto eq tcp counter DROP")
 
+# Supported sets
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule (ip6.daddr) in { ::1; ::2 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule (ip6.dnet) in { 2001:db8::/32; fd00::/8 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule (tcp.dport) in { 80; 443 } counter DROP"
+
+# Unsupported set components
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule (ip6.saddr) in { ::1 } counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT rule (tcp.sport) in { 80 } counter DROP")
+
 make_sandbox
 
 # Add IPv6 addresses on the veth pair
@@ -69,59 +78,79 @@ s.close()
 "
 }
 
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+}
+
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.l4_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq tcp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq tcp counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
 udp6_connect ${HOST_IP6_ADDR} 9990
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.probability
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport eq
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 counter DROP"
 (! udp6_connect ${HOST_IP6_ADDR} 9990)
 udp6_connect ${HOST_IP6_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport range
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 counter DROP"
 (! udp6_connect ${HOST_IP6_ADDR} 9990)
 (! udp6_connect ${HOST_IP6_ADDR} 9995)
 udp6_connect ${HOST_IP6_ADDR} 9996
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "2"
 
 # ip6.daddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.daddr eq ${HOST_IP6_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.daddr eq ${HOST_IP6_ADDR} counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip6.dnet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.dnet eq fd00::/64 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.dnet eq fd00::/64 counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # tcp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule tcp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule tcp.dport eq 9990 counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)
 udp6_connect ${HOST_IP6_ADDR} 9990
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # udp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 counter DROP"
 (! udp6_connect ${HOST_IP6_ADDR} 9990)
 udp6_connect ${HOST_IP6_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # Default policy DROP with explicit ACCEPT rule
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 ACCEPT"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 counter ACCEPT"
 udp6_connect ${HOST_IP6_ADDR} 9990
 (! udp6_connect ${HOST_IP6_ADDR} 9991)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
+
+# (ip6.daddr, udp.dport) multi-component hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.daddr, udp.dport) in { ${HOST_IP6_ADDR}, 9990 } counter DROP"
+(! udp6_connect ${HOST_IP6_ADDR} 9990)
+udp6_connect ${HOST_IP6_ADDR} 9991
+test "$(get_counter c 0)" = "1"
+
+# ip6.daddr hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.daddr) in { ${HOST_IP6_ADDR} } counter DROP"
+(! udp6_connect ${HOST_IP6_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# ip6.dnet trie set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.dnet) in { fd00::/64 } counter DROP"
+(! udp6_connect ${HOST_IP6_ADDR} 9990)
+test "$(get_counter c 0)" = "1"

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
@@ -32,6 +32,17 @@ ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_S
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule ip6.saddr eq ::1 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule ip6.snet eq 2001:db8::/32 counter DROP")
 
+# Supported sets
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (ip4.daddr) in { 1.1.1.1; 2.2.2.2 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (ip4.dnet) in { 10.0.0.0/8 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (ip4.saddr) in { 10.0.0.1 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (ip4.snet) in { 10.0.0.0/8 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (udp.dport) in { 53; 443 } counter DROP"
+
+# Unsupported set components
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (tcp.dport) in { 80 } counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4 ACCEPT rule (tcp.sport) in { 80 } counter DROP")
+
 make_sandbox
 
 CGROUP_PATH=/sys/fs/cgroup/bftest_${_TEST_NAME}
@@ -50,67 +61,87 @@ s.close()
 "
 }
 
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+}
+
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.l4_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq udp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq udp counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.probability
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport eq
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
 udp4_sendmsg ${HOST_IP_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport range
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
 (! udp4_sendmsg ${HOST_IP_ADDR} 9995)
 udp4_sendmsg ${HOST_IP_ADDR} 9996
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "2"
 
 # ip4.daddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.daddr eq ${HOST_IP_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.daddr eq ${HOST_IP_ADDR} counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.dnet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.dnet eq 10.0.0.0/8 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.dnet eq 10.0.0.0/8 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.proto eq udp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.proto eq udp counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.saddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.saddr eq ${NS_IP_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.saddr eq ${NS_IP_ADDR} counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip4.snet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.snet eq 10.0.0.0/8 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule ip4.snet eq 10.0.0.0/8 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # udp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)
 udp4_sendmsg ${HOST_IP_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # Default policy DROP with explicit ACCEPT rule
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 ACCEPT"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 counter ACCEPT"
 udp4_sendmsg ${HOST_IP_ADDR} 9990
 (! udp4_sendmsg ${HOST_IP_ADDR} 9991)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
+
+# ip4.daddr hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.daddr) in { ${HOST_IP_ADDR} } counter DROP"
+(! udp4_sendmsg ${HOST_IP_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# ip4.dnet trie set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.dnet) in { 10.0.0.0/8 } counter DROP"
+(! udp4_sendmsg ${HOST_IP_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# (ip4.saddr, udp.dport) multi-component hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule (ip4.saddr, udp.dport) in { ${NS_IP_ADDR}, 9990 } counter DROP"
+(! udp4_sendmsg ${HOST_IP_ADDR} 9990)
+udp4_sendmsg ${HOST_IP_ADDR} 9991
+test "$(get_counter c 0)" = "1"

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
@@ -32,6 +32,15 @@ ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_S
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule ip4.saddr eq 10.0.0.1 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule ip4.snet eq 10.0.0.0/8 counter DROP")
 
+# Supported sets
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule (ip6.daddr) in { ::1; ::2 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule (ip6.dnet) in { fd00::/64 } counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule (ip6.saddr, udp.dport) in { ::1, 53 } counter DROP"
+
+# Unsupported set components
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule (tcp.dport) in { 80 } counter DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain test BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6 ACCEPT rule (tcp.sport) in { 80 } counter DROP")
+
 make_sandbox
 
 # Add IPv6 addresses on the veth pair
@@ -56,62 +65,82 @@ s.close()
 "
 }
 
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+}
+
 # meta.l3_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.l4_proto
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq udp DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l4_proto eq udp counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.probability
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.probability eq 100% counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport eq
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport eq 9990 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
 udp6_sendmsg ${HOST_IP6_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # meta.dport range
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.dport range 9990-9995 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9995)
 udp6_sendmsg ${HOST_IP6_ADDR} 9996
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "2"
 
 # ip6.daddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.daddr eq ${HOST_IP6_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.daddr eq ${HOST_IP6_ADDR} counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip6.dnet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.dnet eq fd00::/64 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.dnet eq fd00::/64 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip6.saddr
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.saddr eq ${NS_IP6_ADDR} DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.saddr eq ${NS_IP6_ADDR} counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # ip6.snet
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.snet eq fd00::/64 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule ip6.snet eq fd00::/64 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # udp.dport
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 DROP"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule udp.dport eq 9990 counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
 udp6_sendmsg ${HOST_IP6_ADDR} 9991
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
 
 # Default policy DROP with explicit ACCEPT rule
-${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 ACCEPT"
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} DROP rule meta.dport eq 9990 counter ACCEPT"
 udp6_sendmsg ${HOST_IP6_ADDR} 9990
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9991)
-${FROM_NS} ${BFCLI} ruleset flush
+test "$(get_counter c 0)" = "1"
+
+# ip6.daddr hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.daddr) in { ${HOST_IP6_ADDR} } counter DROP"
+(! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# ip6.dnet trie set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.dnet) in { fd00::/64 } counter DROP"
+(! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
+test "$(get_counter c 0)" = "1"
+
+# (ip6.saddr, udp.dport) multi-component hash set
+${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule (ip6.saddr, udp.dport) in { ${NS_IP6_ADDR}, 9990 } counter DROP"
+(! udp6_sendmsg ${HOST_IP6_ADDR} 9990)
+udp6_sendmsg ${HOST_IP6_ADDR} 9991
+test "$(get_counter c 0)" = "1"

--- a/tests/unit/libbpfilter/chain.c
+++ b/tests/unit/libbpfilter/chain.c
@@ -186,6 +186,37 @@ static void incompatible_matchers_disable_rule(void **state)
         assert_true(rule->disabled);
     }
 
+    // L3 conflict via set: ip4.daddr set + ip6.daddr matcher.
+    {
+        _free_bf_chain_ struct bf_chain *chain = NULL;
+        _clean_bf_list_ bf_list sets =
+            bf_list_default(bf_set_free, bf_set_pack);
+        _clean_bf_list_ bf_list rules =
+            bf_list_default(bf_rule_free, bf_rule_pack);
+        _free_bf_set_ struct bf_set *set = NULL;
+        struct bf_rule *rule = NULL;
+
+        enum bf_matcher_type key[] = {BF_MATCHER_IP4_DADDR};
+
+        uint32_t set_index = 0;
+        uint8_t ip6_addr[16] = {};
+
+        assert_ok(bf_set_new(&set, "s", key, ARRAY_SIZE(key)));
+        assert_ok(bf_set_add_elem(set, (uint8_t[4]) {10, 0, 0, 1}));
+        assert_ok(bf_list_push(&sets, (void **)&set));
+
+        assert_ok(bf_rule_new(&rule));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
+                                      &set_index, sizeof(set_index)));
+        assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
+                                      ip6_addr, sizeof(ip6_addr)));
+        assert_ok(bf_list_add_tail(&rules, rule));
+
+        assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
+                               BF_VERDICT_ACCEPT, &sets, &rules));
+        assert_true(rule->disabled);
+    }
+
     // No conflict: same protocol at same layer (TCP sport + TCP dport).
     {
         _free_bf_chain_ struct bf_chain *chain = NULL;
@@ -244,6 +275,52 @@ static void policy_validation(void **state)
                             BF_VERDICT_REDIRECT, NULL, NULL));
 }
 
+static void set_component_unsupported_hook(void **state)
+{
+    _free_bf_chain_ struct bf_chain *chain = NULL;
+    _clean_bf_list_ bf_list sets = bf_list_default(bf_set_free, bf_set_pack);
+    _clean_bf_list_ bf_list rules = bf_list_default(bf_rule_free, bf_rule_pack);
+    _free_bf_set_ struct bf_set *set = NULL;
+    struct bf_rule *rule = NULL;
+
+    enum bf_matcher_type key[] = {BF_MATCHER_IP4_SADDR};
+
+    uint32_t set_index = 0;
+
+    (void)state;
+
+    // Set component unsupported for hook: ip4.saddr on CONNECT4.
+    assert_ok(bf_set_new(&set, "s", key, ARRAY_SIZE(key)));
+    assert_ok(bf_set_add_elem(set, (uint8_t[4]) {10, 0, 0, 1}));
+    assert_ok(bf_list_push(&sets, (void **)&set));
+
+    assert_ok(bf_rule_new(&rule));
+    assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
+                                  &set_index, sizeof(set_index)));
+    assert_ok(bf_list_add_tail(&rules, rule));
+
+    assert_err(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,
+                            BF_VERDICT_ACCEPT, &sets, &rules));
+
+    // Supported component: ip4.daddr on CONNECT4 should succeed.
+    bf_list_clean(&sets);
+    bf_list_clean(&rules);
+
+    enum bf_matcher_type daddr_key[] = {BF_MATCHER_IP4_DADDR};
+
+    assert_ok(bf_set_new(&set, "s2", daddr_key, ARRAY_SIZE(daddr_key)));
+    assert_ok(bf_set_add_elem(set, (uint8_t[4]) {10, 0, 0, 1}));
+    assert_ok(bf_list_push(&sets, (void **)&set));
+
+    assert_ok(bf_rule_new(&rule));
+    assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
+                                  &set_index, sizeof(set_index)));
+    assert_ok(bf_list_add_tail(&rules, rule));
+
+    assert_ok(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,
+                           BF_VERDICT_ACCEPT, &sets, &rules));
+}
+
 static void get_set_by_name(void **state)
 {
     _free_bf_chain_ struct bf_chain *chain = bft_chain_dummy(true);
@@ -264,6 +341,7 @@ int main(void)
         cmocka_unit_test(mixed_enabled_disabled_log_flag),
         cmocka_unit_test(incompatible_matchers_disable_rule),
         cmocka_unit_test(policy_validation),
+        cmocka_unit_test(set_component_unsupported_hook),
         cmocka_unit_test(get_set_by_name),
     };
 


### PR DESCRIPTION
## Summary

Before this change, sets (hash maps and LPM tries used for bulk matching) were only supported on packet-based hooks.  This meant users who wanted to filter against a list of IPs or ports on a `CONNECT/SENDMSG` hook had to create one rule per value, which scales poorly.

This change adds set support for all four `CGROUP_SOCK_ADDR` hooks, reusing the same BPF map infrastructure (hash maps for exact match, LPM tries for prefix match) that packet hooks already use.

### Refactoring: make set codegen composable/generic

Set codegen previously lived entirely in `set.c` and was tightly coupled to packet-based header loading. To reuse it for `CGROUP_SOCK_ADDR` hooks, we extracted the generic pieces (copy field to scratch, map/trie lookup) into shared helpers and moved the packet-specific logic into `packet.c`. Protocol checks and layer conflict detection were also hoisted out of set codegen into `program.c`'s existing dedup loop, so they now cover set components the same way they cover individual matchers.

As a drive-by, set components are now validated individually against the hook's supported matchers.

### `CGROUP_SOCK_ADDR` set codegen

With the shared helpers in place, `CGROUP_SOCK_ADDR` set codegen maps each key component to its `bpf_sock_addr` context field offset, copies the field to the scratch buffer, and calls the shared map lookup. No header parsing needed — `r6` already points to the context.

## Why can't we use the current set codegen?

Packet-based hooks receive a pointer to raw packet memory. The BPF program parses headers layer by layer (L2 -> L3 -> L4), and `r6` points to the current header being inspected.

`CGROUP_SOCK_ADDR` hooks receive a `bpf_sock_addr` context struct instead. The kernel pre-extracts socket metadata into typed fields:

```
struct bpf_sock_addr {
    __u32 user_ip4;        // destination IPv4
    __u32 user_ip6[4];     // destination IPv6
    __u32 user_port;       // destination port (network order)
    __u32 msg_src_ip4;     // source IPv4  (sendmsg only)
    __u32 msg_src_ip6[4];  // source IPv6  (sendmsg only)
    ...
};
```

This difference has two consequences for set codegen:

1. **No header parsing needed.** `r6` already points to the context. Instead of loading a header pointer and extracting fields from parsed packet data, we read directly from context field offsets (`r6 + offsetof(bpf_sock_addr, field)`).

2. **BPF verifier constraints on access width.** Packet memory can be read at any width. Context struct fields must be read at widths that respect field alignment. The verifier rejects misaligned reads from context pointers. The new `bf_stub_load` function handles this by picking the largest safe access width based on both source and destination alignment.

The diagram below shows the two paths:

```
Packet hooks (XDP/TC/NF/cgroup_skb):
  ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
  │ Parse L2/L3  │────>│ Load header  │────>│ Copy field   │───> map lookup
  │ (dynptr)     │     │ ptr into r6  │     │ to scratch   │
  └──────────────┘     └──────────────┘     └──────────────┘

CGROUP_SOCK_ADDR:
  ┌──────────────────┐     ┌──────────────┐
  │ r6 = ctx (set    │────>│ Copy field   │───> map lookup
  │ once in prologue)│     │ to scratch   │
  └──────────────────┘     └──────────────┘
```

## Test plan

- **Unit tests**: validation of set component hook compatibility and cross-layer conflict detection
- **E2e tests**: each `CGROUP_SOCK_ADDR` hook has dry-run parsing tests and behavioral tests covering hash sets, trie sets, and multi-component sets