### PR TITLE
tests: e2e: prevent _BF_HOOK_MAX to string convertion

### DIFF
--- a/tests/harness/test.hpp
+++ b/tests/harness/test.hpp
@@ -306,7 +306,9 @@ public:
     {
         std::vector<std::pair<enum bf_hook, enum bf_matcher_op>> new_tests;
 
-        if (bf_hook_to_flavor(test.hook()) == BF_FLAVOR_CGROUP_SOCK_ADDR) {
+        // bf_hook_to_flavor() doesn't allow invalid hooks.
+        if (test.hook() != _BF_HOOK_MAX &&
+            bf_hook_to_flavor(test.hook()) == BF_FLAVOR_CGROUP_SOCK_ADDR) {
             bf_warn(
                 "BF_FLAVOR_CGROUP_SOCK_ADDR hooks are not supported by MatcherTestsSuite, ignoring");
             return *this;


### PR DESCRIPTION
In MatcherTestsSuite::operator<<(), we check if the MatcherTest includes BF_FLAVOR_CGROUP_SOCK_ADDR hooks by converting the MatcherTest hook into the corresponding flavor. If MatcherTest is targetting all the supported hooks, it will use _BF_HOOK_MAX, which should not be passed to bf_hook_to_flavor().