### PR TITLE
lib,cli,tests,doc: Add negation operator: "not"

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -509,14 +509,14 @@ Matchers are defined such as:
 
 .. code:: shell
 
-    $TYPE [$OP] $PAYLOAD
+    $TYPE [not] [$OP] $PAYLOAD
 
 With:
   - ``$TYPE``: type of the matcher, defined which part of the processed network packet need to be compared against. All the exact matcher types are defined below.
+  - ``not``: optional comparison negation. When used, it prefixes an operator, e.g. ``tcp.sport not eq 80``, ``(ip4.saddr) not in foo``, or, with no operator, ``tcp.sport not 80`` (equivalent to ``tcp.sport not eq 80``).
   - ``$OP``: comparison operation, not all ``$TYPE`` of matchers support all the existing comparison operators:
 
-    - ``eq``: exact equality.
-    - ``not``: inequality.
+    - ``eq``: exact equality. This is the default if not ``$OP`` is provided.
     - ``any``: match the packet against a set of data defined as the payload. If any of the member of the payload set is found in the packet, the matcher is positive. For example, if you want to match all the ``icmp`` and ``udp`` packets: ``ip4.proto any icmp,udp``.
     - ``all``: match the packet against a set of data defined as the payload. If all the member of the payload set are found in the packet, the matcher is positive, even if the packet contains more than only the members defined in the payload. For example, to match all the packets containing *at least* the ``ACK`` TCP flag: ``tcp.flags all ACK``.
     - ``in``: matches the packet against a hashed set of reference values. Using the ``in`` operator is useful when the packet's data needs to be compared against a large set of different values. Let's say you want to filter 1000 different IPv4 addresses, you can either define 1000 ``ip4.saddr eq $IP`` matcher, in which case ``bpfilter`` will compare the packet against every IP one after the other. Or you can use ``(ip4.saddr) in {$IP0,IP1,...}`` in which case ``bpfilter`` will compare the packet's data against the hashed set as a whole in 1 operation.
@@ -553,21 +553,19 @@ Meta
       - ``eq``
       - ``$PROTOCOL``
       - ``$PROTOCOL`` must be a transport layer protocol name (e.g. "ICMP", case insensitive), or a valid decimal or hexadecimal `internet protocol number`_.
-    * - :rspan:`2` Source port
-      - :rspan:`2` ``meta.sport``
+    * - :rspan:`1` Source port
+      - :rspan:`1` ``meta.sport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - ``$PORT`` must be a valid decimal port number.
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`2` Destination port
-      - :rspan:`2` ``meta.dport``
+    * - :rspan:`1` Destination port
+      - :rspan:`1` ``meta.dport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - ``$PORT`` must be a valid decimal port number.
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
@@ -576,18 +574,16 @@ Meta
       - ``eq``
       - ``$PROBABILITY``
       - ``$PROBABILITY`` is a floating-point percentage value (i.e., within [0%, 100%], e.g., "50%" or "33.33%"). For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, probability applies per socket operation: each ``connect()`` or ``sendmsg()`` call is independently accepted or dropped.
-    * - :rspan:`1` Mark
-      - :rspan:`1` ``meta.mark``
+    * - Mark
+      - ``meta.mark``
       - ``eq``
-      - :rspan:`1` ``$MARK``
-      - :rspan:`1` ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. Incompatible with ``BF_HOOK_XDP`` and ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks.
-    * - ``not``
-    * - :rspan:`2` Flow hash
-      - :rspan:`2` ``meta.flow_hash``
+      - ``$MARK``
+      - ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. Incompatible with ``BF_HOOK_XDP`` and ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks.
+    * - :rspan:`1` Flow hash
+      - :rspan:`1` ``meta.flow_hash``
       - ``eq``
-      - :rspan:`1` ``$HASH``
-      - :rspan:`1` ``$HASH`` must be a decimal or hexadecimal 32-bits integer. Only compatible with ``BF_HOOK_TC_INGRESS`` and ``BF_HOOK_TC_EGRESS`` hooks.
-    * - ``not``
+      - ``$HASH``
+      - ``$HASH`` must be a decimal or hexadecimal 32-bits integer. Only compatible with ``BF_HOOK_TC_INGRESS`` and ``BF_HOOK_TC_EGRESS`` hooks.
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` must be decimal or hexadecimal 32-bits integers, with ``$START <= $END``. Only compatible with ``BF_HOOK_TC_INGRESS`` and ``BF_HOOK_TC_EGRESS`` hooks.
@@ -610,48 +606,42 @@ IPv4
       - Operator
       - Payload
       - Notes
-    * - :rspan:`2` Source address
-      - :rspan:`2` ``ip4.saddr``
+    * - :rspan:`1` Source address
+      - :rspan:`1` ``ip4.saddr``
       - ``eq``
-      - :rspan:`1` ``$ADDR``
-      - :rspan:`5` ``$ADDR`` is an IPv4 address in dotted-decimal format, "ddd.ddd.ddd.ddd", where ddd is a decimal number of up to three digits in the range 0 to 255. To filter on an IPv4 network (using an IPv4 address and a subnet mask), see ``ip4.snet`` or ``ip4.dnet``.
-    * - ``not``
+      - ``$ADDR``
+      - :rspan:`3` ``$ADDR`` is an IPv4 address in dotted-decimal format, "ddd.ddd.ddd.ddd", where ddd is a decimal number of up to three digits in the range 0 to 255. To filter on an IPv4 network (using an IPv4 address and a subnet mask), see ``ip4.snet`` or ``ip4.dnet``.
     * - ``in``
       - ``{$ADDR[,...]}``
-    * - :rspan:`2` Destination address
-      - :rspan:`2` ``ip4.daddr``
+    * - :rspan:`1` Destination address
+      - :rspan:`1` ``ip4.daddr``
       - ``eq``
-      - :rspan:`1` ``$ADDR``
-    * - ``not``
+      - ``$ADDR``
     * - ``in``
       - ``{$ADDR[,...]}``
-    * - :rspan:`2` Source network
-      - :rspan:`2` ``ip4.snet``
+    * - :rspan:`1` Source network
+      - :rspan:`1` ``ip4.snet``
       - ``eq``
-      - :rspan:`1` ``$ADDR/$MASK``
-      - :rspan:`5` ``$ADDR`` is an IPv4 network address in dotted-decimal format, \"ddd.ddd.ddd.ddd\", where ddd is a decimal number of up to three digits in the range 0 to 255, ``$MASK`` is a subnet mask in the range 0 to 32.
-    * - ``not``
+      - ``$ADDR/$MASK``
+      - :rspan:`3` ``$ADDR`` is an IPv4 network address in dotted-decimal format, \"ddd.ddd.ddd.ddd\", where ddd is a decimal number of up to three digits in the range 0 to 255, ``$MASK`` is a subnet mask in the range 0 to 32.
     * - ``in``
       - ``{$ADDR/$MASK[,...]}``
-    * - :rspan:`2` Destination network
-      - :rspan:`2` ``ip4.dnet``
+    * - :rspan:`1` Destination network
+      - :rspan:`1` ``ip4.dnet``
       - ``eq``
-      - :rspan:`1` ``$ADDR/$MASK``
-    * - ``not``
+      - ``$ADDR/$MASK``
     * - ``in``
       - ``{$ADDR/$MASK[,...]}``
-    * - :rspan:`1` Protocol
-      - :rspan:`1` ``ip4.proto``
+    * - Protocol
+      - ``ip4.proto``
       - ``eq``
-      - :rspan:`1` ``$PROTOCOL``
-      - :rspan:`1` ``$PROTOCOL`` must be a transport layer protocol name (e.g. "ICMP", case insensitive), or a valid decimal or hexadecimal `internet protocol number`_.
-    * - ``not``
-    * - :rspan:`1` DSCP
-      - :rspan:`1` ``ip4.dscp``
+      - ``$PROTOCOL``
+      - ``$PROTOCOL`` must be a transport layer protocol name (e.g. "ICMP", case insensitive), or a valid decimal or hexadecimal `internet protocol number`_.
+    * - DSCP
+      - ``ip4.dscp``
       - ``eq``
-      - :rspan:`1` ``$DSCP``
-      - :rspan:`1` ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
-    * - ``not``
+      - ``$DSCP``
+      - ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
 
 
 IPv6
@@ -667,48 +657,42 @@ IPv6
       - Operator
       - Payload
       - Notes
-    * - :rspan:`2` Source address
-      - :rspan:`2` ``ip6.saddr``
+    * - :rspan:`1` Source address
+      - :rspan:`1` ``ip6.saddr``
       - ``eq``
-      - :rspan:`1` ``$ADDR``
-      - :rspan:`5` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported). To filter on an IPv6 network (using an IPv6 address and a subnet mask), see ``ip6.snet`` or ``ip6.dnet``.
-    * - ``not``
+      - ``$ADDR``
+      - :rspan:`3` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported). To filter on an IPv6 network (using an IPv6 address and a subnet mask), see ``ip6.snet`` or ``ip6.dnet``.
     * - ``in``
       - ``{$ADDR[,...]}``
-    * - :rspan:`2` Destination address
-      - :rspan:`2` ``ip6.daddr``
+    * - :rspan:`1` Destination address
+      - :rspan:`1` ``ip6.daddr``
       - ``eq``
-      - :rspan:`1` ``$ADDR``
-    * - ``not``
+      - ``$ADDR``
     * - ``in``
       - ``{$ADDR[,...]}``
-    * - :rspan:`2` Source network
-      - :rspan:`2` ``ip6.snet``
+    * - :rspan:`1` Source network
+      - :rspan:`1` ``ip6.snet``
       - ``eq``
-      - :rspan:`1` ``$ADDR/$MASK``
-      - :rspan:`5` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported), ``$MASK`` is a subnet mask in the range 0 to 128.
-    * - ``not``
+      - ``$ADDR/$MASK``
+      - :rspan:`3` ``$ADDR`` must be an IPv6 address composed of 8 hexadecimal numbers (abbreviations are supported), ``$MASK`` is a subnet mask in the range 0 to 128.
     * - ``in``
       - ``{$ADDR/$MASK[,...]}``
-    * - :rspan:`2` Destination network
-      - :rspan:`2` ``ip6.dnet``
+    * - :rspan:`1` Destination network
+      - :rspan:`1` ``ip6.dnet``
       - ``eq``
-      - :rspan:`1` ``$ADDR/$MASK``
-    * - ``not``
+      - ``$ADDR/$MASK``
     * - ``in``
       - ``{$ADDR/$MASK[,...]}``
-    * - :rspan:`1` Next header
-      - :rspan:`1` ``ip6.nexthdr``
+    * - Next header
+      - ``ip6.nexthdr``
       - ``eq``
-      - :rspan:`1` ``$NEXT_HEADER``
-      - :rspan:`1` ``$NEXT_HEADER`` is a transport layer protocol name (e.g. "ICMP", case insensitive), an IPv6 extension header name, or a valid decimal or hexadecimal `internet protocol number`_.
-    * - ``not``
-    * - :rspan:`1` DSCP
-      - :rspan:`1` ``ip6.dscp``
+      - ``$NEXT_HEADER``
+      - ``$NEXT_HEADER`` is a transport layer protocol name (e.g. "ICMP", case insensitive), an IPv6 extension header name, or a valid decimal or hexadecimal `internet protocol number`_.
+    * - DSCP
+      - ``ip6.dscp``
       - ``eq``
-      - :rspan:`1` ``$DSCP``
-      - :rspan:`1` ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
-    * - ``not``
+      - ``$DSCP``
+      - ``$DSCP`` is a `DSCP class name`_ (e.g. "ef", "cs1", "af21", case insensitive) or a numeric value (0-63, decimal or hexadecimal). "be" is accepted as an alias for "cs0".
 
 .. tip::
 
@@ -727,34 +711,31 @@ TCP
       - Operator
       - Payload
       - Notes
-    * - :rspan:`3` Source port
-      - :rspan:`3` ``tcp.sport``
+    * - :rspan:`2` Source port
+      - :rspan:`2` ``tcp.sport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
     * - ``in``
       - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`3` Destination port
-      - :rspan:`3` ``tcp.dport``
+    * - :rspan:`2` Destination port
+      - :rspan:`2` ``tcp.dport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
     * - ``in``
       - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`3` Flags
-      - :rspan:`3` ``tcp.flags``
+    * - :rspan:`2` Flags
+      - :rspan:`2` ``tcp.flags``
       - ``eq``
-      - :rspan:`3` ``$FLAG[,...]``
-      - :rspan:`3` ``$FLAG`` is a comma-separated list of one or more TCP flags (``fin``, ``syn``, ``rst``, ``psh``, ``ack``, ``urg``, ``ece``, or ``cwr``). Flags are case-insensitive.
-    * - ``not``
+      - :rspan:`2` ``$FLAG[,...]``
+      - :rspan:`2` ``$FLAG`` is a comma-separated list of one or more TCP flags (``fin``, ``syn``, ``rst``, ``psh``, ``ack``, ``urg``, ``ece``, or ``cwr``). Flags are case-insensitive.
     * - ``any``
     * - ``all``
 
@@ -763,9 +744,14 @@ TCP
    The ``tcp.flags`` operators can be confusing, as they can be used to match all, some, or none of the flags available in the TCP header. This section aims to provide clarity to their exact behavior:
 
    - ``eq``: the TCP header must contain the exact same flags as defined in the rule. The matcher ``tcp.flags eq syn,ack`` will match ``syn,ack``, but not ``syn,ack,fin`` nor ``rst``.
-   - ``not``: opposite of ``eq``, the TCP header must not contain the exact same flags as defined in the rule. The matcher ``tcp.flags eq syn,ack`` will match ``syn,ack,fin`` or ``rst``, but not ``syn,ack``.
-   - ``any``: the TCP header must contain any of the flags defined in the rule. The matcher ``tcp.flags eq syn,ack`` will match ``syn``, or ``ack``, or ``syn,ack``, but not ``fin``.
+   - ``any``: the TCP header must contain any of the flags defined in the rule. The matcher ``tcp.flags any syn,ack`` will match ``syn``, or ``ack``, or ``syn,ack``, but not ``fin``.
    - ``all``: the TCP header must contain at least the flags defined in the rule. The matcher ``tcp.flags all syn,ack`` will match ``syn,ack,fin``, but not ``syn``, or ``ack,fin``.
+
+   Each operator can be negated with ``not`` to invert the match:
+
+   - ``not eq``: the TCP header must not contain the exact same flags. The matcher ``tcp.flags not eq syn`` will match ``ack``, or ``syn,ack``, but not ``syn`` alone.
+   - ``not any``: none of the specified flags may be present. The matcher ``tcp.flags not any syn,ack`` will match ``fin`` or ``rst``, but not ``syn``, ``ack``, or ``syn,ack``.
+   - ``not all``: not all of the specified flags are present. The matcher ``tcp.flags not all syn,ack`` will match ``syn`` or ``ack`` alone, but not ``syn,ack`` or ``syn,ack,fin``.
 
 
 UDP
@@ -781,23 +767,21 @@ UDP
       - Operator
       - Payload
       - Notes
-    * - :rspan:`3` Source port
-      - :rspan:`3` ``udp.sport``
+    * - :rspan:`2` Source port
+      - :rspan:`2` ``udp.sport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
     * - ``in``
       - ``{$PORT[;...]}``
     * - ``range``
       - ``$START-$END``
       - ``$START`` and ``$END`` are valid port values, as decimal integers.
-    * - :rspan:`3` Destination port
-      - :rspan:`3` ``udp.dport``
+    * - :rspan:`2` Destination port
+      - :rspan:`2` ``udp.dport``
       - ``eq``
-      - :rspan:`1` ``$PORT``
-      - :rspan:`2` ``$PORT`` must be a valid decimal port number.
-    * - ``not``
+      - ``$PORT``
+      - :rspan:`1` ``$PORT`` must be a valid decimal port number.
     * - ``in``
       - ``{$PORT[;...]}``
     * - ``range``
@@ -817,18 +801,16 @@ ICMP
       - Operator
       - Payload
       - Notes
-    * - :rspan:`1` Type
-      - :rspan:`1` ``icmp.type``
+    * - Type
+      - ``icmp.type``
       - ``eq``
-      - :rspan:`1` ``$TYPE``
-      - :rspan:`1` ``$TYPE`` is an ICMP type name (e.g. "echo-reply", case insensitive), or a decimal or hexadecimal `ICMP type value`_.
-    * - ``not``
-    * - :rspan:`1` Code
-      - :rspan:`1` ``icmp.code``
+      - ``$TYPE``
+      - ``$TYPE`` is an ICMP type name (e.g. "echo-reply", case insensitive), or a decimal or hexadecimal `ICMP type value`_.
+    * - Code
+      - ``icmp.code``
       - ``eq``
-      - :rspan:`1` ``$CODE``
-      - :rspan:`1` ``$CODE`` is a decimal or hexadecimal `ICMP code value`_.
-    * - ``not``
+      - ``$CODE``
+      - ``$CODE`` is a decimal or hexadecimal `ICMP code value`_.
 
 .. tip::
 
@@ -847,18 +829,16 @@ ICMPv6
       - Operator
       - Payload
       - Notes
-    * - :rspan:`1` Type
-      - :rspan:`1` ``icmpv6.type``
+    * - Type
+      - ``icmpv6.type``
       - ``eq``
-      - :rspan:`1` ``$TYPE``
-      - :rspan:`1` ``$TYPE`` is an ICMPv6 type name (e.g. "echo-reply", case insensitive), or a decimal or hexadecimal `ICMPv6 type value`_.
-    * - ``not``
-    * - :rspan:`1` Code
-      - :rspan:`1` ``icmpv6.code``
+      - ``$TYPE``
+      - ``$TYPE`` is an ICMPv6 type name (e.g. "echo-reply", case insensitive), or a decimal or hexadecimal `ICMPv6 type value`_.
+    * - Code
+      - ``icmpv6.code``
       - ``eq``
-      - :rspan:`1` ``$CODE``
-      - :rspan:`1` ``$CODE`` is a decimal or hexadecimal `ICMPv6 code value`_.
-    * - ``not``
+      - ``$CODE``
+      - ``$CODE`` is a decimal or hexadecimal `ICMPv6 code value`_.
 
 .. tip::
 

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -54,6 +54,7 @@ rule            { return RULE; }
 set             { return SET; }
 
     /* Keywords */
+not             { return NEGATE; }
 counter         { return COUNTER; }
 
     /* Hooks */
@@ -137,7 +138,7 @@ meta\.l4_proto  { BEGIN(STATE_MATCHER_L4_PROTO); yylval.sval = strdup(yytext); r
 ip4\.proto      { BEGIN(STATE_MATCHER_L4_PROTO); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 ip6\.nexthdr    { BEGIN(STATE_MATCHER_L4_PROTO); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_L4_PROTO>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -158,7 +159,7 @@ meta\.flow_probability { BEGIN(STATE_MATCHER_META_PROBA); yylval.sval = strdup(y
 
 meta\.mark          { BEGIN(STATE_MATCHER_META_MARK); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_META_MARK>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int} {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -168,7 +169,7 @@ meta\.mark          { BEGIN(STATE_MATCHER_META_MARK); yylval.sval = strdup(yytex
 
 meta\.flow_hash     { BEGIN(STATE_MATCHER_META_FLOW_HASH); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_META_FLOW_HASH>{
-    (eq|not|range) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|range) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}(-{int})? {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -179,7 +180,7 @@ meta\.flow_hash     { BEGIN(STATE_MATCHER_META_FLOW_HASH); yylval.sval = strdup(
 ip4\.saddr       { BEGIN(STATE_MATCHER_IPV4_ADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 ip4\.daddr       { BEGIN(STATE_MATCHER_IPV4_ADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IPV4_ADDR>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}\.{int}\.{int}\.{int} {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -190,7 +191,7 @@ ip4\.daddr       { BEGIN(STATE_MATCHER_IPV4_ADDR); yylval.sval = strdup(yytext);
 ip4\.snet       { BEGIN(STATE_MATCHER_IP4_NET); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 ip4\.dnet       { BEGIN(STATE_MATCHER_IP4_NET); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP4_NET>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}\.{int}\.{int}\.{int}\/{int} {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -200,7 +201,7 @@ ip4\.dnet       { BEGIN(STATE_MATCHER_IP4_NET); yylval.sval = strdup(yytext); re
 
 ip4\.dscp       { BEGIN(STATE_MATCHER_IP4_DSCP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP4_DSCP>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -210,7 +211,7 @@ ip4\.dscp       { BEGIN(STATE_MATCHER_IP4_DSCP); yylval.sval = strdup(yytext); r
 
 ip6\.(s|d)addr      { BEGIN(STATE_MATCHER_IP6_ADDR); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP6_ADDR>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     [a-zA-Z0-9:]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -220,7 +221,7 @@ ip6\.(s|d)addr      { BEGIN(STATE_MATCHER_IP6_ADDR); yylval.sval = strdup(yytext
 
 ip6\.(s|d)net       { BEGIN(STATE_MATCHER_IP6_NET); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP6_NET>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     [a-zA-Z0-9:\/]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -230,7 +231,7 @@ ip6\.(s|d)net       { BEGIN(STATE_MATCHER_IP6_NET); yylval.sval = strdup(yytext)
 
 ip6\.dscp           { BEGIN(STATE_MATCHER_IP6_DSCP); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_IP6_DSCP>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -242,7 +243,7 @@ meta\.(s|d)port { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); retur
 tcp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_PORT>{
-    (eq|not|range) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|range) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}(-{int})? {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -252,7 +253,7 @@ udp\.(s|d)port  { BEGIN(STATE_MATCHER_PORT); yylval.sval = strdup(yytext); retur
 
 icmp(v6)?\.type { BEGIN(STATE_MATCHER_ICMP_TYPE); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_ICMP_TYPE>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int}|[0-9a-zA-Z-]+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -262,7 +263,7 @@ icmp(v6)?\.type { BEGIN(STATE_MATCHER_ICMP_TYPE); yylval.sval = strdup(yytext); 
 
 icmp(v6)?\.code { BEGIN(STATE_MATCHER_ICMP_CODE); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_ICMP_CODE>{
-    (eq|not) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     {int} {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);
@@ -272,7 +273,7 @@ icmp(v6)?\.code { BEGIN(STATE_MATCHER_ICMP_CODE); yylval.sval = strdup(yytext); 
 
 tcp\.flags      { BEGIN(STATE_MATCHER_TCP_FLAGS); yylval.sval = strdup(yytext); return MATCHER_TYPE; }
 <STATE_MATCHER_TCP_FLAGS>{
-    (eq|not|any|all) { yylval.sval = strdup(yytext); return MATCHER_OP; }
+    (eq|any|all) { yylval.sval = strdup(yytext); return MATCHER_OP; }
     ([a-zA-Z]+,?)+ {
         BEGIN(INITIAL);
         yylval.sval = strdup(yytext);

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -101,7 +101,7 @@
 %token CHAIN
 %token RULE
 %token SET
-%token LOG COUNTER MARK
+%token NEGATE LOG COUNTER MARK
 %token REDIRECT_TOKEN
 %token <sval> SET_TYPE
 %token <sval> SET_RAW_PAYLOAD
@@ -125,6 +125,8 @@
 %type <matcher_type> matcher_type
 
 %type <matcher_op> matcher_op
+
+%type <bval> negate
 
 %type <void> sets
 %type <void> set
@@ -431,25 +433,25 @@ matchers        : matcher
                     $$ = TAKE_PTR($1);
                 }
                 ;
-matcher         : matcher_type matcher_op RAW_PAYLOAD
+matcher         : matcher_type negate matcher_op RAW_PAYLOAD
                 {
                     _free_bf_matcher_ struct bf_matcher *matcher = NULL;
-                    _cleanup_free_ const char *payload = $3;
+                    _cleanup_free_ const char *payload = $4;
                     int r;
 
-                    r = bf_matcher_new_from_raw(&matcher, $1, $2, payload);
+                    r = bf_matcher_new_from_raw(&matcher, $1, $3, payload, $2);
                     if (r)
                         bf_parse_err("failed to create a new matcher\n");
 
                     $$ = TAKE_PTR(matcher);
                 }
-                | SET_TYPE matcher_op SET_RAW_PAYLOAD
+                | SET_TYPE negate matcher_op SET_RAW_PAYLOAD
                 {
                      _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                      _free_bf_set_ struct bf_set *set = NULL;
                     _cleanup_free_ const char *raw_key = $1;
-                    _cleanup_free_ const char *payload = $3;
-                    enum bf_matcher_op op = $2;
+                    _cleanup_free_ const char *payload = $4;
+                    enum bf_matcher_op op = $3;
                      uint32_t set_id = bf_list_size(&ruleset->sets);
                      int r;
 
@@ -466,23 +468,23 @@ matcher         : matcher_type matcher_op RAW_PAYLOAD
 
                      TAKE_PTR(set);
 
-                    r = bf_matcher_new(&matcher, BF_MATCHER_SET, BF_MATCHER_IN, &set_id, sizeof(set_id));
+                    r = bf_matcher_new(&matcher, BF_MATCHER_SET, BF_MATCHER_IN, &set_id, sizeof(set_id), $2);
                     if (r)
                         bf_parse_err("failed to create a new matcher");
 
                      $$ = TAKE_PTR(matcher);
                 }
-                | SET_TYPE matcher_op STRING
+                | SET_TYPE negate matcher_op STRING
                 {
                     _free_bf_matcher_ struct bf_matcher *matcher = NULL;
                     _cleanup_free_ const char *raw_key = $1;
-                    _cleanup_free_ const char *name = $3;
+                    _cleanup_free_ const char *name = $4;
                      uint32_t set_id = 0;
                     struct bf_set *found_set = NULL;
                     _free_bf_set_ struct bf_set *test_key = NULL;
                     int r;
 
-                    if ($2 != BF_MATCHER_IN)
+                    if ($3 != BF_MATCHER_IN)
                         bf_parse_err("only the 'in' operator is supported for sets");
 
                     r = bf_set_new_from_raw(&test_key, NULL, raw_key, "{}");
@@ -506,12 +508,15 @@ matcher         : matcher_type matcher_op RAW_PAYLOAD
                     if (found_set->n_comps != test_key->n_comps || memcmp(found_set->key, test_key->key, found_set->n_comps * sizeof(enum bf_matcher_type)))
                         bf_parse_err("using named set '%s', but key doesn't match", name);
 
-                    r = bf_matcher_new(&matcher, BF_MATCHER_SET, BF_MATCHER_IN, &set_id, sizeof(set_id));
+                    r = bf_matcher_new(&matcher, BF_MATCHER_SET, BF_MATCHER_IN, &set_id, sizeof(set_id), $2);
                     if (r)
                         bf_parse_err("failed to create a new matcher");
 
                      $$ = TAKE_PTR(matcher);
                 }
+                ;
+negate          : %empty { $$ = false; }
+                | NEGATE { $$ = true; }
                 ;
 matcher_type    : MATCHER_TYPE
                 {

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -201,6 +201,9 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
             const struct bf_matcher_ops *ops = bf_matcher_get_ops(
                 bf_matcher_get_type(matcher), bf_matcher_get_op(matcher));
 
+            const bool negate = bf_matcher_get_negate(matcher);
+            const char *in_str = negate ? "not in" : "in";
+
             if (bf_matcher_get_type(matcher) == BF_MATCHER_SET) {
                 struct bf_set *set =
                     bf_chain_get_set_for_matcher(chain, matcher);
@@ -215,9 +218,9 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
                 }
 
                 if (set->name) {
-                    (void)fprintf(stdout, ") in %s", set->name);
+                    (void)fprintf(stdout, ") %s %s", in_str, set->name);
                 } else {
-                    (void)fprintf(stdout, ") in {\n");
+                    (void)fprintf(stdout, ") %s {\n", in_str);
 
                     bf_hashset_foreach (&set->elems, node) {
                         uint32_t payload_idx = 0;
@@ -244,7 +247,7 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
                 (void)fprintf(
                     stdout, "        %s",
                     bf_matcher_type_to_str(bf_matcher_get_type(matcher)));
-                (void)fprintf(stdout, " %s ",
+                (void)fprintf(stdout, "%s %s ", negate ? " not" : "",
                               bf_matcher_op_to_str(bf_matcher_get_op(matcher)));
 
                 if (ops) {

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -129,8 +129,8 @@ static int _bf_cgroup_skb_gen_inline_matcher(struct bf_program *program,
         EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_1,
                                   offsetof(struct __sk_buff, mark)));
 
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 4, BPF_REG_1);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 4,
+                            BPF_REG_1);
     default:
         return bf_packet_gen_inline_matcher(program, matcher);
     }

--- a/src/libbpfilter/cgen/cgroup_sock_addr.c
+++ b/src/libbpfilter/cgen/cgroup_sock_addr.c
@@ -155,8 +155,8 @@ static int _bf_cgroup_sock_addr_load_and_cmp(struct bf_program *program,
     if (r)
         return r;
 
-    return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                        bf_matcher_payload(matcher), size, BPF_REG_1);
+    return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), size,
+                        BPF_REG_1);
 }
 
 static int _bf_cgroup_sock_addr_generate_net(struct bf_program *program,
@@ -177,8 +177,8 @@ static int _bf_cgroup_sock_addr_generate_net(struct bf_program *program,
     if (r)
         return r;
 
-    return bf_cmp_masked_value(program, bf_matcher_get_op(matcher), data,
-                               prefixlen, size, BPF_REG_1);
+    return bf_cmp_masked_value(program, matcher, data, prefixlen, size,
+                               BPF_REG_1);
 }
 
 /* `user_port` is a __u32 in network byte order with the upper 16 bits
@@ -201,11 +201,11 @@ static int _bf_cgroup_sock_addr_generate_port(struct bf_program *program,
     if (bf_matcher_get_op(matcher) == BF_MATCHER_RANGE) {
         uint16_t *ports = (uint16_t *)bf_matcher_payload(matcher);
         EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
-        return bf_cmp_range(program, ports[0], ports[1], BPF_REG_1);
+        return bf_cmp_range(program, matcher, ports[0], ports[1], BPF_REG_1);
     }
 
-    return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                        bf_matcher_payload(matcher), 2, BPF_REG_1);
+    return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 2,
+                        BPF_REG_1);
 }
 
 static ssize_t _bf_cgroup_sock_addr_ctx_offset(enum bf_matcher_type type)
@@ -338,8 +338,8 @@ _bf_cgroup_sock_addr_gen_inline_matcher(struct bf_program *program,
             program, matcher, offsetof(struct bpf_sock_addr, user_ip4), 4);
     case BF_MATCHER_IP4_PROTO:
         EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_8));
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 1, BPF_REG_1);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 1,
+                            BPF_REG_1);
     case BF_MATCHER_IP6_SADDR:
         return _bf_cgroup_sock_addr_load_and_cmp(
             program, matcher, offsetof(struct bpf_sock_addr, msg_src_ip6), 16);

--- a/src/libbpfilter/cgen/matcher/cmp.c
+++ b/src/libbpfilter/cgen/matcher/cmp.c
@@ -9,6 +9,8 @@
 #include <linux/bpf_common.h>
 
 #include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include <bpfilter/logger.h>
@@ -16,6 +18,31 @@
 
 #include "cgen/jmp.h"
 #include "cgen/program.h"
+
+uint8_t bf_cmp_get_jmp_ins(const struct bf_matcher *matcher)
+{
+    bool continue_on_equal;
+
+    assert(matcher);
+
+    switch (bf_matcher_get_op(matcher)) {
+    case BF_MATCHER_EQ:
+    case BF_MATCHER_ALL:
+        continue_on_equal = true;
+        break;
+    case BF_MATCHER_ANY:
+    case BF_MATCHER_IN:
+        continue_on_equal = false;
+        break;
+    default:
+        bf_abort("invalid matcher op to get jmp instruction %d",
+                 bf_matcher_get_op(matcher));
+    }
+
+    continue_on_equal ^= bf_matcher_get_negate(matcher);
+
+    return continue_on_equal ? BPF_JNE : BPF_JEQ;
+}
 
 #define _BF_MASK_LAST_BYTE 15
 
@@ -70,14 +97,20 @@ static void _bf_prefix_to_mask(unsigned int prefixlen, uint8_t *mask,
         mask[prefixlen / 8] = (0xff << (8 - prefixlen % 8)) & 0xff;
 }
 
-int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
+int bf_cmp_value(struct bf_program *program, const struct bf_matcher *matcher,
                  const void *ref, unsigned int size, int reg)
 {
+    enum bf_matcher_op op = bf_matcher_get_op(matcher);
+    uint8_t jmp_op;
+
     assert(program);
+    assert(matcher);
     assert(ref);
 
-    if (op != BF_MATCHER_EQ && op != BF_MATCHER_NE)
+    if (op != BF_MATCHER_EQ)
         return bf_err_r(-EINVAL, "unsupported operator %d", op);
+
+    jmp_op = bf_cmp_get_jmp_ins(matcher);
 
     switch (size) {
     case 1:
@@ -88,9 +121,7 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
         uint32_t val =
             (size == 1) ? *(const uint8_t *)ref : *(const uint16_t *)ref;
 
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program,
-            BPF_JMP_IMM(op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ, reg, val, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(jmp_op, reg, val, 0));
         break;
     }
     case 4: {
@@ -99,9 +130,8 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
         uint32_t val = *(const uint32_t *)ref;
 
         EMIT(program, BPF_MOV32_IMM(BPF_REG_2, val));
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_REG(op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ, reg,
-                                 BPF_REG_2, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_REG(jmp_op, reg, BPF_REG_2, 0));
         break;
     }
     case 8: {
@@ -113,9 +143,8 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
                                 _bf_read_u64(ref));
         if (r)
             return r;
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_REG(op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ, reg,
-                                 BPF_REG_2, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_REG(jmp_op, reg, BPF_REG_2, 0));
         break;
     }
     case 16: {
@@ -129,7 +158,7 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
         if (r)
             return r;
 
-        if (op == BF_MATCHER_EQ) {
+        if (jmp_op == BPF_JNE) {
             EMIT_FIXUP_JMP_NEXT_RULE(program,
                                      BPF_JMP_REG(BPF_JNE, reg, BPF_REG_3, 0));
 
@@ -140,12 +169,12 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
             EMIT_FIXUP_JMP_NEXT_RULE(
                 program, BPF_JMP_REG(BPF_JNE, reg + 1, BPF_REG_3, 0));
         } else {
-            /* NE: the address must differ in at least one half.
+            /* JEQ: the address must differ in at least one half.
              * If the first half differs, the matcher matched — jump
              * past the second half check and the unconditional
              * jump-to-next-rule. If the first half matches, check the
              * second half: if it also matches, the full address is
-             * equal, so the NE matcher fails — jump to next rule. */
+             * equal, so the matcher fails — jump to next rule. */
             _clean_bf_jmpctx_ struct bf_jmpctx j0 = bf_jmpctx_default();
             _clean_bf_jmpctx_ struct bf_jmpctx j1 = bf_jmpctx_default();
 
@@ -170,15 +199,21 @@ int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
     return 0;
 }
 
-int bf_cmp_masked_value(struct bf_program *program, enum bf_matcher_op op,
-                        const void *ref, unsigned int prefixlen,
-                        unsigned int size, int reg)
+int bf_cmp_masked_value(struct bf_program *program,
+                        const struct bf_matcher *matcher, const void *ref,
+                        unsigned int prefixlen, unsigned int size, int reg)
 {
+    enum bf_matcher_op op = bf_matcher_get_op(matcher);
+    uint8_t jmp_op;
+
     assert(program);
+    assert(matcher);
     assert(ref);
 
-    if (op != BF_MATCHER_EQ && op != BF_MATCHER_NE)
+    if (op != BF_MATCHER_EQ)
         return bf_err_r(-EINVAL, "unsupported operator %d", op);
+
+    jmp_op = bf_cmp_get_jmp_ins(matcher);
 
     switch (size) {
     case 4: {
@@ -195,9 +230,8 @@ int bf_cmp_masked_value(struct bf_program *program, enum bf_matcher_op op,
             EMIT(program, BPF_ALU32_REG(BPF_AND, BPF_REG_2, BPF_REG_3));
         }
 
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_REG(op == BF_MATCHER_EQ ? BPF_JNE : BPF_JEQ, reg,
-                                 BPF_REG_2, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_REG(jmp_op, reg, BPF_REG_2, 0));
         break;
     }
     case 16: {
@@ -233,7 +267,7 @@ int bf_cmp_masked_value(struct bf_program *program, enum bf_matcher_op op,
         if (r)
             return r;
 
-        if (op == BF_MATCHER_EQ) {
+        if (jmp_op == BPF_JNE) {
             EMIT_FIXUP_JMP_NEXT_RULE(program,
                                      BPF_JMP_REG(BPF_JNE, reg, BPF_REG_3, 0));
 
@@ -268,10 +302,22 @@ int bf_cmp_masked_value(struct bf_program *program, enum bf_matcher_op op,
     return 0;
 }
 
-int bf_cmp_range(struct bf_program *program, uint32_t min, uint32_t max,
-                 int reg)
+int bf_cmp_range(struct bf_program *program, const struct bf_matcher *matcher,
+                 uint32_t min, uint32_t max, int reg)
 {
     assert(program);
+    assert(matcher);
+
+    if (bf_matcher_get_negate(matcher)) {
+        _clean_bf_jmpctx_ struct bf_jmpctx j0 = bf_jmpctx_default();
+        _clean_bf_jmpctx_ struct bf_jmpctx j1 = bf_jmpctx_default();
+
+        j0 = bf_jmpctx_get(program, BPF_JMP32_IMM(BPF_JLT, reg, min, 0));
+        j1 = bf_jmpctx_get(program, BPF_JMP32_IMM(BPF_JGT, reg, max, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_A(0));
+
+        return 0;
+    }
 
     EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP32_IMM(BPF_JLT, reg, min, 0));
     EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP32_IMM(BPF_JGT, reg, max, 0));
@@ -279,17 +325,20 @@ int bf_cmp_range(struct bf_program *program, uint32_t min, uint32_t max,
     return 0;
 }
 
-int bf_cmp_bitfield(struct bf_program *program, enum bf_matcher_op op,
-                    uint32_t flags, int reg)
+int bf_cmp_bitfield(struct bf_program *program,
+                    const struct bf_matcher *matcher, uint32_t flags, int reg)
 {
+    enum bf_matcher_op op = bf_matcher_get_op(matcher);
+
     assert(program);
+    assert(matcher);
 
     if (op != BF_MATCHER_ANY && op != BF_MATCHER_ALL)
         return bf_err_r(-EINVAL, "unsupported operator %d", op);
 
     EMIT(program, BPF_ALU32_IMM(BPF_AND, reg, flags));
     EMIT_FIXUP_JMP_NEXT_RULE(
-        program, BPF_JMP32_IMM(op == BF_MATCHER_ANY ? BPF_JEQ : BPF_JNE, reg,
+        program, BPF_JMP32_IMM(bf_cmp_get_jmp_ins(matcher), reg,
                                op == BF_MATCHER_ANY ? 0 : flags, 0));
 
     return 0;

--- a/src/libbpfilter/cgen/matcher/cmp.h
+++ b/src/libbpfilter/cgen/matcher/cmp.h
@@ -7,72 +7,98 @@
 
 #include <stdint.h>
 
-#include <bpfilter/matcher.h>
-
+struct bf_matcher;
 struct bf_program;
 
 /**
+ * @brief Get the BPF jump opcode for a matcher, accounting for negation.
+ *
+ * Returns the BPF opcode to use in a jump-to-next-rule instruction. The
+ * returned opcode encodes the "skip if not matching" semantics, with the
+ * matcher's `bf_matcher_op` and negation flag already folded in.
+ *
+ * Not valid for `BF_MATCHER_RANGE`, which requires two separate jump
+ * instructions with different opcodes.
+ *
+ * @param matcher Matcher to query. Can't be NULL.
+ * @return BPF jump opcode (e.g. `BPF_JNE` or `BPF_JEQ`).
+ */
+uint8_t bf_cmp_get_jmp_ins(const struct bf_matcher *matcher);
+
+/**
  * @brief Compare the value in `reg` against a reference value.
+ *
+ * Only valid for `BF_MATCHER_EQ` operator (use `negate` flag for
+ * inequality).
  *
  * For size 16, the value spans `reg` (low 64 bits) and `reg + 1`
  * (high 64 bits). Clobbers `BPF_REG_2` for size 4/8 and
  * `BPF_REG_3`/`BPF_REG_4` for size 16.
  *
  * @param program Program to emit into. Can't be NULL.
- * @param op `BF_MATCHER_EQ` or `BF_MATCHER_NE`.
+ * @param matcher Matcher to query for op and negation. Can't be NULL.
  * @param ref Pointer to reference value. Can't be NULL.
  * @param size Comparison width in bytes: 1, 2, 4, 8, or 16.
  * @param reg BPF register holding the value to compare.
  * @return 0 on success, negative errno on error.
  */
-int bf_cmp_value(struct bf_program *program, enum bf_matcher_op op,
+int bf_cmp_value(struct bf_program *program, const struct bf_matcher *matcher,
                  const void *ref, unsigned int size, int reg);
 
 /**
  * @brief Mask the value in `reg` by `prefixlen`, then compare.
+ *
+ * Only valid for `BF_MATCHER_EQ` operator (use `negate` flag for
+ * inequality).
  *
  * For size 16, the value spans `reg` and `reg + 1`. Modifies `reg`
  * (and `reg + 1`) in-place. Clobbers `BPF_REG_2`/`BPF_REG_3` for
  * size 4 and `BPF_REG_3`/`BPF_REG_4` for size 16.
  *
  * @param program Program to emit into. Can't be NULL.
- * @param op `BF_MATCHER_EQ` or `BF_MATCHER_NE`.
+ * @param matcher Matcher to query for op and negation. Can't be NULL.
  * @param ref Pointer to unmasked reference value. Can't be NULL.
  * @param prefixlen Prefix length in bits (1-32 for size 4, 1-128 for size 16).
  * @param size Comparison width in bytes: 4 or 16.
  * @param reg BPF register holding the value to compare.
  * @return 0 on success, negative errno on error.
  */
-int bf_cmp_masked_value(struct bf_program *program, enum bf_matcher_op op,
-                        const void *ref, unsigned int prefixlen,
-                        unsigned int size, int reg);
+int bf_cmp_masked_value(struct bf_program *program,
+                        const struct bf_matcher *matcher, const void *ref,
+                        unsigned int prefixlen, unsigned int size, int reg);
 
 /**
  * @brief Check `min <= reg <= max`, for values up to 32 bits.
+ *
+ * Only valid for `BF_MATCHER_RANGE` operator. If the matcher's
+ * negation flag is set, matches when the value is outside the range.
  *
  * All values must be in host byte order; the caller is responsible for
  * any conversion (e.g., `BSWAP` for network-order port values).
  *
  * @param program Program to emit into. Can't be NULL.
+ * @param matcher Matcher to query for negation. Can't be NULL.
  * @param min Minimum value.
  * @param max Maximum value.
  * @param reg BPF register holding the value to compare.
  * @return 0 on success, negative errno on error.
  */
-int bf_cmp_range(struct bf_program *program, uint32_t min, uint32_t max,
-                 int reg);
+int bf_cmp_range(struct bf_program *program, const struct bf_matcher *matcher,
+                 uint32_t min, uint32_t max, int reg);
 
 /**
  * @brief Check `reg` against a bitmask, for values up to 32 bits.
+ *
+ * Only valid for `BF_MATCHER_ANY` and `BF_MATCHER_ALL` operators.
  *
  * ANY: `(reg & flags) != 0`
  * ALL: `(reg & flags) == flags`
  *
  * @param program Program to emit into. Can't be NULL.
- * @param op `BF_MATCHER_ANY` or `BF_MATCHER_ALL`.
+ * @param matcher Matcher to query for op and negation. Can't be NULL.
  * @param flags Bitmask to check against.
  * @param reg BPF register holding the value to check.
  * @return 0 on success, negative errno on error.
  */
-int bf_cmp_bitfield(struct bf_program *program, enum bf_matcher_op op,
-                    uint32_t flags, int reg);
+int bf_cmp_bitfield(struct bf_program *program,
+                    const struct bf_matcher *matcher, uint32_t flags, int reg);

--- a/src/libbpfilter/cgen/matcher/meta.c
+++ b/src/libbpfilter/cgen/matcher/meta.c
@@ -21,6 +21,7 @@
 #include <bpfilter/logger.h>
 #include <bpfilter/matcher.h>
 
+#include "cgen/jmp.h"
 #include "cgen/matcher/cmp.h"
 #include "cgen/program.h"
 #include "cgen/runtime.h"
@@ -35,7 +36,7 @@ static int _bf_matcher_generate_meta_iface(struct bf_program *program,
     EMIT(program,
          BPF_LDX_MEM(BPF_H, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(ifindex)));
     EMIT_FIXUP_JMP_NEXT_RULE(
-        program, BPF_JMP_IMM(BPF_JNE, BPF_REG_1,
+        program, BPF_JMP_IMM(bf_cmp_get_jmp_ins(matcher), BPF_REG_1,
                              *(uint32_t *)bf_matcher_payload(matcher), 0));
 
     return 0;
@@ -46,12 +47,17 @@ _bf_matcher_generate_meta_probability(struct bf_program *program,
                                       const struct bf_matcher *matcher)
 {
     float proba = *(float *)bf_matcher_payload(matcher);
+    uint32_t threshold = (uint32_t)((double)UINT32_MAX * (proba / 100.0));
 
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_get_prandom_u32));
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program,
-        BPF_JMP_IMM(BPF_JGT, BPF_REG_0,
-                    (uint32_t)((double)UINT32_MAX * (proba / 100.0)), 0));
+
+    if (bf_matcher_get_negate(matcher)) {
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JLE, BPF_REG_0, threshold, 0));
+    } else {
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(BPF_JGT, BPF_REG_0, threshold, 0));
+    }
 
     return 0;
 }
@@ -92,11 +98,10 @@ static int _bf_matcher_generate_meta_port(struct bf_program *program,
 
     if (bf_matcher_get_op(matcher) == BF_MATCHER_RANGE) {
         EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
-        return bf_cmp_range(program, port[0], port[1], BPF_REG_1);
+        return bf_cmp_range(program, matcher, port[0], port[1], BPF_REG_1);
     }
 
-    return bf_cmp_value(program, bf_matcher_get_op(matcher), port, 2,
-                        BPF_REG_1);
+    return bf_cmp_value(program, matcher, port, 2, BPF_REG_1);
 }
 
 static int
@@ -104,6 +109,7 @@ _bf_matcher_generate_meta_flow_probability(struct bf_program *program,
                                            const struct bf_matcher *matcher)
 {
     float proba = *(float *)bf_matcher_payload(matcher);
+    uint32_t threshold = (uint32_t)((double)UINT32_MAX * (proba / 100.0));
 
     // Ensure L3 is IPv4 or IPv6, skip to next rule otherwise
     EMIT(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_7, htobe16(ETH_P_IP), 2));
@@ -140,10 +146,13 @@ _bf_matcher_generate_meta_flow_probability(struct bf_program *program,
     /* Compare the computed hash with the threshold based on probability.
      * The hash is uniformly distributed across 32 bits, so we compare against
      * UINT32_MAX * (proba / 100.0) to select the desired percentage of flows. */
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program,
-        BPF_JMP32_IMM(BPF_JGT, BPF_REG_0,
-                      (uint32_t)((double)UINT32_MAX * (proba / 100.0)), 0));
+    if (bf_matcher_get_negate(matcher)) {
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP32_IMM(BPF_JLE, BPF_REG_0, threshold, 0));
+    } else {
+        EMIT_FIXUP_JMP_NEXT_RULE(
+            program, BPF_JMP32_IMM(BPF_JGT, BPF_REG_0, threshold, 0));
+    }
 
     return 0;
 }
@@ -156,11 +165,11 @@ int bf_matcher_generate_meta(struct bf_program *program,
         return _bf_matcher_generate_meta_iface(program, matcher);
     case BF_MATCHER_META_L3_PROTO: {
         uint16_t be_val = htobe16(*(uint16_t *)bf_matcher_payload(matcher));
-        return bf_cmp_value(program, BF_MATCHER_EQ, &be_val, 2, BPF_REG_7);
+        return bf_cmp_value(program, matcher, &be_val, 2, BPF_REG_7);
     }
     case BF_MATCHER_META_L4_PROTO:
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 1, BPF_REG_8);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 1,
+                            BPF_REG_8);
     case BF_MATCHER_META_PROBABILITY:
         return _bf_matcher_generate_meta_probability(program, matcher);
     case BF_MATCHER_META_SPORT:

--- a/src/libbpfilter/cgen/matcher/set.c
+++ b/src/libbpfilter/cgen/matcher/set.c
@@ -7,6 +7,7 @@
 
 #include <bpfilter/matcher.h>
 
+#include "cgen/matcher/cmp.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
 
@@ -22,8 +23,8 @@ int bf_set_generate_map_lookup(struct bf_program *program,
     EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, key_offset));
     EMIT(program, BPF_EMIT_CALL(BPF_FUNC_map_lookup_elem));
 
-    // Jump to the next rule if map_lookup_elem returned 0
-    EMIT_FIXUP_JMP_NEXT_RULE(program, BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 0));
+    EMIT_FIXUP_JMP_NEXT_RULE(
+        program, BPF_JMP_IMM(bf_cmp_get_jmp_ins(matcher), BPF_REG_0, 0, 0));
 
     return 0;
 }

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -146,8 +146,8 @@ static int _bf_nf_gen_inline_matcher(struct bf_program *program,
             return offset;
         EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_2, offset));
 
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 4, BPF_REG_1);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 4,
+                            BPF_REG_1);
     default:
         return bf_packet_gen_inline_matcher(program, matcher);
     }

--- a/src/libbpfilter/cgen/packet.c
+++ b/src/libbpfilter/cgen/packet.c
@@ -132,9 +132,8 @@ static int _bf_matcher_pkt_load_and_cmp(struct bf_program *program,
     if (r)
         return r;
 
-    return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                        bf_matcher_payload(matcher), meta->hdr_payload_size,
-                        BPF_REG_1);
+    return bf_cmp_value(program, matcher, bf_matcher_payload(matcher),
+                        meta->hdr_payload_size, BPF_REG_1);
 }
 
 static int _bf_matcher_pkt_generate_net(struct bf_program *program,
@@ -150,8 +149,8 @@ static int _bf_matcher_pkt_generate_net(struct bf_program *program,
     if (r)
         return r;
 
-    return bf_cmp_masked_value(program, bf_matcher_get_op(matcher), data,
-                               prefixlen, meta->hdr_payload_size, BPF_REG_1);
+    return bf_cmp_masked_value(program, matcher, data, prefixlen,
+                               meta->hdr_payload_size, BPF_REG_1);
 }
 
 static int _bf_matcher_pkt_generate_port(struct bf_program *program,
@@ -171,12 +170,11 @@ static int _bf_matcher_pkt_generate_port(struct bf_program *program,
          * reference value. This is a JLT/JGT comparison, we need to have the
          * MSB where the machine expects then. */
         EMIT(program, BPF_BSWAP(BPF_REG_1, 16));
-        return bf_cmp_range(program, ports[0], ports[1], BPF_REG_1);
+        return bf_cmp_range(program, matcher, ports[0], ports[1], BPF_REG_1);
     }
 
-    return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                        bf_matcher_payload(matcher), meta->hdr_payload_size,
-                        BPF_REG_1);
+    return bf_cmp_value(program, matcher, bf_matcher_payload(matcher),
+                        meta->hdr_payload_size, BPF_REG_1);
 }
 
 static int
@@ -193,13 +191,15 @@ _bf_matcher_pkt_generate_tcp_flags(struct bf_program *program,
     switch (bf_matcher_get_op(matcher)) {
     case BF_MATCHER_ANY:
     case BF_MATCHER_ALL:
-        return bf_cmp_bitfield(program, bf_matcher_get_op(matcher),
+        return bf_cmp_bitfield(program, matcher,
                                *(uint8_t *)bf_matcher_payload(matcher),
                                BPF_REG_1);
+    case BF_MATCHER_EQ:
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher),
+                            meta->hdr_payload_size, BPF_REG_1);
     default:
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), meta->hdr_payload_size,
-                            BPF_REG_1);
+        return bf_err_r(-EINVAL, "unsupported operator %d",
+                        bf_matcher_get_op(matcher));
     }
 }
 
@@ -209,6 +209,9 @@ _bf_matcher_pkt_generate_ip6_nexthdr(struct bf_program *program,
 {
     const uint8_t ehdr = *(uint8_t *)bf_matcher_payload(matcher);
     uint8_t eh_mask;
+    uint8_t jmp_op;
+
+    jmp_op = bf_cmp_get_jmp_ins(matcher);
 
     switch (ehdr) {
     case IPPROTO_HOPOPTS:
@@ -226,19 +229,19 @@ _bf_matcher_pkt_generate_ip6_nexthdr(struct bf_program *program,
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10,
                                   BF_PROG_CTX_OFF(ipv6_eh)));
         EMIT(program, BPF_ALU64_IMM(BPF_AND, BPF_REG_1, eh_mask));
+
+        /* Extension header check: after AND with eh_mask, a non-zero
+         * result means the header is present. For EQ (jmp_op=JNE),
+         * we want to skip if zero (not present), so we use the
+         * *opposite* opcode here. */
         EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM((bf_matcher_get_op(matcher) == BF_MATCHER_EQ) ?
-                                     BPF_JEQ :
-                                     BPF_JNE,
+            program, BPF_JMP_IMM(jmp_op == BPF_JNE ? BPF_JEQ : BPF_JNE,
                                  BPF_REG_1, 0, 0));
         break;
     default:
         /* check l4 protocols using `BPF_REG_8` */
-        EMIT_FIXUP_JMP_NEXT_RULE(
-            program, BPF_JMP_IMM((bf_matcher_get_op(matcher) == BF_MATCHER_EQ) ?
-                                     BPF_JNE :
-                                     BPF_JEQ,
-                                 BPF_REG_8, ehdr, 0));
+        EMIT_FIXUP_JMP_NEXT_RULE(program,
+                                 BPF_JMP_IMM(jmp_op, BPF_REG_8, ehdr, 0));
         break;
     }
 
@@ -262,11 +265,9 @@ static int _bf_matcher_pkt_generate_ip4_dscp(struct bf_program *program,
      * the 6-bit DSCP field, then compare against dscp << 2. */
     EMIT(program, BPF_ALU64_IMM(BPF_AND, BPF_REG_1, 0xfc));
 
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program,
-        BPF_JMP_IMM(bf_matcher_get_op(matcher) == BF_MATCHER_EQ ? BPF_JNE :
-                                                                  BPF_JEQ,
-                    BPF_REG_1, (uint8_t)dscp << 2, 0));
+    EMIT_FIXUP_JMP_NEXT_RULE(program,
+                             BPF_JMP_IMM(bf_cmp_get_jmp_ins(matcher), BPF_REG_1,
+                                         (uint8_t)dscp << 2, 0));
 
     return 0;
 }
@@ -292,11 +293,9 @@ static int _bf_matcher_pkt_generate_ip6_dscp(struct bf_program *program,
     EMIT(program, BPF_ENDIAN(BPF_TO_BE, BPF_REG_1, 16));
     EMIT(program, BPF_ALU64_IMM(BPF_AND, BPF_REG_1, 0x0fc0));
 
-    EMIT_FIXUP_JMP_NEXT_RULE(
-        program,
-        BPF_JMP_IMM(bf_matcher_get_op(matcher) == BF_MATCHER_EQ ? BPF_JNE :
-                                                                  BPF_JEQ,
-                    BPF_REG_1, (uint16_t)dscp << 6, 0));
+    EMIT_FIXUP_JMP_NEXT_RULE(program,
+                             BPF_JMP_IMM(bf_cmp_get_jmp_ins(matcher), BPF_REG_1,
+                                         (uint16_t)dscp << 6, 0));
 
     return 0;
 }

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -100,8 +100,8 @@ static int _bf_tc_gen_inline_matcher(struct bf_program *program,
         EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_1,
                                   offsetof(struct __sk_buff, mark)));
 
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 4, BPF_REG_1);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 4,
+                            BPF_REG_1);
     case BF_MATCHER_META_FLOW_HASH:
         EMIT(program,
              BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
@@ -109,11 +109,11 @@ static int _bf_tc_gen_inline_matcher(struct bf_program *program,
 
         if (bf_matcher_get_op(matcher) == BF_MATCHER_RANGE) {
             uint32_t *hash = (uint32_t *)bf_matcher_payload(matcher);
-            return bf_cmp_range(program, hash[0], hash[1], BPF_REG_0);
+            return bf_cmp_range(program, matcher, hash[0], hash[1], BPF_REG_0);
         }
 
-        return bf_cmp_value(program, bf_matcher_get_op(matcher),
-                            bf_matcher_payload(matcher), 4, BPF_REG_0);
+        return bf_cmp_value(program, matcher, bf_matcher_payload(matcher), 4,
+                            BPF_REG_0);
     default:
         return bf_packet_gen_inline_matcher(program, matcher);
     }

--- a/src/libbpfilter/include/bpfilter/matcher.h
+++ b/src/libbpfilter/include/bpfilter/matcher.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -183,8 +184,6 @@ enum bf_matcher_op
 {
     /// Test for equality.
     BF_MATCHER_EQ,
-    /// Test for inequality.
-    BF_MATCHER_NE,
     /// Test for partial subset match
     BF_MATCHER_ANY,
     /// Test for complete subset match
@@ -269,11 +268,12 @@ struct bf_matcher_meta
  *        @p type . Can be NULL but only if @p payload_len is 0, in which case
  *        there is no payload.
  * @param payload_len Length of the payload.
+ * @param negate If true, negate the comparison result.
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
                    enum bf_matcher_op op, const void *payload,
-                   size_t payload_len);
+                   size_t payload_len, bool negate);
 
 /**
  * @brief Allocate and initialise a new matcher from a raw payload (string).
@@ -284,11 +284,12 @@ int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
  * @param op Comparison operator.
  * @param payload Raw payload, as a string, to parse and populate the matcher
  *        with. Can't be NULL.
+ * @param negate If true, negate the comparison result.
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_matcher_new_from_raw(struct bf_matcher **matcher,
                             enum bf_matcher_type type, enum bf_matcher_op op,
-                            const char *payload);
+                            const char *payload, bool negate);
 
 /**
  * @brief Allocate and initalize a new matcher from serialized data.
@@ -329,6 +330,7 @@ enum bf_matcher_op bf_matcher_get_op(const struct bf_matcher *matcher);
 const void *bf_matcher_payload(const struct bf_matcher *matcher);
 size_t bf_matcher_payload_len(const struct bf_matcher *matcher);
 size_t bf_matcher_len(const struct bf_matcher *matcher);
+bool bf_matcher_get_negate(const struct bf_matcher *matcher);
 
 /**
  * @brief Get meta structure for a given matcher type.

--- a/src/libbpfilter/include/bpfilter/rule.h
+++ b/src/libbpfilter/include/bpfilter/rule.h
@@ -137,11 +137,12 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix);
  *        type . Can be NULL but only if @p payload_len is 0, in which case
  *        there is no payload.
  * @param payload_len Length of the payload.
+ * @param negate If true, negate the matcher's comparison.
  * @return 0 on success, or negative errno value on failure.
  */
 int bf_rule_add_matcher(struct bf_rule *rule, enum bf_matcher_type type,
                         enum bf_matcher_op op, const void *payload,
-                        size_t payload_len);
+                        size_t payload_len, bool negate);
 
 static inline void bf_rule_mark_set(struct bf_rule *rule, uint32_t mark)
 {

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -59,6 +59,8 @@ struct bf_matcher
     enum bf_matcher_type type;
     /// Comparison operator.
     enum bf_matcher_op op;
+    /// Negate the comparison result.
+    bool negate;
     /// Total matcher size (including payload).
     size_t len;
     /// Payload to match the packet against (if any).
@@ -843,8 +845,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
                                    _bf_parse_l4_proto, _bf_print_l4_proto),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
-                                   _bf_parse_l4_proto, _bf_print_l4_proto),
                 },
         },
     [BF_MATCHER_META_SPORT] =
@@ -854,8 +854,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,
@@ -868,8 +866,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
                                    _bf_parse_l4_port_range,
@@ -895,8 +891,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint32_t),
                                    _bf_parse_mark, _bf_print_mark),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint32_t),
-                                   _bf_parse_mark, _bf_print_mark),
                 },
         },
     [BF_MATCHER_META_FLOW_HASH] =
@@ -911,8 +905,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint32_t),
-                                   _bf_parse_u32, _bf_print_u32),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint32_t),
                                    _bf_parse_u32, _bf_print_u32),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint32_t),
                                    _bf_parse_u32_range, _bf_print_u32_range),
@@ -944,8 +936,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint32_t),
                                    _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint32_t),
-                                   _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint32_t),
                                    _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
                 },
@@ -960,8 +950,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint32_t),
-                                   _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint32_t),
                                    _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint32_t),
                                    _bf_parse_ipv4_addr, _bf_print_ipv4_addr),
@@ -979,8 +967,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct bf_ip4_lpm_key),
                                    _bf_parse_ipv4_net, _bf_print_ipv4_net),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct bf_ip4_lpm_key),
-                                   _bf_parse_ipv4_net, _bf_print_ipv4_net),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct bf_ip4_lpm_key),
                                    _bf_parse_ipv4_net, _bf_print_ipv4_net),
                 },
@@ -995,8 +981,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct bf_ip4_lpm_key),
-                                   _bf_parse_ipv4_net, _bf_print_ipv4_net),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct bf_ip4_lpm_key),
                                    _bf_parse_ipv4_net, _bf_print_ipv4_net),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct bf_ip4_lpm_key),
                                    _bf_parse_ipv4_net, _bf_print_ipv4_net),
@@ -1013,8 +997,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_l4_proto, _bf_print_l4_proto),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_l4_proto, _bf_print_l4_proto),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_l4_proto, _bf_print_l4_proto),
                 },
@@ -1030,8 +1012,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_dscp, _bf_print_dscp),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_dscp, _bf_print_dscp),
                 },
         },
     [BF_MATCHER_IP6_SADDR] =
@@ -1045,8 +1025,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct in6_addr),
-                                   _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct in6_addr),
                                    _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct in6_addr),
                                    _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
@@ -1062,8 +1040,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct in6_addr),
-                                   _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct in6_addr),
                                    _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct in6_addr),
                                    _bf_parse_ipv6_addr, _bf_print_ipv6_addr),
@@ -1081,8 +1057,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct bf_ip6_lpm_key),
                                    _bf_parse_ipv6_net, _bf_print_ipv6_net),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct bf_ip6_lpm_key),
-                                   _bf_parse_ipv6_net, _bf_print_ipv6_net),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct bf_ip6_lpm_key),
                                    _bf_parse_ipv6_net, _bf_print_ipv6_net),
                 },
@@ -1097,8 +1071,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(struct bf_ip6_lpm_key),
-                                   _bf_parse_ipv6_net, _bf_print_ipv6_net),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(struct bf_ip6_lpm_key),
                                    _bf_parse_ipv6_net, _bf_print_ipv6_net),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(struct bf_ip6_lpm_key),
                                    _bf_parse_ipv6_net, _bf_print_ipv6_net),
@@ -1115,8 +1087,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_l4_proto, _bf_print_l4_proto),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_l4_proto, _bf_print_l4_proto),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_l4_proto, _bf_print_l4_proto),
                 },
@@ -1132,8 +1102,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_dscp, _bf_print_dscp),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_dscp, _bf_print_dscp),
                 },
         },
     [BF_MATCHER_TCP_SPORT] =
@@ -1146,8 +1114,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
@@ -1168,8 +1134,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
@@ -1188,8 +1152,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_tcp_flags, _bf_print_tcp_flags),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_tcp_flags, _bf_print_tcp_flags),
                     BF_MATCHER_OPS(BF_MATCHER_ANY, sizeof(uint8_t),
                                    _bf_parse_tcp_flags, _bf_print_tcp_flags),
                     BF_MATCHER_OPS(BF_MATCHER_ALL, sizeof(uint8_t),
@@ -1207,8 +1169,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_RANGE, 2 * sizeof(uint16_t),
@@ -1225,8 +1185,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint16_t),
-                                   _bf_parse_l4_port, _bf_print_l4_port),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint16_t),
                                    _bf_parse_l4_port, _bf_print_l4_port),
@@ -1246,8 +1204,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_icmp_type, _bf_print_icmp_type),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_icmp_type, _bf_print_icmp_type),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_icmp_type, _bf_print_icmp_type),
                 },
@@ -1262,8 +1218,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
-                                   _bf_parse_icmp_code, _bf_print_icmp_code),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
                                    _bf_parse_icmp_code, _bf_print_icmp_code),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_icmp_code, _bf_print_icmp_code),
@@ -1281,9 +1235,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
                                    _bf_parse_icmpv6_type,
                                    _bf_print_icmpv6_type),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
-                                   _bf_parse_icmpv6_type,
-                                   _bf_print_icmpv6_type),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_icmpv6_type,
                                    _bf_print_icmpv6_type),
@@ -1299,8 +1250,6 @@ static struct bf_matcher_meta _bf_matcher_metas[_BF_MATCHER_TYPE_MAX] = {
             .ops =
                 {
                     BF_MATCHER_OPS(BF_MATCHER_EQ, sizeof(uint8_t),
-                                   _bf_parse_icmp_code, _bf_print_icmp_code),
-                    BF_MATCHER_OPS(BF_MATCHER_NE, sizeof(uint8_t),
                                    _bf_parse_icmp_code, _bf_print_icmp_code),
                     BF_MATCHER_OPS(BF_MATCHER_IN, sizeof(uint8_t),
                                    _bf_parse_icmp_code, _bf_print_icmp_code),
@@ -1335,7 +1284,7 @@ const struct bf_matcher_ops *bf_matcher_get_ops(enum bf_matcher_type type,
 
 int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
                    enum bf_matcher_op op, const void *payload,
-                   size_t payload_len)
+                   size_t payload_len, bool negate)
 {
     _free_bf_matcher_ struct bf_matcher *_matcher = NULL;
 
@@ -1348,6 +1297,7 @@ int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
 
     _matcher->type = type;
     _matcher->op = op;
+    _matcher->negate = negate;
     _matcher->len = sizeof(struct bf_matcher) + payload_len;
     bf_memcpy(_matcher->payload, payload, payload_len);
 
@@ -1358,7 +1308,7 @@ int bf_matcher_new(struct bf_matcher **matcher, enum bf_matcher_type type,
 
 int bf_matcher_new_from_raw(struct bf_matcher **matcher,
                             enum bf_matcher_type type, enum bf_matcher_op op,
-                            const char *payload)
+                            const char *payload, bool negate)
 {
     _free_bf_matcher_ struct bf_matcher *_matcher = NULL;
     const struct bf_matcher_ops *ops;
@@ -1379,6 +1329,7 @@ int bf_matcher_new_from_raw(struct bf_matcher **matcher,
 
     _matcher->type = type;
     _matcher->op = op;
+    _matcher->negate = negate;
     _matcher->len = sizeof(*_matcher) + ops->ref_payload_size;
 
     r = ops->parse(_matcher->type, _matcher->op, &_matcher->payload, payload);
@@ -1397,6 +1348,7 @@ int bf_matcher_new_from_pack(struct bf_matcher **matcher, bf_rpack_node_t node)
     enum bf_matcher_op op;
     const void *payload;
     size_t payload_len;
+    bool negate = false;
     int r;
 
     assert(matcher);
@@ -1409,11 +1361,17 @@ int bf_matcher_new_from_pack(struct bf_matcher **matcher, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_matcher.op");
 
+    if (bf_rpack_kv_contains(node, "negate")) {
+        r = bf_rpack_kv_bool(node, "negate", &negate);
+        if (r)
+            return bf_rpack_key_err(r, "bf_matcher.negate");
+    }
+
     r = bf_rpack_kv_bin(node, "payload", &payload, &payload_len);
     if (r)
         return bf_rpack_key_err(r, "bf_matcher.payload");
 
-    r = bf_matcher_new(&_matcher, type, op, payload, payload_len);
+    r = bf_matcher_new(&_matcher, type, op, payload, payload_len, negate);
     if (r)
         return bf_err_r(r, "failed to create bf_matcher from pack");
 
@@ -1440,6 +1398,7 @@ int bf_matcher_pack(const struct bf_matcher *matcher, bf_wpack_t *pack)
 
     bf_wpack_kv_int(pack, "type", matcher->type);
     bf_wpack_kv_int(pack, "op", matcher->op);
+    bf_wpack_kv_bool(pack, "negate", matcher->negate);
     bf_wpack_kv_bin(pack, "payload", matcher->payload,
                     matcher->len - sizeof(*matcher));
 
@@ -1457,6 +1416,7 @@ void bf_matcher_dump(const struct bf_matcher *matcher, prefix_t *prefix)
 
     DUMP(prefix, "type: %s", bf_matcher_type_to_str(matcher->type));
     DUMP(prefix, "op: %s", bf_matcher_op_to_str(matcher->op));
+    DUMP(prefix, "negate: %s", matcher->negate ? "true" : "false");
     DUMP(prefix, "len: %ld", matcher->len);
     DUMP(bf_dump_prefix_last(prefix), "payload:");
     bf_dump_prefix_push(prefix);
@@ -1495,6 +1455,12 @@ size_t bf_matcher_len(const struct bf_matcher *matcher)
 {
     assert(matcher);
     return matcher->len;
+}
+
+bool bf_matcher_get_negate(const struct bf_matcher *matcher)
+{
+    assert(matcher);
+    return matcher->negate;
 }
 
 static const char *_bf_matcher_type_strs[] = {
@@ -1557,9 +1523,9 @@ int bf_matcher_type_from_str(const char *str, enum bf_matcher_type *type)
 }
 
 static const char *_bf_matcher_ops_strs[] = {
-    [BF_MATCHER_EQ] = "eq",   [BF_MATCHER_NE] = "not",
-    [BF_MATCHER_ANY] = "any", [BF_MATCHER_ALL] = "all",
-    [BF_MATCHER_IN] = "in",   [BF_MATCHER_RANGE] = "range",
+    [BF_MATCHER_EQ] = "eq",       [BF_MATCHER_ANY] = "any",
+    [BF_MATCHER_ALL] = "all",     [BF_MATCHER_IN] = "in",
+    [BF_MATCHER_RANGE] = "range",
 };
 
 static_assert_enum_mapping(_bf_matcher_ops_strs, _BF_MATCHER_OP_MAX);

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -203,14 +203,14 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
 
 int bf_rule_add_matcher(struct bf_rule *rule, enum bf_matcher_type type,
                         enum bf_matcher_op op, const void *payload,
-                        size_t payload_len)
+                        size_t payload_len, bool negate)
 {
     _free_bf_matcher_ struct bf_matcher *matcher = NULL;
     int r;
 
     assert(rule);
 
-    r = bf_matcher_new(&matcher, type, op, payload, payload_len);
+    r = bf_matcher_new(&matcher, type, op, payload, payload_len, negate);
     if (r)
         return r;
 

--- a/tests/e2e/matchers/icmp_code.cpp
+++ b/tests/e2e/matchers/icmp_code.cpp
@@ -54,20 +54,44 @@ static void icmp_code_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_icmp_code", 0, 1, -1);
-}
 
-/**
- * Verify that icmp.code ne N does not match a packet with code N
- * but matches packets with different codes.
- */
-static void icmp_code_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
+    // Try with negation
+    BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ,
+                                           {3}, true)}));
 
-    BFT_CHAIN_SET(
-        bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_NE, {3})}));
+    // ICMP code=3 should NOT match the rule -> ACCEPT (policy)
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::ICMPv4 {.type = 8, .code = 3},
+        test->verdictAccept());
+
+    // ICMP code=0 should match -> DROP
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::ICMPv4 {.type = 8, .code = 0},
+        test->verdictDrop());
+
+    // TCP packet must not match an ICMP rule (protocol guard) -> ACCEPT
+    // This does not change for matcher negation
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictAccept());
+
+    bft_assert_counter_eq("test_icmp_code", 0, 1, -1);
+
+    BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ,
+                                           {3}, true)}));
 
     // ICMP code=3 should not match -> ACCEPT (policy)
     bft_assert_prog_run(
@@ -108,7 +132,7 @@ static void icmp_code_in(void **state)
     set << std::vector<uint8_t> {3} << std::vector<uint8_t> {0};
 
     BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
-                  << std::move(set)
+                  << set
                   << bf::Rule(BF_VERDICT_DROP, true, {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
@@ -138,6 +162,39 @@ static void icmp_code_in(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_icmp_code", 0, 2, -1);
+
+    // Try with negation
+    BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
+                  << set
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
+                                           {0, 0, 0, 0}, true)}));
+
+    // ICMP code=3 is in set so negation is -> ACCEPT
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::ICMPv4 {.type = 8, .code = 3},
+        test->verdictAccept());
+
+    // ICMP code=0 is also in set so negation is -> ACCEPT
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::ICMPv4 {.type = 8, .code = 0},
+        test->verdictAccept());
+
+    // ICMP code=5 is not in set so negation is -> DROP
+    bft_assert_prog_run(
+        "test_icmp_code", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::ICMPv4 {.type = 8, .code = 5},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_icmp_code", 0, 1, -1);
 }
 
 int main()
@@ -145,7 +202,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_ICMP_CODE);
 
     suite << MatcherTest(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ, icmp_code_eq);
-    suite << MatcherTest(BF_MATCHER_ICMP_CODE, BF_MATCHER_NE, icmp_code_ne);
     suite << MatcherTest(BF_MATCHER_ICMP_CODE, BF_MATCHER_IN, icmp_code_in);
 
     return suite.run();

--- a/tests/e2e/matchers/icmp_type.cpp
+++ b/tests/e2e/matchers/icmp_type.cpp
@@ -53,20 +53,12 @@ static void icmp_type_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_icmp_type", 0, 1, -1);
-}
 
-/**
- * Verify that icmp.type ne N does not match a packet with type N
- * but matches packets with different types.
- */
-static void icmp_type_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
-    BFT_CHAIN_SET(
-        bf::Chain("test_icmp_type", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_ICMP_TYPE, BF_MATCHER_NE, {8})}));
+    // Negation
+    BFT_CHAIN_SET(bf::Chain("test_icmp_type", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ,
+                                           {8}, true)}));
 
     // ICMP type=8 should not match -> ACCEPT (policy)
     bft_assert_prog_run(
@@ -144,7 +136,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_ICMP_TYPE);
 
     suite << MatcherTest(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ, icmp_type_eq);
-    suite << MatcherTest(BF_MATCHER_ICMP_TYPE, BF_MATCHER_NE, icmp_type_ne);
     suite << MatcherTest(BF_MATCHER_ICMP_TYPE, BF_MATCHER_IN, icmp_type_in);
 
     return suite.run();

--- a/tests/e2e/matchers/icmpv6_code.cpp
+++ b/tests/e2e/matchers/icmpv6_code.cpp
@@ -53,20 +53,12 @@ static void icmpv6_code_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_icmpv6_code", 0, 1, -1);
-}
 
-/**
- * Verify that icmpv6.code ne N does not match a packet with code N
- * but matches packets with different codes.
- */
-static void icmpv6_code_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
-    BFT_CHAIN_SET(
-        bf::Chain("test_icmpv6_code", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_NE, {3})}));
+    // Negation
+    BFT_CHAIN_SET(bf::Chain("test_icmpv6_code", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_ICMPV6_CODE,
+                                           BF_MATCHER_EQ, {3}, true)}));
 
     // ICMPv6 code=3 should not match -> ACCEPT
     bft_assert_prog_run(
@@ -144,7 +136,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_ICMPV6_CODE);
 
     suite << MatcherTest(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_EQ, icmpv6_code_eq);
-    suite << MatcherTest(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_NE, icmpv6_code_ne);
     suite << MatcherTest(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_IN, icmpv6_code_in);
 
     return suite.run();

--- a/tests/e2e/matchers/icmpv6_type.cpp
+++ b/tests/e2e/matchers/icmpv6_type.cpp
@@ -53,20 +53,12 @@ static void icmpv6_type_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_icmpv6_type", 0, 1, -1);
-}
 
-/**
- * Verify that icmpv6.type ne N does not match a packet with type N
- * but matches packets with different types.
- */
-static void icmpv6_type_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_type", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
                               {bf::Matcher(BF_MATCHER_ICMPV6_TYPE,
-                                           BF_MATCHER_NE, {128})}));
+                                           BF_MATCHER_EQ, {128}, true)}));
 
     // ICMPv6 type=128 should not match -> ACCEPT
     bft_assert_prog_run(
@@ -144,7 +136,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_ICMPV6_TYPE);
 
     suite << MatcherTest(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ, icmpv6_type_eq);
-    suite << MatcherTest(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_NE, icmpv6_type_ne);
     suite << MatcherTest(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_IN, icmpv6_type_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip4_daddr.cpp
+++ b/tests/e2e/matchers/ip4_daddr.cpp
@@ -41,20 +41,12 @@ static void ip4_daddr_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip4_daddr", 0, 1, -1);
-}
 
-/**
- * Verify ip4.daddr ne does not match the configured destination address but
- * matches all other addresses. Counter tracks only matching packets.
- */
-static void ip4_daddr_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip4_daddr", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP4_DADDR, BF_MATCHER_NE,
-                                           {192, 0, 2, 2})}));
+                              {bf::Matcher(BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,
+                                           {192, 0, 2, 2}, true)}));
 
     bft_assert_prog_run(
         "test_ip4_daddr", test->hook(),
@@ -122,7 +114,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_DADDR);
 
     suite << MatcherTest(BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ, ip4_daddr_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_DADDR, BF_MATCHER_NE, ip4_daddr_ne);
     suite << MatcherTest(BF_MATCHER_IP4_DADDR, BF_MATCHER_IN, ip4_daddr_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip4_dnet.cpp
+++ b/tests/e2e/matchers/ip4_dnet.cpp
@@ -103,25 +103,15 @@ static void ip4_dnet_eq(void **state)
         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip4_dnet", 0, 1, -1);
-}
 
-/**
- * Verify ip4.dnet ne does not match when the destination address is within
- * the configured subnet but matches addresses outside it. Exercises /24, /32
- * (no-masking code path), and /0 (which covers all addresses, so NE /0 never
- * matches).
- */
-static void ip4_dnet_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // /24 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_NE,
-                                 bft_ip4_lpm_key(24, 192, 0, 2, 0))}));
+                    {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
 
-    // daddr=192.0.2.100 is in subnet -> NE does not match -> ACCEPT
+    // daddr=192.0.2.100 is in subnet -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_ip4_dnet", test->hook(),
         bft::Ethernet() /
@@ -129,7 +119,7 @@ static void ip4_dnet_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // daddr=192.0.3.1 is not in subnet -> NE matches -> DROP
+    // daddr=192.0.3.1 is not in subnet -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip4_dnet", test->hook(),
         bft::Ethernet() /
@@ -139,12 +129,13 @@ static void ip4_dnet_ne(void **state)
 
     bft_assert_counter_eq("test_ip4_dnet", 0, 1, -1);
 
-    // /32 ne: daddr exactly matching the host -> NE does not match -> ACCEPT
+    // /32 not eq: daddr exactly matching the host -> does not match ->
+    // ACCEPT
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_NE,
-                                 bft_ip4_lpm_key(32, 192, 0, 2, 2))}));
+                    {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(32, 192, 0, 2, 2), true)}));
 
     bft_assert_prog_run(
         "test_ip4_dnet", test->hook(),
@@ -153,7 +144,7 @@ static void ip4_dnet_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // daddr differs from the /32 host -> NE matches -> DROP
+    // daddr differs from the /32 host -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip4_dnet", test->hook(),
         bft::Ethernet() /
@@ -163,11 +154,13 @@ static void ip4_dnet_ne(void **state)
 
     bft_assert_counter_eq("test_ip4_dnet", 0, 1, -1);
 
-    // /0 ne: /0 covers the entire address space; NE /0 never matches.
-    BFT_CHAIN_SET(bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_NE,
-                                           bft_ip4_lpm_key(0, 0, 0, 0, 0))}));
+    // /0 not eq: /0 covers the entire address space; not eq /0 never
+    // matches.
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(0, 0, 0, 0, 0), true)}));
 
     bft_assert_prog_run(
         "test_ip4_dnet", test->hook(),
@@ -229,7 +222,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_DNET);
 
     suite << MatcherTest(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ, ip4_dnet_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_DNET, BF_MATCHER_NE, ip4_dnet_ne);
     suite << MatcherTest(BF_MATCHER_IP4_DNET, BF_MATCHER_IN, ip4_dnet_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip4_dscp.cpp
+++ b/tests/e2e/matchers/ip4_dscp.cpp
@@ -59,23 +59,14 @@ static void ip4_dscp_eq(void **state)
                         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip4_dscp", 0, 2, -1);
-}
 
-/**
- * Verify ip4.dscp ne does not match packets whose DSCP field equals the
- * configured value, and matches all others. The matcher ignores the 2-bit ECN
- * field, so a packet with the same DSCP but non-zero ECN still does not match.
- */
-static void ip4_dscp_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(
-        bf::Chain("test_ip4_dscp", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_DSCP, BF_MATCHER_NE, {8})}));
+        bf::Chain("test_ip4_dscp", test->hook(), BF_VERDICT_ACCEPT) << bf::Rule(
+            BF_VERDICT_DROP, true, {},
+            {bf::Matcher(BF_MATCHER_IP4_DSCP, BF_MATCHER_EQ, {8}, true)}));
 
-    // tos=0x20 (DSCP=8) matches the reference value, NE does not fire -> ACCEPT
+    // tos=0x20 (DSCP=8) matches the reference value, not eq does not fire -> ACCEPT
     bft_assert_prog_run("test_ip4_dscp", test->hook(),
                         bft::Ethernet() /
                             bft::IPv4 {.saddr = "192.0.2.1",
@@ -84,7 +75,7 @@ static void ip4_dscp_ne(void **state)
                             bft::TCP {},
                         test->verdictAccept());
 
-    // tos=0 (DSCP=0) does not match the reference value, NE fires -> DROP
+    // tos=0 (DSCP=0) does not match the reference value, not eq fires -> DROP
     bft_assert_prog_run(
         "test_ip4_dscp", test->hook(),
         bft::Ethernet() /
@@ -110,7 +101,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_DSCP);
 
     suite << MatcherTest(BF_MATCHER_IP4_DSCP, BF_MATCHER_EQ, ip4_dscp_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_DSCP, BF_MATCHER_NE, ip4_dscp_ne);
 
     return suite.run();
 }

--- a/tests/e2e/matchers/ip4_proto.cpp
+++ b/tests/e2e/matchers/ip4_proto.cpp
@@ -44,22 +44,14 @@ static void ip4_proto_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip4_proto", 0, 1, -1);
-}
 
-/**
- * Verify ip4.proto ne does not match the configured protocol value but matches
- * packets with any other protocol.
- */
-static void ip4_proto_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
+    // Negation
+    BFT_CHAIN_SET(bf::Chain("test_ip4_proto", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
+                                           {6}, true)}));
 
-    BFT_CHAIN_SET(
-        bf::Chain("test_ip4_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_NE, {6})}));
-
-    // TCP -> protocol=6 -> NE does not match -> ACCEPT
+    // TCP -> protocol=6 -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_ip4_proto", test->hook(),
         bft::Ethernet() /
@@ -67,7 +59,7 @@ static void ip4_proto_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // UDP -> protocol=17 -> NE matches -> DROP
+    // UDP -> protocol=17 -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip4_proto", test->hook(),
         bft::Ethernet() /
@@ -128,7 +120,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_PROTO);
 
     suite << MatcherTest(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, ip4_proto_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_PROTO, BF_MATCHER_NE, ip4_proto_ne);
     suite << MatcherTest(BF_MATCHER_IP4_PROTO, BF_MATCHER_IN, ip4_proto_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip4_saddr.cpp
+++ b/tests/e2e/matchers/ip4_saddr.cpp
@@ -43,20 +43,12 @@ static void ip4_saddr_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip4_saddr", 0, 1, -1);
-}
 
-/**
- * Verify ip4.saddr ne does not match the configured source address but matches
- * all other addresses. Counter tracks only matching packets.
- */
-static void ip4_saddr_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip4_saddr", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_NE,
-                                           {192, 0, 2, 1})}));
+                              {bf::Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
+                                           {192, 0, 2, 1}, true)}));
 
     // saddr=192.0.2.1 should not match -> ACCEPT
     bft_assert_prog_run(
@@ -128,7 +120,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_SADDR);
 
     suite << MatcherTest(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ, ip4_saddr_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_SADDR, BF_MATCHER_NE, ip4_saddr_ne);
     suite << MatcherTest(BF_MATCHER_IP4_SADDR, BF_MATCHER_IN, ip4_saddr_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip4_snet.cpp
+++ b/tests/e2e/matchers/ip4_snet.cpp
@@ -64,6 +64,31 @@ static void ip4_snet_eq(void **state)
 
     bft_assert_counter_eq("test_ip4_snet", 0, 3, -1);
 
+    // Try with negation: 192.0.2.0/24
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
+
+    // saddr=192.0.2.1 is in subnet, but negated -> ACCEPT
+    bft_assert_prog_run(
+        "test_ip4_snet", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.2.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictAccept());
+
+    // saddr=192.0.3.1 is not in subnet, negated -> DROP
+    bft_assert_prog_run(
+        "test_ip4_snet", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.3.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_ip4_snet", 0, 1, -1);
+
     // /32 (single host): mask=0xffffffff triggers the no-masking code path in
     // bf_cmp_masked_value(), comparing the address directly without AND.
     BFT_CHAIN_SET(
@@ -106,25 +131,15 @@ static void ip4_snet_eq(void **state)
         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip4_snet", 0, 1, -1);
-}
 
-/**
- * Verify ip4.snet ne does not match when the source address is within the
- * configured subnet but matches addresses outside it. Exercises /24, /32
- * (no-masking code path), and /0 (which covers all addresses, so NE /0 never
- * matches).
- */
-static void ip4_snet_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // /24 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_NE,
-                                 bft_ip4_lpm_key(24, 192, 0, 2, 0))}));
+                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
 
-    // saddr=192.0.2.1 is in subnet -> NE does not match -> ACCEPT
+    // saddr=192.0.2.1 is in subnet -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_ip4_snet", test->hook(),
         bft::Ethernet() /
@@ -132,7 +147,7 @@ static void ip4_snet_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // saddr=192.0.3.1 is not in subnet -> NE matches -> DROP
+    // saddr=192.0.3.1 is not in subnet -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip4_snet", test->hook(),
         bft::Ethernet() /
@@ -142,12 +157,12 @@ static void ip4_snet_ne(void **state)
 
     bft_assert_counter_eq("test_ip4_snet", 0, 1, -1);
 
-    // /32 ne: saddr exactly matching the host -> NE does not match -> ACCEPT
+    // /32 not eq: saddr exactly matching the host -> does not match -> ACCEPT
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_NE,
-                                 bft_ip4_lpm_key(32, 192, 0, 2, 1))}));
+                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(32, 192, 0, 2, 1), true)}));
 
     bft_assert_prog_run(
         "test_ip4_snet", test->hook(),
@@ -156,7 +171,7 @@ static void ip4_snet_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // saddr differs from the /32 host -> NE matches -> DROP
+    // saddr differs from the /32 host -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip4_snet", test->hook(),
         bft::Ethernet() /
@@ -166,11 +181,13 @@ static void ip4_snet_ne(void **state)
 
     bft_assert_counter_eq("test_ip4_snet", 0, 1, -1);
 
-    // /0 ne: /0 covers the entire address space; NE /0 never matches.
-    BFT_CHAIN_SET(bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_NE,
-                                           bft_ip4_lpm_key(0, 0, 0, 0, 0))}));
+    // /0 not eq: /0 covers the entire address space; not eq /0 never
+    // matches.
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
+                                 bft_ip4_lpm_key(0, 0, 0, 0, 0), true)}));
 
     bft_assert_prog_run(
         "test_ip4_snet", test->hook(),
@@ -232,7 +249,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP4_SNET);
 
     suite << MatcherTest(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ, ip4_snet_eq);
-    suite << MatcherTest(BF_MATCHER_IP4_SNET, BF_MATCHER_NE, ip4_snet_ne);
     suite << MatcherTest(BF_MATCHER_IP4_SNET, BF_MATCHER_IN, ip4_snet_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip6_daddr.cpp
+++ b/tests/e2e/matchers/ip6_daddr.cpp
@@ -41,20 +41,13 @@ static void ip6_daddr_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip6_daddr", 0, 1, -1);
-}
 
-/**
- * Verify ip6.daddr ne does not match the configured IPv6 destination address
- * but matches all other addresses. Counter tracks only matching packets.
- */
-static void ip6_daddr_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
-    BFT_CHAIN_SET(bf::Chain("test_ip6_daddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP6_DADDR, BF_MATCHER_NE,
-                                           bft_ipv6_addr("2001:db8::2"))}));
+    // Negation
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip6_daddr", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
+                                 bft_ipv6_addr("2001:db8::2"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_daddr", test->hook(),
@@ -121,7 +114,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_DADDR);
 
     suite << MatcherTest(BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ, ip6_daddr_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_DADDR, BF_MATCHER_NE, ip6_daddr_ne);
     suite << MatcherTest(BF_MATCHER_IP6_DADDR, BF_MATCHER_IN, ip6_daddr_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip6_dnet.cpp
+++ b/tests/e2e/matchers/ip6_dnet.cpp
@@ -94,23 +94,13 @@ static void ip6_dnet_eq(void **state)
         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip6_dnet", 0, 1, -1);
-}
 
-/**
- * Verify ip6.dnet ne does not match when the IPv6 destination address is
- * within the configured prefix but matches addresses outside it. Exercises
- * /32, /128 (no-masking code path), and /0 (which covers all addresses, so
- * NE /0 never matches).
- */
-static void ip6_dnet_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation: /32 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_NE,
-                                 bft_ip6_lpm_key(32, "2001:db8::"))}));
+                    {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
+                                 bft_ip6_lpm_key(32, "2001:db8::"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_dnet", test->hook(),
@@ -128,14 +118,14 @@ static void ip6_dnet_ne(void **state)
 
     bft_assert_counter_eq("test_ip6_dnet", 0, 1, -1);
 
-    // /128 ne: daddr matching the exact host -> NE does not match -> ACCEPT;
-    // daddr differing by one bit -> NE matches -> DROP. Exercises the
+    // /128 not eq: daddr matching the exact host -> does not match ->
+    // ACCEPT; daddr differing by one bit -> matches -> DROP. Exercises the
     // no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_NE,
-                                 bft_ip6_lpm_key(128, "2001:db8::2"))}));
+                    {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
+                                 bft_ip6_lpm_key(128, "2001:db8::2"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_dnet", test->hook(),
@@ -153,11 +143,12 @@ static void ip6_dnet_ne(void **state)
 
     bft_assert_counter_eq("test_ip6_dnet", 0, 1, -1);
 
-    // /0 ne: /0 covers the entire address space; NE /0 never matches.
+    // /0 not eq: /0 covers the entire address space; not eq /0 never
+    // matches.
     BFT_CHAIN_SET(bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_NE,
-                                           bft_ip6_lpm_key(0, "::"))}));
+                              {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
+                                           bft_ip6_lpm_key(0, "::"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_dnet", test->hook(),
@@ -219,7 +210,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_DNET);
 
     suite << MatcherTest(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ, ip6_dnet_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_DNET, BF_MATCHER_NE, ip6_dnet_ne);
     suite << MatcherTest(BF_MATCHER_IP6_DNET, BF_MATCHER_IN, ip6_dnet_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip6_dscp.cpp
+++ b/tests/e2e/matchers/ip6_dscp.cpp
@@ -60,24 +60,15 @@ static void ip6_dscp_eq(void **state)
                         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip6_dscp", 0, 2, -1);
-}
 
-/**
- * Verify ip6.dscp ne does not match packets whose DSCP field equals the
- * configured value, and matches all others. The matcher ignores the 2-bit ECN
- * field, so a packet with the same DSCP but non-zero ECN still does not match.
- */
-static void ip6_dscp_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(
-        bf::Chain("test_ip6_dscp", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_DSCP, BF_MATCHER_NE, {8})}));
+        bf::Chain("test_ip6_dscp", test->hook(), BF_VERDICT_ACCEPT) << bf::Rule(
+            BF_VERDICT_DROP, true, {},
+            {bf::Matcher(BF_MATCHER_IP6_DSCP, BF_MATCHER_EQ, {8}, true)}));
 
-    // traffic_class=0x20 (DSCP=8) matches the reference value, NE does not
-    // fire -> ACCEPT
+    // traffic_class=0x20 (DSCP=8) matches the reference value, not eq does
+    // not fire -> ACCEPT
     bft_assert_prog_run("test_ip6_dscp", test->hook(),
                         bft::Ethernet() /
                             bft::IPv6 {.saddr = "2001:db8::1",
@@ -86,8 +77,8 @@ static void ip6_dscp_ne(void **state)
                             bft::TCP {},
                         test->verdictAccept());
 
-    // traffic_class=0 (DSCP=0) does not match the reference value, NE fires
-    // -> DROP
+    // traffic_class=0 (DSCP=0) does not match the reference value, not eq
+    // fires -> DROP
     bft_assert_prog_run("test_ip6_dscp", test->hook(),
                         bft::Ethernet() /
                             bft::IPv6 {.saddr = "2001:db8::1",
@@ -114,7 +105,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_DSCP);
 
     suite << MatcherTest(BF_MATCHER_IP6_DSCP, BF_MATCHER_EQ, ip6_dscp_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_DSCP, BF_MATCHER_NE, ip6_dscp_ne);
 
     return suite.run();
 }

--- a/tests/e2e/matchers/ip6_nexthdr.cpp
+++ b/tests/e2e/matchers/ip6_nexthdr.cpp
@@ -44,22 +44,14 @@ static void ip6_nexthdr_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip6_nexthdr", 0, 1, -1);
-}
 
-/**
- * Verify ip6.nexthdr ne does not match the configured next header value but
- * matches packets with any other next header.
- */
-static void ip6_nexthdr_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
+    // Negation
+    BFT_CHAIN_SET(bf::Chain("test_ip6_nexthdr", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_IP6_NEXTHDR,
+                                           BF_MATCHER_EQ, {6}, true)}));
 
-    BFT_CHAIN_SET(
-        bf::Chain("test_ip6_nexthdr", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_NE, {6})}));
-
-    // TCP -> nexthdr=6 -> NE does not match -> ACCEPT
+    // TCP -> nexthdr=6 -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_ip6_nexthdr", test->hook(),
         bft::Ethernet() /
@@ -67,7 +59,7 @@ static void ip6_nexthdr_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // UDP -> nexthdr=17 -> NE matches -> DROP
+    // UDP -> nexthdr=17 -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip6_nexthdr", test->hook(),
         bft::Ethernet() /
@@ -129,7 +121,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_NEXTHDR);
 
     suite << MatcherTest(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_EQ, ip6_nexthdr_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_NE, ip6_nexthdr_ne);
     suite << MatcherTest(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_IN, ip6_nexthdr_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip6_saddr.cpp
+++ b/tests/e2e/matchers/ip6_saddr.cpp
@@ -41,20 +41,37 @@ static void ip6_saddr_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_ip6_saddr", 0, 1, -1);
-}
 
-/**
- * Verify ip6.saddr ne does not match the configured IPv6 source address but
- * matches all other addresses. Counter tracks only matching packets.
- */
-static void ip6_saddr_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
+    // Try with negation
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
+                                 bft_ipv6_addr("2001:db8::1"), true)}));
 
-    BFT_CHAIN_SET(bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_NE,
-                                           bft_ipv6_addr("2001:db8::1"))}));
+    // saddr=2001:db8::1 matches, but negated -> ACCEPT
+    bft_assert_prog_run(
+        "test_ip6_saddr", test->hook(),
+        bft::Ethernet() /
+            bft::IPv6 {.saddr = "2001:db8::1", .daddr = "2001:db8::2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictAccept());
+
+    // saddr=2001:db8::3 doesn't match, negated -> DROP
+    bft_assert_prog_run(
+        "test_ip6_saddr", test->hook(),
+        bft::Ethernet() /
+            bft::IPv6 {.saddr = "2001:db8::3", .daddr = "2001:db8::2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_ip6_saddr", 0, 1, -1);
+
+    BFT_CHAIN_SET(
+        bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
+                                 bft_ipv6_addr("2001:db8::1"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_saddr", test->hook(),
@@ -121,7 +138,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_SADDR);
 
     suite << MatcherTest(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ, ip6_saddr_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_SADDR, BF_MATCHER_NE, ip6_saddr_ne);
     suite << MatcherTest(BF_MATCHER_IP6_SADDR, BF_MATCHER_IN, ip6_saddr_in);
 
     return suite.run();

--- a/tests/e2e/matchers/ip6_snet.cpp
+++ b/tests/e2e/matchers/ip6_snet.cpp
@@ -98,25 +98,15 @@ static void ip6_snet_eq(void **state)
         test->verdictDrop());
 
     bft_assert_counter_eq("test_ip6_snet", 0, 1, -1);
-}
 
-/**
- * Verify ip6.snet ne does not match when the IPv6 source address is within
- * the configured prefix but matches addresses outside it. Exercises /32, /128
- * (no-masking code path), and /0 (which covers all addresses, so NE /0 never
- * matches).
- */
-static void ip6_snet_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation: /32 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_NE,
-                                 bft_ip6_lpm_key(32, "2001:db8::"))}));
+                    {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
+                                 bft_ip6_lpm_key(32, "2001:db8::"), true)}));
 
-    // saddr in subnet -> NE does not match -> ACCEPT
+    // saddr in subnet -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_ip6_snet", test->hook(),
         bft::Ethernet() /
@@ -124,7 +114,7 @@ static void ip6_snet_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // saddr outside subnet -> NE matches -> DROP
+    // saddr outside subnet -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_ip6_snet", test->hook(),
         bft::Ethernet() /
@@ -134,14 +124,14 @@ static void ip6_snet_ne(void **state)
 
     bft_assert_counter_eq("test_ip6_snet", 0, 1, -1);
 
-    // /128 ne: saddr matching the exact host -> NE does not match -> ACCEPT;
-    // saddr differing by one bit -> NE matches -> DROP. Exercises the
+    // /128 not eq: saddr matching the exact host -> does not match ->
+    // ACCEPT; saddr differing by one bit -> matches -> DROP. Exercises the
     // no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_NE,
-                                 bft_ip6_lpm_key(128, "2001:db8::1"))}));
+                    {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
+                                 bft_ip6_lpm_key(128, "2001:db8::1"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_snet", test->hook(),
@@ -159,11 +149,12 @@ static void ip6_snet_ne(void **state)
 
     bft_assert_counter_eq("test_ip6_snet", 0, 1, -1);
 
-    // /0 ne: /0 covers the entire address space; NE /0 never matches.
+    // /0 not eq: /0 covers the entire address space; not eq /0 never
+    // matches.
     BFT_CHAIN_SET(bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_NE,
-                                           bft_ip6_lpm_key(0, "::"))}));
+                              {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
+                                           bft_ip6_lpm_key(0, "::"), true)}));
 
     bft_assert_prog_run(
         "test_ip6_snet", test->hook(),
@@ -224,7 +215,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_IP6_SNET);
 
     suite << MatcherTest(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ, ip6_snet_eq);
-    suite << MatcherTest(BF_MATCHER_IP6_SNET, BF_MATCHER_NE, ip6_snet_ne);
     suite << MatcherTest(BF_MATCHER_IP6_SNET, BF_MATCHER_IN, ip6_snet_in);
 
     return suite.run();

--- a/tests/e2e/matchers/meta_dport.cpp
+++ b/tests/e2e/matchers/meta_dport.cpp
@@ -69,20 +69,12 @@ static void meta_dport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_dport", 0, 3, -1);
-}
 
-/**
- * Verify meta.dport ne does not match the configured destination port but
- * matches packets to any other port across both TCP and UDP.
- */
-static void meta_dport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_meta_dport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_META_DPORT, BF_MATCHER_NE,
-                                           bft_port_be(80))}));
+                              {bf::Matcher(BF_MATCHER_META_DPORT, BF_MATCHER_EQ,
+                                           bft_port_be(80), true)}));
 
     bft_assert_prog_run(
         "test_meta_dport", test->hook(),
@@ -180,7 +172,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_META_DPORT);
 
     suite << MatcherTest(BF_MATCHER_META_DPORT, BF_MATCHER_EQ, meta_dport_eq);
-    suite << MatcherTest(BF_MATCHER_META_DPORT, BF_MATCHER_NE, meta_dport_ne);
     suite << MatcherTest(BF_MATCHER_META_DPORT, BF_MATCHER_RANGE,
                          meta_dport_range);
 

--- a/tests/e2e/matchers/meta_flow_hash.cpp
+++ b/tests/e2e/matchers/meta_flow_hash.cpp
@@ -36,21 +36,14 @@ static void meta_flow_hash_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_fhash", 0, 0, -1);
-}
 
-/**
- * ne UINT32_MAX should match since flow_hash is very unlikely to be
- * UINT32_MAX. This verifies the ne codegen path.
- */
-static void meta_flow_hash_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // not eq UINT32_MAX should match since flow_hash is very unlikely to be
+    // UINT32_MAX
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fhash", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_NE,
-                                 bft_u32_payload(UINT_MAX))}));
+                    {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_EQ,
+                                 bft_u32_payload(UINT_MAX), true)}));
 
     bft_assert_prog_run(
         "test_meta_fhash", test->hook(),
@@ -107,8 +100,6 @@ int main()
 
     suite << MatcherTest(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_EQ,
                          meta_flow_hash_eq);
-    suite << MatcherTest(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_NE,
-                         meta_flow_hash_ne);
     suite << MatcherTest(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_RANGE,
                          meta_flow_hash_range);
 

--- a/tests/e2e/matchers/meta_flow_probability.cpp
+++ b/tests/e2e/matchers/meta_flow_probability.cpp
@@ -54,6 +54,38 @@ static void meta_flow_probability_eq(void **state)
 
     bft_assert_counter_eq("test_meta_fprob", 0, 0, -1);
 
+    // Negated 100.0f should never match
+    BFT_CHAIN_SET(bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
+                                           BF_MATCHER_EQ,
+                                           bft_float_payload(100.0f), true)}));
+
+    bft_assert_prog_run(
+        "test_meta_fprob", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.2.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictAccept());
+
+    bft_assert_counter_eq("test_meta_fprob", 0, 0, -1);
+
+    // Negated 0.0f should always match
+    BFT_CHAIN_SET(bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
+                                           BF_MATCHER_EQ,
+                                           bft_float_payload(0.0f), true)}));
+
+    bft_assert_prog_run(
+        "test_meta_fprob", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.2.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_meta_fprob", 0, 1, -1);
+
     // meta_flow_probability explicitly guards against non-TCP/UDP L4: an ICMP
     // packet must be skipped (jumps to next rule) and the drop verdict must
     // not fire even at 100% probability.

--- a/tests/e2e/matchers/meta_l4_proto.cpp
+++ b/tests/e2e/matchers/meta_l4_proto.cpp
@@ -43,23 +43,15 @@ static void meta_l4_proto_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_l4_proto", 0, 1, -1);
-}
 
-/**
- * Verify meta.l4_proto ne does not match the configured protocol value but
- * matches packets with any other L4 protocol.
- */
-static void meta_l4_proto_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(
         bf::Chain("test_meta_l4_proto", test->hook(), BF_VERDICT_ACCEPT)
         << bf::Rule(BF_VERDICT_DROP, true, {},
-                    {bf::Matcher(BF_MATCHER_META_L4_PROTO, BF_MATCHER_NE,
-                                 bft_u16_payload(6))}));
+                    {bf::Matcher(BF_MATCHER_META_L4_PROTO, BF_MATCHER_EQ,
+                                 bft_u16_payload(6), true)}));
 
-    // TCP -> l4_proto=6 -> NE does not match -> ACCEPT
+    // TCP -> l4_proto=6 -> not eq does not match -> ACCEPT
     bft_assert_prog_run(
         "test_meta_l4_proto", test->hook(),
         bft::Ethernet() /
@@ -67,7 +59,7 @@ static void meta_l4_proto_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80},
         test->verdictAccept());
 
-    // UDP -> l4_proto=17 -> NE matches -> DROP
+    // UDP -> l4_proto=17 -> not eq matches -> DROP
     bft_assert_prog_run(
         "test_meta_l4_proto", test->hook(),
         bft::Ethernet() /
@@ -84,8 +76,6 @@ int main()
 
     suite << MatcherTest(BF_MATCHER_META_L4_PROTO, BF_MATCHER_EQ,
                          meta_l4_proto_eq);
-    suite << MatcherTest(BF_MATCHER_META_L4_PROTO, BF_MATCHER_NE,
-                         meta_l4_proto_ne);
 
     return suite.run();
 }

--- a/tests/e2e/matchers/meta_mark.cpp
+++ b/tests/e2e/matchers/meta_mark.cpp
@@ -51,22 +51,12 @@ static void meta_mark_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_mark", 0, 0, -1);
-}
 
-/**
- * Verify meta.mark ne does not match when the skb mark equals the configured
- * value but matches when it differs. BPF_PROG_TEST_RUN always provides
- * mark=0, so ne 0 never matches and ne 42 always matches.
- */
-static void meta_mark_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
-    // ne 0 should NOT match since mark=0
+    // not eq 0 should NOT match since mark=0
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_NE,
-                                           bft_u32_payload(0))}));
+                              {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
+                                           bft_u32_payload(0), true)}));
 
     bft_assert_prog_run(
         "test_meta_mark", test->hook(),
@@ -77,11 +67,11 @@ static void meta_mark_ne(void **state)
 
     bft_assert_counter_eq("test_meta_mark", 0, 0, -1);
 
-    // ne 42 should match since mark=0 != 42
+    // not eq 42 should match since mark=0 != 42
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_NE,
-                                           bft_u32_payload(42))}));
+                              {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
+                                           bft_u32_payload(42), true)}));
 
     bft_assert_prog_run(
         "test_meta_mark", test->hook(),
@@ -98,7 +88,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_META_MARK);
 
     suite << MatcherTest(BF_MATCHER_META_MARK, BF_MATCHER_EQ, meta_mark_eq);
-    suite << MatcherTest(BF_MATCHER_META_MARK, BF_MATCHER_NE, meta_mark_ne);
 
     return suite.run();
 }

--- a/tests/e2e/matchers/meta_probability.cpp
+++ b/tests/e2e/matchers/meta_probability.cpp
@@ -52,6 +52,38 @@ static void meta_probability_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_prob", 0, 0, -1);
+
+    // Negated 100.0f should never match
+    BFT_CHAIN_SET(
+        bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
+                                 bft_float_payload(100.0f), true)}));
+
+    bft_assert_prog_run(
+        "test_meta_prob", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.2.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictAccept());
+
+    bft_assert_counter_eq("test_meta_prob", 0, 0, -1);
+
+    // Negated 0.0f should always match
+    BFT_CHAIN_SET(
+        bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
+                                 bft_float_payload(0.0f), true)}));
+
+    bft_assert_prog_run(
+        "test_meta_prob", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "192.0.2.1", .daddr = "192.0.2.2"} /
+            bft::TCP {.sport = 12345, .dport = 80},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_meta_prob", 0, 1, -1);
 }
 
 int main()

--- a/tests/e2e/matchers/meta_sport.cpp
+++ b/tests/e2e/matchers/meta_sport.cpp
@@ -68,20 +68,12 @@ static void meta_sport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_meta_sport", 0, 3, -1);
-}
 
-/**
- * Verify meta.sport ne does not match the configured source port but matches
- * packets from any other port across both TCP and UDP.
- */
-static void meta_sport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_meta_sport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_NE,
-                                           bft_port_be(12345))}));
+                              {bf::Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_EQ,
+                                           bft_port_be(12345), true)}));
 
     bft_assert_prog_run(
         "test_meta_sport", test->hook(),
@@ -179,7 +171,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_META_SPORT);
 
     suite << MatcherTest(BF_MATCHER_META_SPORT, BF_MATCHER_EQ, meta_sport_eq);
-    suite << MatcherTest(BF_MATCHER_META_SPORT, BF_MATCHER_NE, meta_sport_ne);
     suite << MatcherTest(BF_MATCHER_META_SPORT, BF_MATCHER_RANGE,
                          meta_sport_range);
 

--- a/tests/e2e/matchers/tcp_dport.cpp
+++ b/tests/e2e/matchers/tcp_dport.cpp
@@ -60,21 +60,12 @@ static void tcp_dport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_dport", 0, 2, -1);
-}
 
-/**
- * Verify tcp.dport ne does not match the configured destination port but
- * matches TCP packets to any other port. Also verifies the protocol guard: a
- * UDP packet must not match a TCP rule.
- */
-static void tcp_dport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_dport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_TCP_DPORT, BF_MATCHER_NE,
-                                           bft_port_be(80))}));
+                              {bf::Matcher(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
+                                           bft_port_be(80), true)}));
 
     // TCP dport=80 should not match -> ACCEPT
     bft_assert_prog_run(
@@ -210,7 +201,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_TCP_DPORT);
 
     suite << MatcherTest(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ, tcp_dport_eq);
-    suite << MatcherTest(BF_MATCHER_TCP_DPORT, BF_MATCHER_NE, tcp_dport_ne);
     suite << MatcherTest(BF_MATCHER_TCP_DPORT, BF_MATCHER_IN, tcp_dport_in);
     suite << MatcherTest(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE,
                          tcp_dport_range);

--- a/tests/e2e/matchers/tcp_flags.cpp
+++ b/tests/e2e/matchers/tcp_flags.cpp
@@ -52,23 +52,14 @@ static void tcp_flags_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_flags", 0, 2, -1);
-}
 
-/**
- * Verify tcp.flags ne does not match when the flags field equals the
- * configured value exactly but matches when the flags differ.
- */
-static void tcp_flags_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
-    // SYN = 0x02
+    // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_NE,
-                                           {0x02})}));
+                              {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_EQ,
+                                           {0x02}, true)}));
 
-    // SYN only -> exact match for NE -> ACCEPT
+    // SYN only -> exact match, but negated -> ACCEPT
     bft_assert_prog_run(
         "test_tcp_flags", test->hook(),
         bft::Ethernet() /
@@ -76,12 +67,12 @@ static void tcp_flags_ne(void **state)
             bft::TCP {.sport = 12345, .dport = 80, .syn = true},
         test->verdictAccept());
 
-    // ACK only -> not equal -> DROP
+    // SYN+ACK -> not exact match, negated -> DROP
     bft_assert_prog_run(
         "test_tcp_flags", test->hook(),
         bft::Ethernet() /
             bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
-            bft::TCP {.sport = 12345, .dport = 80, .ack = true},
+            bft::TCP {.sport = 12345, .dport = 80, .syn = true, .ack = true},
         test->verdictDrop());
 
     bft_assert_counter_eq("test_tcp_flags", 0, 1, -1);
@@ -127,6 +118,30 @@ static void tcp_flags_any(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_flags", 0, 2, -1);
+
+    // Try with negation
+    BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY,
+                                           {0x12}, true)}));
+
+    // SYN only -> has SYN bit from mask, but negated -> ACCEPT
+    bft_assert_prog_run(
+        "test_tcp_flags", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 12345, .dport = 80, .syn = true},
+        test->verdictAccept());
+
+    // RST only -> no overlap with SYN|ACK, negated -> DROP
+    bft_assert_prog_run(
+        "test_tcp_flags", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 12345, .dport = 80, .rst = true},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_tcp_flags", 0, 1, -1);
 }
 
 /**
@@ -173,6 +188,30 @@ static void tcp_flags_all(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_flags", 0, 2, -1);
+
+    // Try with negation
+    BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
+                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                              {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ALL,
+                                           {0x12}, true)}));
+
+    // SYN+ACK -> all bits present, but negated -> ACCEPT
+    bft_assert_prog_run(
+        "test_tcp_flags", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 12345, .dport = 80, .syn = true, .ack = true},
+        test->verdictAccept());
+
+    // SYN only -> missing ACK bit, negated -> DROP
+    bft_assert_prog_run(
+        "test_tcp_flags", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 12345, .dport = 80, .syn = true},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_tcp_flags", 0, 1, -1);
 }
 
 int main()
@@ -180,7 +219,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_TCP_FLAGS);
 
     suite << MatcherTest(BF_MATCHER_TCP_FLAGS, BF_MATCHER_EQ, tcp_flags_eq);
-    suite << MatcherTest(BF_MATCHER_TCP_FLAGS, BF_MATCHER_NE, tcp_flags_ne);
     suite << MatcherTest(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY, tcp_flags_any);
     suite << MatcherTest(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ALL, tcp_flags_all);
 

--- a/tests/e2e/matchers/tcp_sport.cpp
+++ b/tests/e2e/matchers/tcp_sport.cpp
@@ -60,21 +60,12 @@ static void tcp_sport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_sport", 0, 2, -1);
-}
 
-/**
- * Verify tcp.sport ne does not match the configured source port but matches
- * TCP packets from any other port. Also verifies the protocol guard: a UDP
- * packet must not match a TCP rule.
- */
-static void tcp_sport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_NE,
-                                           bft_port_be(12345))}));
+                              {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
+                                           bft_port_be(12345), true)}));
 
     // TCP sport=12345 should not match -> ACCEPT
     bft_assert_prog_run(
@@ -203,6 +194,39 @@ static void tcp_sport_range(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_tcp_sport", 0, 3, -1);
+
+    // Try with negation
+    BFT_CHAIN_SET(
+        bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
+        << bf::Rule(BF_VERDICT_DROP, true, {},
+                    {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_RANGE,
+                                 bft_port_range(1000, 2000), true)}));
+
+    // TCP sport=1500 is in range, but negated -> ACCEPT
+    bft_assert_prog_run(
+        "test_tcp_sport", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 1500, .dport = 80},
+        test->verdictAccept());
+
+    // TCP sport=999 is below range, negated -> DROP
+    bft_assert_prog_run(
+        "test_tcp_sport", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 999, .dport = 80},
+        test->verdictDrop());
+
+    // TCP sport=2001 is above range, negated -> DROP
+    bft_assert_prog_run(
+        "test_tcp_sport", test->hook(),
+        bft::Ethernet() /
+            bft::IPv4 {.saddr = "127.0.0.1", .daddr = "127.0.0.2"} /
+            bft::TCP {.sport = 2001, .dport = 80},
+        test->verdictDrop());
+
+    bft_assert_counter_eq("test_tcp_sport", 0, 2, -1);
 }
 
 int main()
@@ -210,7 +234,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_TCP_SPORT);
 
     suite << MatcherTest(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ, tcp_sport_eq);
-    suite << MatcherTest(BF_MATCHER_TCP_SPORT, BF_MATCHER_NE, tcp_sport_ne);
     suite << MatcherTest(BF_MATCHER_TCP_SPORT, BF_MATCHER_IN, tcp_sport_in);
     suite << MatcherTest(BF_MATCHER_TCP_SPORT, BF_MATCHER_RANGE,
                          tcp_sport_range);

--- a/tests/e2e/matchers/udp_dport.cpp
+++ b/tests/e2e/matchers/udp_dport.cpp
@@ -58,21 +58,12 @@ static void udp_dport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_udp_dport", 0, 2, -1);
-}
 
-/**
- * Verify udp.dport ne does not match the configured destination port but
- * matches UDP packets to any other port. Also verifies the protocol guard: a
- * TCP packet must not match a UDP rule.
- */
-static void udp_dport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_udp_dport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_UDP_DPORT, BF_MATCHER_NE,
-                                           bft_port_be(53))}));
+                              {bf::Matcher(BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ,
+                                           bft_port_be(53), true)}));
 
     bft_assert_prog_run(
         "test_udp_dport", test->hook(),
@@ -204,7 +195,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_UDP_DPORT);
 
     suite << MatcherTest(BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ, udp_dport_eq);
-    suite << MatcherTest(BF_MATCHER_UDP_DPORT, BF_MATCHER_NE, udp_dport_ne);
     suite << MatcherTest(BF_MATCHER_UDP_DPORT, BF_MATCHER_IN, udp_dport_in);
     suite << MatcherTest(BF_MATCHER_UDP_DPORT, BF_MATCHER_RANGE,
                          udp_dport_range);

--- a/tests/e2e/matchers/udp_sport.cpp
+++ b/tests/e2e/matchers/udp_sport.cpp
@@ -58,21 +58,12 @@ static void udp_sport_eq(void **state)
         test->verdictAccept());
 
     bft_assert_counter_eq("test_udp_sport", 0, 2, -1);
-}
 
-/**
- * Verify udp.sport ne does not match the configured source port but matches
- * UDP packets from any other port. Also verifies the protocol guard: a TCP
- * packet must not match a UDP rule.
- */
-static void udp_sport_ne(void **state)
-{
-    auto *test = static_cast<MatcherTest *>(*state);
-
+    // Negation
     BFT_CHAIN_SET(bf::Chain("test_udp_sport", test->hook(), BF_VERDICT_ACCEPT)
                   << bf::Rule(BF_VERDICT_DROP, true, {},
-                              {bf::Matcher(BF_MATCHER_UDP_SPORT, BF_MATCHER_NE,
-                                           bft_port_be(12345))}));
+                              {bf::Matcher(BF_MATCHER_UDP_SPORT, BF_MATCHER_EQ,
+                                           bft_port_be(12345), true)}));
 
     bft_assert_prog_run(
         "test_udp_sport", test->hook(),
@@ -204,7 +195,6 @@ int main()
     auto suite = MatcherTestsSuite(BF_MATCHER_UDP_SPORT);
 
     suite << MatcherTest(BF_MATCHER_UDP_SPORT, BF_MATCHER_EQ, udp_sport_eq);
-    suite << MatcherTest(BF_MATCHER_UDP_SPORT, BF_MATCHER_NE, udp_sport_ne);
     suite << MatcherTest(BF_MATCHER_UDP_SPORT, BF_MATCHER_IN, udp_sport_in);
     suite << MatcherTest(BF_MATCHER_UDP_SPORT, BF_MATCHER_RANGE,
                          udp_sport_range);

--- a/tests/e2e/parsing/icmp_code.sh
+++ b/tests/e2e/parsing/icmp_code.sh
@@ -27,3 +27,7 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icm
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icmp.code not 257 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icmp.code not -0x01 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icmp.code not -0xff counter DROP")
+
+# Negation
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icmp.code not eq 3 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule icmp.code not 3 counter DROP"

--- a/tests/e2e/parsing/ip4_snet.sh
+++ b/tests/e2e/parsing/ip4_snet.sh
@@ -33,3 +33,7 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.snet not 1.1.1.1/0x75 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.snet not -1.1.1.1 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.snet not -1.1.1.1/1 counter DROP")
+
+# Negation
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.snet not eq 192.168.0.0/24 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.snet not 10.0.0.0/8 counter DROP"

--- a/tests/e2e/parsing/ip6_saddr.sh
+++ b/tests/e2e/parsing/ip6_saddr.sh
@@ -53,3 +53,7 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.saddr not :2001:db8::1 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.saddr not 2001::db8:: counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.saddr not 2001:db8::1: counter DROP")
+
+# Negation
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.saddr not eq 2001:db8::1 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip6.saddr not 2001:db8::1 counter DROP"

--- a/tests/e2e/parsing/named_set.sh
+++ b/tests/e2e/parsing/named_set.sh
@@ -22,6 +22,16 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT
         counter
         ACCEPT
 "
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT
+    set myset (ip4.saddr) in {
+        192.168.1.1;
+        192.168.1.2
+    }
+    rule
+        (ip4.saddr) not in myset
+        counter
+        ACCEPT
+"
 
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT set myset (ip4.saddr) eq { 192.168.1.1 }")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT set myset (ip4.saddr, meta.ifindex) in { 192.168.1.1 }")

--- a/tests/e2e/parsing/tcp_flags.sh
+++ b/tests/e2e/parsing/tcp_flags.sh
@@ -45,3 +45,9 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags any fin,fin,syn counter DROP"
 
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags all fin,syn,rst,psh,ack,urg,ece,cwr,invalid counter DROP")
+
+# Negation
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags not eq syn counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags not syn counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags not any syn,ack counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.flags not all syn,ack counter DROP"

--- a/tests/e2e/parsing/tcp_sport.sh
+++ b/tests/e2e/parsing/tcp_sport.sh
@@ -39,3 +39,8 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport range -1--4 counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport range not-port counter DROP")
 (! ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport range notport counter DROP")
+
+# Negation
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport not eq 80 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport not 80 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule tcp.sport not range 80-443 counter DROP"

--- a/tests/harness/Matcher.hpp
+++ b/tests/harness/Matcher.hpp
@@ -29,13 +29,15 @@ private:
     bf_matcher_type _type;
     bf_matcher_op _op;
     std::vector<uint8_t> _payload;
+    bool _negate;
 
 public:
     Matcher(bf_matcher_type type, bf_matcher_op op,
-            std::vector<uint8_t> payload):
+            std::vector<uint8_t> payload, bool negate = false):
         _type {type},
         _op {op},
-        _payload {std::move(payload)} {};
+        _payload {std::move(payload)},
+        _negate {negate} {};
 
     [[nodiscard]] bf_matcher_type type() const
     {
@@ -52,12 +54,17 @@ public:
         return _payload;
     }
 
+    [[nodiscard]] bool negate() const
+    {
+        return _negate;
+    }
+
     [[nodiscard]] std::unique_ptr<bf_matcher, deleter> get() const
     {
         struct bf_matcher *matcher = nullptr;
 
         int r = bf_matcher_new(&matcher, _type, _op, _payload.data(),
-                               _payload.size());
+                               _payload.size(), _negate);
         if (r != 0)
             throw std::runtime_error("failed to create bf_matcher");
 

--- a/tests/harness/Rule.hpp
+++ b/tests/harness/Rule.hpp
@@ -67,7 +67,8 @@ public:
         for (const Matcher &matcher: _matchers) {
             const auto &payload = matcher.payload();
             r = bf_rule_add_matcher(rule, matcher.type(), matcher.op(),
-                                    payload.data(), payload.size());
+                                    payload.data(), payload.size(),
+                                    matcher.negate());
             if (r != 0) {
                 bf_rule_free(&rule);
                 throw std::runtime_error("failed to add bf_matcher to bf_rule");

--- a/tests/harness/fake.c
+++ b/tests/harness/fake.c
@@ -108,18 +108,18 @@ struct bf_chain *bft_chain_dummy(bool with_rules)
 
             id = 0;
             r = bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN, &id,
-                                    sizeof(id));
+                                    sizeof(id), false);
             if (r)
                 return NULL;
 
             r = bf_rule_add_matcher(rule, BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,
-                                    &ip, sizeof(ip));
+                                    &ip, sizeof(ip), false);
             if (r)
                 return NULL;
 
             ++id;
             r = bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN, &id,
-                                    sizeof(id));
+                                    sizeof(id), false);
             if (r)
                 return NULL;
 
@@ -160,7 +160,7 @@ struct bf_chain *bft_chain_dummy(bool with_rules)
 
             ++id;
             r = bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN, &id,
-                                    sizeof(id));
+                                    sizeof(id), false);
             if (r)
                 return NULL;
 
@@ -215,7 +215,7 @@ struct bf_matcher *bft_matcher_dummy(const void *data, size_t data_len)
     _free_bf_matcher_ struct bf_matcher *matcher = NULL;
 
     (void)bf_matcher_new(&matcher, BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ, data,
-                         data_len);
+                         data_len, false);
 
     return TAKE_PTR(matcher);
 }

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -305,6 +305,7 @@ bool bft_matcher_equal(const struct bf_matcher *matcher0,
 {
     return bf_matcher_get_type(matcher0) == bf_matcher_get_type(matcher1) &&
            bf_matcher_get_op(matcher0) == bf_matcher_get_op(matcher1) &&
+           bf_matcher_get_negate(matcher0) == bf_matcher_get_negate(matcher1) &&
            bf_matcher_payload_len(matcher0) ==
                bf_matcher_payload_len(matcher1) &&
            0 == memcmp(bf_matcher_payload(matcher0),

--- a/tests/unit/libbpfilter/chain.c
+++ b/tests/unit/libbpfilter/chain.c
@@ -124,13 +124,13 @@ static void mixed_enabled_disabled_log_flag(void **state)
     assert_ok(bf_rule_new(&r0));
     r0->log = 1;
     assert_ok(bf_rule_add_matcher(r0, BF_MATCHER_SET, BF_MATCHER_IN, &set_index,
-                                  sizeof(set_index)));
+                                  sizeof(set_index), false));
     assert_ok(bf_list_add_tail(&rules, r0));
 
     set_index = 1;
     assert_ok(bf_rule_new(&r1));
     assert_ok(bf_rule_add_matcher(r1, BF_MATCHER_SET, BF_MATCHER_IN, &set_index,
-                                  sizeof(set_index)));
+                                  sizeof(set_index), false));
     assert_ok(bf_list_add_tail(&rules, r1));
 
     assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS, BF_VERDICT_ACCEPT,
@@ -156,9 +156,9 @@ static void incompatible_matchers_disable_rule(void **state)
 
         assert_ok(bf_rule_new(&rule));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
-                                      &ip4_addr, sizeof(ip4_addr)));
+                                      &ip4_addr, sizeof(ip4_addr), false));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
-                                      ip6_addr, sizeof(ip6_addr)));
+                                      ip6_addr, sizeof(ip6_addr), false));
         assert_ok(bf_list_add_tail(&rules, rule));
 
         assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
@@ -176,9 +176,9 @@ static void incompatible_matchers_disable_rule(void **state)
 
         assert_ok(bf_rule_new(&rule));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
-                                      &port, sizeof(port)));
+                                      &port, sizeof(port), false));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ,
-                                      &port, sizeof(port)));
+                                      &port, sizeof(port), false));
         assert_ok(bf_list_add_tail(&rules, rule));
 
         assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
@@ -207,9 +207,9 @@ static void incompatible_matchers_disable_rule(void **state)
 
         assert_ok(bf_rule_new(&rule));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
-                                      &set_index, sizeof(set_index)));
+                                      &set_index, sizeof(set_index), false));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
-                                      ip6_addr, sizeof(ip6_addr)));
+                                      ip6_addr, sizeof(ip6_addr), false));
         assert_ok(bf_list_add_tail(&rules, rule));
 
         assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
@@ -227,9 +227,9 @@ static void incompatible_matchers_disable_rule(void **state)
 
         assert_ok(bf_rule_new(&rule));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
-                                      &port, sizeof(port)));
+                                      &port, sizeof(port), false));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
-                                      &port, sizeof(port)));
+                                      &port, sizeof(port), false));
         assert_ok(bf_list_add_tail(&rules, rule));
 
         assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
@@ -248,9 +248,9 @@ static void incompatible_matchers_disable_rule(void **state)
 
         assert_ok(bf_rule_new(&rule));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
-                                      &ip4_addr, sizeof(ip4_addr)));
+                                      &ip4_addr, sizeof(ip4_addr), false));
         assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
-                                      &port, sizeof(port)));
+                                      &port, sizeof(port), false));
         assert_ok(bf_list_add_tail(&rules, rule));
 
         assert_ok(bf_chain_new(&chain, "test", BF_HOOK_TC_EGRESS,
@@ -296,7 +296,7 @@ static void set_component_unsupported_hook(void **state)
 
     assert_ok(bf_rule_new(&rule));
     assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
-                                  &set_index, sizeof(set_index)));
+                                  &set_index, sizeof(set_index), false));
     assert_ok(bf_list_add_tail(&rules, rule));
 
     assert_err(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,
@@ -314,7 +314,7 @@ static void set_component_unsupported_hook(void **state)
 
     assert_ok(bf_rule_new(&rule));
     assert_ok(bf_rule_add_matcher(rule, BF_MATCHER_SET, BF_MATCHER_IN,
-                                  &set_index, sizeof(set_index)));
+                                  &set_index, sizeof(set_index), false));
     assert_ok(bf_list_add_tail(&rules, rule));
 
     assert_ok(bf_chain_new(&chain, "test", BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4,

--- a/tests/unit/libbpfilter/matcher.c
+++ b/tests/unit/libbpfilter/matcher.c
@@ -21,7 +21,7 @@ static void new_and_free(void **state)
 
     // Create matcher with payload
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
-                             payload, sizeof(payload)));
+                             payload, sizeof(payload), false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_IP4_SADDR);
     assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_EQ);
@@ -32,7 +32,7 @@ static void new_and_free(void **state)
     // Create matcher with small payload
     uint8_t proto = 6; // TCP
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
-                             &proto, sizeof(proto)));
+                             &proto, sizeof(proto), false));
     assert_non_null(matcher);
 }
 
@@ -44,7 +44,7 @@ static void new_with_payload(void **state)
     (void)state;
 
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,
-                             &addr, sizeof(addr)));
+                             &addr, sizeof(addr), false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_payload_len(matcher), sizeof(addr));
     assert_int_equal(*(uint32_t *)bf_matcher_payload(matcher), addr);
@@ -57,20 +57,28 @@ static void getters(void **state)
 
     (void)state;
 
-    assert_ok(bf_matcher_new(&matcher, BF_MATCHER_TCP_DPORT, BF_MATCHER_NE,
-                             payload, sizeof(payload)));
+    assert_ok(bf_matcher_new(&matcher, BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
+                             payload, sizeof(payload), false));
 
     // Test all getters
     assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_TCP_DPORT);
-    assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_NE);
+    assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_EQ);
     assert_int_equal(bf_matcher_payload_len(matcher), sizeof(payload));
     assert_non_null(bf_matcher_payload(matcher));
     assert_true(bf_matcher_len(matcher) > 0);
+    assert_false(bf_matcher_get_negate(matcher));
 
     // Verify payload content
     const uint8_t *p = bf_matcher_payload(matcher);
     for (size_t i = 0; i < sizeof(payload); ++i)
         assert_int_equal(p[i], payload[i]);
+
+    bf_matcher_free(&matcher);
+
+    // Test negate=true at construction
+    assert_ok(bf_matcher_new(&matcher, BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
+                             payload, sizeof(payload), true));
+    assert_true(bf_matcher_get_negate(matcher));
 }
 
 static void pack_and_unpack(void **state)
@@ -87,7 +95,7 @@ static void pack_and_unpack(void **state)
 
     // Create and pack source matcher
     assert_ok(bf_matcher_new(&source, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
-                             &port, sizeof(port)));
+                             &port, sizeof(port), false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -114,7 +122,7 @@ static void pack_and_unpack_small_payload(void **state)
 
     // Create matcher with small payload
     assert_ok(bf_matcher_new(&source, BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
-                             &proto, sizeof(proto)));
+                             &proto, sizeof(proto), false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -126,6 +134,63 @@ static void pack_and_unpack_small_payload(void **state)
     assert_true(bft_matcher_equal(source, destination));
 }
 
+static void pack_and_unpack_with_negate(void **state)
+{
+    _free_bf_matcher_ struct bf_matcher *source = NULL;
+    _free_bf_matcher_ struct bf_matcher *destination = NULL;
+    _free_bf_wpack_ bf_wpack_t *wpack = NULL;
+    _free_bf_rpack_ bf_rpack_t *rpack = NULL;
+    const void *data;
+    size_t data_len;
+    uint16_t port = htons(80);
+
+    (void)state;
+
+    // Create source matcher with negate=true
+    assert_ok(bf_matcher_new(&source, BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
+                             &port, sizeof(port), true));
+    assert_true(bf_matcher_get_negate(source));
+
+    // Pack and unpack
+    assert_ok(bf_wpack_new(&wpack));
+    assert_ok(bf_matcher_pack(source, wpack));
+    assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
+
+    assert_ok(bf_rpack_new(&rpack, data, data_len));
+    assert_ok(bf_matcher_new_from_pack(&destination, bf_rpack_root(rpack)));
+
+    // Verify negate round-trips correctly
+    assert_true(bf_matcher_get_negate(destination));
+    assert_true(bft_matcher_equal(source, destination));
+}
+
+static void unpack_without_negate_defaults_false(void **state)
+{
+    _free_bf_matcher_ struct bf_matcher *matcher = NULL;
+    _free_bf_rpack_ bf_rpack_t *rpack = NULL;
+    _free_bf_wpack_ bf_wpack_t *wpack = NULL;
+    const void *data;
+    size_t data_len;
+    uint16_t port = htons(80);
+
+    (void)state;
+
+    assert_ok(bf_wpack_new(&wpack));
+    bf_wpack_kv_int(wpack, "type", BF_MATCHER_TCP_SPORT);
+    bf_wpack_kv_int(wpack, "op", BF_MATCHER_EQ);
+    bf_wpack_kv_bin(wpack, "payload", &port, sizeof(port));
+    assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
+
+    assert_ok(bf_rpack_new(&rpack, data, data_len));
+    assert_ok(bf_matcher_new_from_pack(&matcher, bf_rpack_root(rpack)));
+
+    assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_TCP_SPORT);
+    assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_EQ);
+    assert_false(bf_matcher_get_negate(matcher));
+    assert_int_equal(bf_matcher_payload_len(matcher), sizeof(port));
+    assert_memory_equal(bf_matcher_payload(matcher), &port, sizeof(port));
+}
+
 static void dump(void **state)
 {
     _free_bf_matcher_ struct bf_matcher *matcher = NULL;
@@ -135,7 +200,7 @@ static void dump(void **state)
     (void)state;
 
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
-                             payload, sizeof(payload)));
+                             payload, sizeof(payload), false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -148,7 +213,7 @@ static void dump_small_payload(void **state)
     (void)state;
 
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
-                             &proto, sizeof(proto)));
+                             &proto, sizeof(proto), false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -161,7 +226,7 @@ static void dump_ipv4_addr(void **state)
 
     // Test dumping IPv4 address matcher (tests _bf_print_ipv4_addr)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DADDR,
-                                      BF_MATCHER_EQ, "10.0.0.1"));
+                                      BF_MATCHER_EQ, "10.0.0.1", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -174,7 +239,7 @@ static void dump_ipv6_addr(void **state)
 
     // Test dumping IPv6 address matcher (tests _bf_print_ipv6_addr)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SADDR,
-                                      BF_MATCHER_EQ, "2001:db8::1"));
+                                      BF_MATCHER_EQ, "2001:db8::1", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -187,12 +252,12 @@ static void dump_port(void **state)
 
     // Test dumping port matcher (tests _bf_print_port)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_DPORT,
-                                      BF_MATCHER_EQ, "443"));
+                                      BF_MATCHER_EQ, "443", false));
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_UDP_SPORT,
-                                      BF_MATCHER_EQ, "53"));
+                                      BF_MATCHER_EQ, "53", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -205,12 +270,12 @@ static void dump_l4_proto(void **state)
 
     // Test dumping L4 protocol matcher (tests _bf_print_l4_proto)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "tcp"));
+                                      BF_MATCHER_EQ, "tcp", false));
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "icmp"));
+                                      BF_MATCHER_EQ, "icmp", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -224,7 +289,7 @@ static void dump_tcp_flags(void **state)
 
     // Test dumping TCP flags matcher (tests _bf_print_tcp_flags)
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY,
-                             &flags, sizeof(flags)));
+                             &flags, sizeof(flags), false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -237,7 +302,7 @@ static void dump_icmp_type(void **state)
 
     // Test dumping ICMP type matcher (tests _bf_print_icmp_type)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_TYPE,
-                                      BF_MATCHER_EQ, "echo-request"));
+                                      BF_MATCHER_EQ, "echo-request", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -250,12 +315,12 @@ static void dump_various_ops(void **state)
 
     // Test different operators
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_DPORT,
-                                      BF_MATCHER_NE, "80"));
+                                      BF_MATCHER_RANGE, "80-443", false));
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_IN, "udp"));
+                                      BF_MATCHER_IN, "udp", false));
     bf_matcher_dump(matcher, &prefix);
 }
 
@@ -492,7 +557,7 @@ static void get_ops(void **state)
     ops = bf_matcher_get_ops(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ);
     assert_non_null(ops);
 
-    ops = bf_matcher_get_ops(BF_MATCHER_TCP_DPORT, BF_MATCHER_NE);
+    ops = bf_matcher_get_ops(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE);
     assert_non_null(ops);
 
     // Not all combinations are valid, so some may return NULL
@@ -512,7 +577,7 @@ static void meta_iface(void **state)
 
     // Test with numeric interface index
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                      BF_MATCHER_EQ, "1"));
+                                      BF_MATCHER_EQ, "1", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_META_IFACE);
     assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_EQ);
@@ -521,7 +586,7 @@ static void meta_iface(void **state)
 
     // Test with interface index as string
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                      BF_MATCHER_EQ, "42"));
+                                      BF_MATCHER_EQ, "42", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -534,15 +599,16 @@ static void meta_iface_invalid(void **state)
 
     // Test with invalid interface index (negative)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                       BF_MATCHER_EQ, "-1"));
+                                       BF_MATCHER_EQ, "-1", false));
 
     // Test with invalid interface index (too large)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                       BF_MATCHER_EQ, "999999999999"));
+                                       BF_MATCHER_EQ, "999999999999", false));
 
     // Test with invalid string
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                       BF_MATCHER_EQ, "invalid_iface_name"));
+                                       BF_MATCHER_EQ, "invalid_iface_name",
+                                       false));
 }
 
 static void meta_l3_proto(void **state)
@@ -554,28 +620,29 @@ static void meta_l3_proto(void **state)
 
     // Test with IPv4 ethertype string
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                      BF_MATCHER_EQ, "ipv4"));
+                                      BF_MATCHER_EQ, "ipv4", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with IPv6 ethertype string
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                      BF_MATCHER_EQ, "ipv6"));
+                                      BF_MATCHER_EQ, "ipv6", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with decimal ethertype
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                      BF_MATCHER_EQ, "2048")); // 0x0800 (IPv4)
+                                      BF_MATCHER_EQ, "2048",
+                                      false)); // 0x0800 (IPv4)
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with hexadecimal ethertype
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                      BF_MATCHER_EQ, "0x86DD")); // IPv6
+                                      BF_MATCHER_EQ, "0x86DD", false)); // IPv6
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -589,7 +656,7 @@ static void meta_probability(void **state)
 
     // Test with 0%
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "0%"));
+                                      BF_MATCHER_EQ, "0%", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_payload_len(matcher), sizeof(float));
     assert_true(*(float *)bf_matcher_payload(matcher) == 0.0f);
@@ -598,7 +665,7 @@ static void meta_probability(void **state)
 
     // Test with 50%
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "50%"));
+                                      BF_MATCHER_EQ, "50%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) == 50.0f);
     bf_matcher_dump(matcher, &prefix);
@@ -606,7 +673,7 @@ static void meta_probability(void **state)
 
     // Test with 100%
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "100%"));
+                                      BF_MATCHER_EQ, "100%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) == 100.0f);
     bf_matcher_dump(matcher, &prefix);
@@ -614,7 +681,7 @@ static void meta_probability(void **state)
 
     // Test with floating-point value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "33.33%"));
+                                      BF_MATCHER_EQ, "33.33%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) > 33.32f);
     assert_true(*(float *)bf_matcher_payload(matcher) < 33.34f);
@@ -623,7 +690,7 @@ static void meta_probability(void **state)
 
     // Test with small floating-point value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "0.1%"));
+                                      BF_MATCHER_EQ, "0.1%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) > 0.09f);
     assert_true(*(float *)bf_matcher_payload(matcher) < 0.11f);
@@ -638,19 +705,19 @@ static void meta_probability_invalid(void **state)
 
     // Test with value over 100%
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                       BF_MATCHER_EQ, "101%"));
+                                       BF_MATCHER_EQ, "101%", false));
 
     // Test with value slightly over 100%
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                       BF_MATCHER_EQ, "100.01%"));
+                                       BF_MATCHER_EQ, "100.01%", false));
 
     // Test without % sign
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                       BF_MATCHER_EQ, "50"));
+                                       BF_MATCHER_EQ, "50", false));
 
     // Test with negative value
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                       BF_MATCHER_EQ, "-10%"));
+                                       BF_MATCHER_EQ, "-10%", false));
 }
 
 static void meta_probability_pack_unpack(void **state)
@@ -666,7 +733,7 @@ static void meta_probability_pack_unpack(void **state)
 
     // Test pack/unpack with integer percentage
     assert_ok(bf_matcher_new_from_raw(&source, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "50%"));
+                                      BF_MATCHER_EQ, "50%", false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -682,7 +749,7 @@ static void meta_probability_pack_unpack(void **state)
 
     // Test pack/unpack with floating-point percentage
     assert_ok(bf_matcher_new_from_raw(&source, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "33.33%"));
+                                      BF_MATCHER_EQ, "33.33%", false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -702,28 +769,28 @@ static void meta_sport_dport(void **state)
 
     // Test META_SPORT with EQ
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                      BF_MATCHER_EQ, "8080"));
+                                      BF_MATCHER_EQ, "8080", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
-    // Test META_SPORT with NE
+    // Test META_SPORT with EQ
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                      BF_MATCHER_NE, "22"));
+                                      BF_MATCHER_EQ, "22", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test META_DPORT with EQ
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_DPORT,
-                                      BF_MATCHER_EQ, "443"));
+                                      BF_MATCHER_EQ, "443", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
-    // Test META_DPORT with NE
+    // Test META_DPORT with EQ
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_DPORT,
-                                      BF_MATCHER_NE, "80"));
+                                      BF_MATCHER_EQ, "80", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -737,7 +804,7 @@ static void meta_sport_dport_range(void **state)
 
     // Test META_SPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                      BF_MATCHER_RANGE, "1024-65535"));
+                                      BF_MATCHER_RANGE, "1024-65535", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_payload_len(matcher), 2 * sizeof(uint16_t));
     bf_matcher_dump(matcher, &prefix);
@@ -745,14 +812,14 @@ static void meta_sport_dport_range(void **state)
 
     // Test META_DPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_DPORT,
-                                      BF_MATCHER_RANGE, "8000-9000"));
+                                      BF_MATCHER_RANGE, "8000-9000", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test single port range (min == max)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                      BF_MATCHER_RANGE, "80-80"));
+                                      BF_MATCHER_RANGE, "80-80", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -765,23 +832,23 @@ static void meta_sport_dport_range_invalid(void **state)
 
     // Test with reversed range (max < min)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                       BF_MATCHER_RANGE, "9000-8000"));
+                                       BF_MATCHER_RANGE, "9000-8000", false));
 
     // Test with missing end port
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                       BF_MATCHER_RANGE, "8000-"));
+                                       BF_MATCHER_RANGE, "8000-", false));
 
     // Test with missing start port
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                       BF_MATCHER_RANGE, "-9000"));
+                                       BF_MATCHER_RANGE, "-9000", false));
 
     // Test with no delimiter
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                       BF_MATCHER_RANGE, "8000"));
+                                       BF_MATCHER_RANGE, "8000", false));
 
     // Test with invalid port number
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                       BF_MATCHER_RANGE, "1024-70000"));
+                                       BF_MATCHER_RANGE, "1024-70000", false));
 }
 
 static void meta_mark(void **state)
@@ -793,7 +860,7 @@ static void meta_mark(void **state)
 
     // Test with decimal mark
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                      BF_MATCHER_EQ, "42"));
+                                      BF_MATCHER_EQ, "42", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint32_t *)bf_matcher_payload(matcher), 42);
     bf_matcher_dump(matcher, &prefix);
@@ -801,15 +868,15 @@ static void meta_mark(void **state)
 
     // Test with hexadecimal mark
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                      BF_MATCHER_EQ, "0x1234"));
+                                      BF_MATCHER_EQ, "0x1234", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint32_t *)bf_matcher_payload(matcher), 0x1234);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
-    // Test with NE operator
+    // Test with EQ operator
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                      BF_MATCHER_NE, "0"));
+                                      BF_MATCHER_EQ, "0", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -822,15 +889,15 @@ static void meta_mark_invalid(void **state)
 
     // Test with negative value
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                       BF_MATCHER_EQ, "-1"));
+                                       BF_MATCHER_EQ, "-1", false));
 
     // Test with value too large (> UINT32_MAX)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                       BF_MATCHER_EQ, "0x100000000"));
+                                       BF_MATCHER_EQ, "0x100000000", false));
 
     // Test with invalid string
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                       BF_MATCHER_EQ, "not_a_number"));
+                                       BF_MATCHER_EQ, "not_a_number", false));
 }
 
 static void new_from_raw_ip4_addr(void **state)
@@ -841,7 +908,7 @@ static void new_from_raw_ip4_addr(void **state)
 
     // Test IPv4 address parsing
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SADDR,
-                                      BF_MATCHER_EQ, "192.168.1.1"));
+                                      BF_MATCHER_EQ, "192.168.1.1", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_IP4_SADDR);
     assert_int_equal(bf_matcher_get_op(matcher), BF_MATCHER_EQ);
@@ -849,7 +916,7 @@ static void new_from_raw_ip4_addr(void **state)
 
     // Test with CIDR notation (use SNET for network matching)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                      BF_MATCHER_IN, "10.0.0.0/8"));
+                                      BF_MATCHER_IN, "10.0.0.0/8", false));
     assert_non_null(matcher);
 }
 
@@ -861,12 +928,12 @@ static void new_from_raw_ip6_addr(void **state)
 
     // Test IPv6 address parsing
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DADDR,
-                                      BF_MATCHER_EQ, "::1"));
+                                      BF_MATCHER_EQ, "::1", false));
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DADDR,
-                                      BF_MATCHER_EQ, "2001:db8::1"));
+                                      BF_MATCHER_EQ, "2001:db8::1", false));
     assert_non_null(matcher);
 }
 
@@ -878,12 +945,12 @@ static void new_from_raw_port(void **state)
 
     // Test port parsing
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_DPORT,
-                                      BF_MATCHER_EQ, "80"));
+                                      BF_MATCHER_EQ, "80", false));
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_UDP_SPORT,
-                                      BF_MATCHER_EQ, "53"));
+                                      BF_MATCHER_EQ, "53", false));
     assert_non_null(matcher);
 }
 
@@ -895,18 +962,18 @@ static void new_from_raw_proto(void **state)
 
     // Test protocol parsing
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "tcp"));
+                                      BF_MATCHER_EQ, "tcp", false));
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "udp"));
+                                      BF_MATCHER_EQ, "udp", false));
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
     // Test with numeric value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "6"));
+                                      BF_MATCHER_EQ, "6", false));
     assert_non_null(matcher);
 }
 
@@ -918,15 +985,16 @@ static void new_from_raw_invalid(void **state)
 
     // Test invalid IPv4 address
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SADDR,
-                                       BF_MATCHER_EQ, "999.999.999.999"));
+                                       BF_MATCHER_EQ, "999.999.999.999",
+                                       false));
 
     // Test invalid port
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_DPORT,
-                                       BF_MATCHER_EQ, "99999"));
+                                       BF_MATCHER_EQ, "99999", false));
 
     // Test invalid protocol
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                       BF_MATCHER_EQ, "invalid_proto"));
+                                       BF_MATCHER_EQ, "invalid_proto", false));
 }
 
 static void ipv4_network_matchers(void **state)
@@ -938,28 +1006,28 @@ static void ipv4_network_matchers(void **state)
 
     // Test IP4_SNET
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                      BF_MATCHER_IN, "192.168.0.0/16"));
+                                      BF_MATCHER_IN, "192.168.0.0/16", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test IP4_DNET with /8
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DNET,
-                                      BF_MATCHER_EQ, "10.0.0.0/8"));
+                                      BF_MATCHER_EQ, "10.0.0.0/8", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with /32 (single host)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                      BF_MATCHER_NE, "127.0.0.1/32"));
+                                      BF_MATCHER_EQ, "127.0.0.1/32", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with /24
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DNET,
-                                      BF_MATCHER_IN, "172.16.0.0/12"));
+                                      BF_MATCHER_IN, "172.16.0.0/12", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -973,28 +1041,28 @@ static void ipv6_network_matchers(void **state)
 
     // Test IP6_SNET
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SNET,
-                                      BF_MATCHER_IN, "2001:db8::/32"));
+                                      BF_MATCHER_IN, "2001:db8::/32", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test IP6_DNET
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DNET,
-                                      BF_MATCHER_EQ, "fe80::/10"));
+                                      BF_MATCHER_EQ, "fe80::/10", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with /128 (single host)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SNET,
-                                      BF_MATCHER_NE, "::1/128"));
+                                      BF_MATCHER_EQ, "::1/128", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with abbreviated IPv6
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DNET,
-                                      BF_MATCHER_IN, "ff00::/8"));
+                                      BF_MATCHER_IN, "ff00::/8", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -1007,15 +1075,16 @@ static void ipv4_network_invalid(void **state)
 
     // Test with missing prefix length
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                       BF_MATCHER_IN, "192.168.0.0"));
+                                       BF_MATCHER_IN, "192.168.0.0", false));
 
     // Test with invalid prefix length (> 32)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                       BF_MATCHER_IN, "192.168.0.0/33"));
+                                       BF_MATCHER_IN, "192.168.0.0/33", false));
 
     // Test with invalid IP address
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DNET,
-                                       BF_MATCHER_IN, "999.999.999.999/8"));
+                                       BF_MATCHER_IN, "999.999.999.999/8",
+                                       false));
 }
 
 static void ipv6_network_invalid(void **state)
@@ -1026,15 +1095,15 @@ static void ipv6_network_invalid(void **state)
 
     // Test with missing prefix length
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SNET,
-                                       BF_MATCHER_IN, "2001:db8::1"));
+                                       BF_MATCHER_IN, "2001:db8::1", false));
 
     // Test with invalid prefix length (> 128)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SNET,
-                                       BF_MATCHER_IN, "2001:db8::/129"));
+                                       BF_MATCHER_IN, "2001:db8::/129", false));
 
     // Test with invalid IPv6 address
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DNET,
-                                       BF_MATCHER_IN, "gggg::/64"));
+                                       BF_MATCHER_IN, "gggg::/64", false));
 }
 
 static void icmp_code(void **state)
@@ -1046,21 +1115,21 @@ static void icmp_code(void **state)
 
     // Test ICMP code with decimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                      BF_MATCHER_EQ, "0"));
+                                      BF_MATCHER_EQ, "0", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with different code value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                      BF_MATCHER_NE, "3"));
+                                      BF_MATCHER_EQ, "3", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with hexadecimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                      BF_MATCHER_EQ, "0x0a"));
+                                      BF_MATCHER_EQ, "0x0a", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -1074,21 +1143,21 @@ static void icmpv6_code(void **state)
 
     // Test ICMPv6 code with decimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_CODE,
-                                      BF_MATCHER_EQ, "0"));
+                                      BF_MATCHER_EQ, "0", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
-    // Test with NE operator
+    // Test with EQ operator
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_CODE,
-                                      BF_MATCHER_NE, "1"));
+                                      BF_MATCHER_EQ, "1", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with hexadecimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_CODE,
-                                      BF_MATCHER_IN, "0x05"));
+                                      BF_MATCHER_IN, "0x05", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -1103,7 +1172,7 @@ static void ip6_dscp(void **state)
 
     // Test IPv6 DSCP with decimal value 0 (minimum)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "0"));
+                                      BF_MATCHER_EQ, "0", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
     bf_matcher_dump(matcher, &prefix);
@@ -1111,7 +1180,7 @@ static void ip6_dscp(void **state)
 
     // Test with decimal value 63 (maximum DSCP)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "63"));
+                                      BF_MATCHER_EQ, "63", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 63);
     bf_matcher_dump(matcher, &prefix);
@@ -1119,22 +1188,22 @@ static void ip6_dscp(void **state)
 
     // Test with DSCP value 46 (EF - Expedited Forwarding)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "46"));
+                                      BF_MATCHER_EQ, "46", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
-    // Test with NE operator
+    // Test with EQ operator
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_NE, "8"));
+                                      BF_MATCHER_EQ, "8", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with hexadecimal value (0x2e = 46)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "0x2e"));
+                                      BF_MATCHER_EQ, "0x2e", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
     bf_matcher_dump(matcher, &prefix);
@@ -1142,7 +1211,7 @@ static void ip6_dscp(void **state)
 
     // Test with hexadecimal value (0x3f = 63)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "0x3f"));
+                                      BF_MATCHER_EQ, "0x3f", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 63);
     bf_matcher_dump(matcher, &prefix);
@@ -1150,21 +1219,21 @@ static void ip6_dscp(void **state)
 
     // Test with class name keyword
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "ef"));
+                                      BF_MATCHER_EQ, "ef", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
     bf_matcher_free(&matcher);
 
     // Test with BE alias (case insensitive)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "BE"));
+                                      BF_MATCHER_EQ, "BE", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
     bf_matcher_free(&matcher);
 
     // Test print function via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                      BF_MATCHER_EQ, "0x20"));
+                                      BF_MATCHER_EQ, "0x20", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP6_DSCP, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1179,19 +1248,19 @@ static void ip6_dscp_invalid(void **state)
 
     // Test with value > 63
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                       BF_MATCHER_EQ, "64"));
+                                       BF_MATCHER_EQ, "64", false));
 
     // Test with invalid class name
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                       BF_MATCHER_EQ, "cs8"));
+                                       BF_MATCHER_EQ, "cs8", false));
 
     // Test with negative value
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                       BF_MATCHER_EQ, "-1"));
+                                       BF_MATCHER_EQ, "-1", false));
 
     // Test with value > 0x3f in hex
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DSCP,
-                                       BF_MATCHER_EQ, "0x40"));
+                                       BF_MATCHER_EQ, "0x40", false));
 }
 
 static void icmpv6_type(void **state)
@@ -1203,7 +1272,7 @@ static void icmpv6_type(void **state)
 
     // Test ICMPv6 type with string name (tests _bf_parse_icmpv6_type)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_EQ, "echo-request"));
+                                      BF_MATCHER_EQ, "echo-request", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 128);
     bf_matcher_dump(matcher, &prefix);
@@ -1211,7 +1280,7 @@ static void icmpv6_type(void **state)
 
     // Test with echo-reply
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_EQ, "echo-reply"));
+                                      BF_MATCHER_EQ, "echo-reply", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 129);
     bf_matcher_dump(matcher, &prefix);
@@ -1219,23 +1288,23 @@ static void icmpv6_type(void **state)
 
     // Test with decimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_NE, "128"));
+                                      BF_MATCHER_EQ, "128", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with hexadecimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_IN,
-                                      "0x81")); // 129 (echo-reply)
+                                      BF_MATCHER_IN, "0x81",
+                                      false)); // 129 (echo-reply)
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with another named type
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_EQ,
-                                      "destination-unreachable"));
+                                      BF_MATCHER_EQ, "destination-unreachable",
+                                      false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 1);
     bf_matcher_dump(matcher, &prefix);
@@ -1250,7 +1319,7 @@ static void tcp_port_range(void **state)
 
     // Test TCP_SPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_SPORT,
-                                      BF_MATCHER_RANGE, "1024-2048"));
+                                      BF_MATCHER_RANGE, "1024-2048", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_payload_len(matcher), 2 * sizeof(uint16_t));
     bf_matcher_dump(matcher, &prefix);
@@ -1258,7 +1327,7 @@ static void tcp_port_range(void **state)
 
     // Test TCP_DPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_DPORT,
-                                      BF_MATCHER_RANGE, "80-443"));
+                                      BF_MATCHER_RANGE, "80-443", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -1272,14 +1341,14 @@ static void udp_port_range(void **state)
 
     // Test UDP_SPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_UDP_SPORT,
-                                      BF_MATCHER_RANGE, "5000-6000"));
+                                      BF_MATCHER_RANGE, "5000-6000", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test UDP_DPORT with RANGE
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_UDP_DPORT,
-                                      BF_MATCHER_RANGE, "53-53"));
+                                      BF_MATCHER_RANGE, "53-53", false));
     assert_non_null(matcher);
     bf_matcher_dump(matcher, &prefix);
 }
@@ -1293,7 +1362,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_iface via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_IFACE,
-                                      BF_MATCHER_EQ, "1"));
+                                      BF_MATCHER_EQ, "1", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_IFACE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1302,7 +1371,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_l3_proto via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                      BF_MATCHER_EQ, "ipv4"));
+                                      BF_MATCHER_EQ, "ipv4", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_L3_PROTO, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1311,7 +1380,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_l4_proto via ops (using META_L4_PROTO)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L4_PROTO,
-                                      BF_MATCHER_EQ, "tcp"));
+                                      BF_MATCHER_EQ, "tcp", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_L4_PROTO, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1320,7 +1389,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_l4_proto via ops (using IP4_PROTO)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "udp"));
+                                      BF_MATCHER_EQ, "udp", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1329,7 +1398,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_l4_port via ops (using TCP_SPORT)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_SPORT,
-                                      BF_MATCHER_EQ, "8080"));
+                                      BF_MATCHER_EQ, "8080", false));
     ops = bf_matcher_get_ops(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1338,7 +1407,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_l4_port_range via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_SPORT,
-                                      BF_MATCHER_RANGE, "1024-65535"));
+                                      BF_MATCHER_RANGE, "1024-65535", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_SPORT, BF_MATCHER_RANGE);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1347,7 +1416,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_probability via ops (integer value)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "50%"));
+                                      BF_MATCHER_EQ, "50%", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1356,7 +1425,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_probability via ops (fractional value)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_PROBABILITY,
-                                      BF_MATCHER_EQ, "33.33%"));
+                                      BF_MATCHER_EQ, "33.33%", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1364,8 +1433,9 @@ static void print_functions(void **state)
     bf_matcher_free(&matcher);
 
     // Test _bf_print_probability via ops (flow_probability, integer value)
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "50%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "50%", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1373,8 +1443,9 @@ static void print_functions(void **state)
     bf_matcher_free(&matcher);
 
     // Test _bf_print_probability via ops (flow_probability, fractional value)
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "33.33%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "33.33%", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1383,7 +1454,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_mark via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_MARK,
-                                      BF_MATCHER_EQ, "0x1234"));
+                                      BF_MATCHER_EQ, "0x1234", false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_MARK, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1392,7 +1463,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_ipv4_addr via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SADDR,
-                                      BF_MATCHER_EQ, "192.168.1.1"));
+                                      BF_MATCHER_EQ, "192.168.1.1", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1401,7 +1472,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_ipv4_net via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_SNET,
-                                      BF_MATCHER_IN, "192.168.0.0/16"));
+                                      BF_MATCHER_IN, "192.168.0.0/16", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP4_SNET, BF_MATCHER_IN);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1410,7 +1481,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_ipv6_addr via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_SADDR,
-                                      BF_MATCHER_EQ, "2001:db8::1"));
+                                      BF_MATCHER_EQ, "2001:db8::1", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1419,7 +1490,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_ipv6_net via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP6_DNET,
-                                      BF_MATCHER_IN, "2001:db8::/32"));
+                                      BF_MATCHER_IN, "2001:db8::/32", false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP6_DNET, BF_MATCHER_IN);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1428,7 +1499,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_tcp_flags via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_FLAGS,
-                                      BF_MATCHER_ANY, "syn,ack"));
+                                      BF_MATCHER_ANY, "syn,ack", false));
     ops = bf_matcher_get_ops(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1437,7 +1508,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_icmp_type via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_TYPE,
-                                      BF_MATCHER_EQ, "echo-request"));
+                                      BF_MATCHER_EQ, "echo-request", false));
     ops = bf_matcher_get_ops(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1446,7 +1517,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_icmp_code via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                      BF_MATCHER_EQ, "3"));
+                                      BF_MATCHER_EQ, "3", false));
     ops = bf_matcher_get_ops(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1455,7 +1526,7 @@ static void print_functions(void **state)
 
     // Test _bf_print_icmpv6_type via ops
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                      BF_MATCHER_EQ, "echo-request"));
+                                      BF_MATCHER_EQ, "echo-request", false));
     ops = bf_matcher_get_ops(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1471,51 +1542,56 @@ static void error_paths_parse(void **state)
 
     // Test _bf_parse_l3_proto error path with completely invalid input
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                       BF_MATCHER_EQ, "not_a_protocol"));
+                                       BF_MATCHER_EQ, "not_a_protocol", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_META_L3_PROTO,
-                                       BF_MATCHER_EQ, "99999")); // Too large
+                                       BF_MATCHER_EQ, "99999",
+                                       false)); // Too large
 
     // Test _bf_parse_l4_proto with valid hex values
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "0x06"));
+                                      BF_MATCHER_EQ, "0x06", false));
     bf_matcher_free(&matcher);
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                      BF_MATCHER_EQ, "0x11"));
+                                      BF_MATCHER_EQ, "0x11", false));
     bf_matcher_free(&matcher);
 
     // Test _bf_parse_l4_proto error path with invalid protocol
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                       BF_MATCHER_EQ, "xyz"));
+                                       BF_MATCHER_EQ, "xyz", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                       BF_MATCHER_EQ,
-                                       "256")); // Too large for uint8_t
+                                       BF_MATCHER_EQ, "256",
+                                       false)); // Too large for uint8_t
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_PROTO,
-                                       BF_MATCHER_EQ,
-                                       "0x100")); // Too large for uint8_t
+                                       BF_MATCHER_EQ, "0x100",
+                                       false)); // Too large for uint8_t
 
     // Test _bf_parse_tcp_flags error path with invalid flag
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_FLAGS,
-                                       BF_MATCHER_ANY, "invalid_flag"));
+                                       BF_MATCHER_ANY, "invalid_flag", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_TCP_FLAGS,
-                                       BF_MATCHER_ANY, "syn,invalid,ack"));
+                                       BF_MATCHER_ANY, "syn,invalid,ack",
+                                       false));
 
     // Test _bf_parse_icmp_code error path with invalid code
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                       BF_MATCHER_EQ, "not_a_number"));
+                                       BF_MATCHER_EQ, "not_a_number", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_CODE,
-                                       BF_MATCHER_EQ, "256")); // Too large
+                                       BF_MATCHER_EQ, "256",
+                                       false)); // Too large
 
     // Test _bf_parse_icmp_type error path with invalid type
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_TYPE,
-                                       BF_MATCHER_EQ, "invalid-type"));
+                                       BF_MATCHER_EQ, "invalid-type", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMP_TYPE,
-                                       BF_MATCHER_EQ, "999")); // Too large
+                                       BF_MATCHER_EQ, "999",
+                                       false)); // Too large
 
     // Test _bf_parse_icmpv6_type error path with invalid type
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                       BF_MATCHER_EQ, "not-a-type"));
+                                       BF_MATCHER_EQ, "not-a-type", false));
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_ICMPV6_TYPE,
-                                       BF_MATCHER_EQ, "300")); // Too large
+                                       BF_MATCHER_EQ, "300",
+                                       false)); // Too large
 }
 
 static void error_paths_print(void **state)
@@ -1533,7 +1609,7 @@ static void error_paths_print(void **state)
 
     // Test _bf_print_iface error path with invalid ifindex (name lookup fails)
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_META_IFACE, BF_MATCHER_EQ,
-                             &invalid_ifindex, sizeof(invalid_ifindex)));
+                             &invalid_ifindex, sizeof(invalid_ifindex), false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_IFACE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1543,7 +1619,8 @@ static void error_paths_print(void **state)
 
     // Test _bf_print_l3_proto error path with unknown ethertype
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_META_L3_PROTO, BF_MATCHER_EQ,
-                             &unknown_ethertype, sizeof(unknown_ethertype)));
+                             &unknown_ethertype, sizeof(unknown_ethertype),
+                             false));
     ops = bf_matcher_get_ops(BF_MATCHER_META_L3_PROTO, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1553,7 +1630,8 @@ static void error_paths_print(void **state)
 
     // Test _bf_print_l4_proto error path with unknown protocol
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
-                             &unknown_protocol, sizeof(unknown_protocol)));
+                             &unknown_protocol, sizeof(unknown_protocol),
+                             false));
     ops = bf_matcher_get_ops(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1563,7 +1641,8 @@ static void error_paths_print(void **state)
 
     // Test _bf_print_icmp_type error path with unknown type
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ,
-                             &unknown_icmp_type, sizeof(unknown_icmp_type)));
+                             &unknown_icmp_type, sizeof(unknown_icmp_type),
+                             false));
     ops = bf_matcher_get_ops(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1573,8 +1652,8 @@ static void error_paths_print(void **state)
 
     // Test _bf_print_icmpv6_type error path with unknown type
     assert_ok(bf_matcher_new(&matcher, BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ,
-                             &unknown_icmpv6_type,
-                             sizeof(unknown_icmpv6_type)));
+                             &unknown_icmpv6_type, sizeof(unknown_icmpv6_type),
+                             false));
     ops = bf_matcher_get_ops(BF_MATCHER_ICMPV6_TYPE, BF_MATCHER_EQ);
     assert_non_null(ops);
     assert_non_null(ops->print);
@@ -1592,55 +1671,55 @@ static void ip4_dscp(void **state)
 
     // Test ip4.dscp with decimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "16"));
+                                      BF_MATCHER_EQ, "16", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_get_type(matcher), BF_MATCHER_IP4_DSCP);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp with hexadecimal value
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "0x10"));
+                                      BF_MATCHER_EQ, "0x10", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0x10);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp with minimum value (0)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "0"));
+                                      BF_MATCHER_EQ, "0", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp with maximum value (63)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "63"));
+                                      BF_MATCHER_EQ, "63", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 63);
     bf_matcher_free(&matcher);
 
-    // Test ip4.dscp with NE operator
+    // Test ip4.dscp with EQ operator
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_NE, "8"));
+                                      BF_MATCHER_EQ, "8", false));
     assert_non_null(matcher);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp with class name keyword
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "ef"));
+                                      BF_MATCHER_EQ, "ef", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 46);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp with BE alias (case insensitive)
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "BE"));
+                                      BF_MATCHER_EQ, "BE", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 0);
     bf_matcher_free(&matcher);
 
     // Test ip4.dscp print function
     assert_ok(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                      BF_MATCHER_EQ, "0x3f"));
+                                      BF_MATCHER_EQ, "0x3f", false));
     assert_non_null(matcher);
     assert_int_equal(*(uint8_t *)bf_matcher_payload(matcher), 63);
     bf_matcher_dump(matcher, &prefix);
@@ -1648,23 +1727,23 @@ static void ip4_dscp(void **state)
 
     // Test ip4.dscp with invalid value (> 63)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                       BF_MATCHER_EQ, "64"));
+                                       BF_MATCHER_EQ, "64", false));
 
     // Test ip4.dscp with invalid hex value (> 0x3f)
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                       BF_MATCHER_EQ, "0x40"));
+                                       BF_MATCHER_EQ, "0x40", false));
 
     // Test ip4.dscp with invalid class name
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                       BF_MATCHER_EQ, "cs8"));
+                                       BF_MATCHER_EQ, "cs8", false));
 
     // Test ip4.dscp with invalid string
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                       BF_MATCHER_EQ, "invalid"));
+                                       BF_MATCHER_EQ, "invalid", false));
 
     // Test ip4.dscp with negative value
     assert_err(bf_matcher_new_from_raw(&matcher, BF_MATCHER_IP4_DSCP,
-                                       BF_MATCHER_EQ, "-1"));
+                                       BF_MATCHER_EQ, "-1", false));
 }
 
 static void meta_flow_probability(void **state)
@@ -1675,8 +1754,9 @@ static void meta_flow_probability(void **state)
     (void)state;
 
     // Test with 0%
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "0%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "0%", false));
     assert_non_null(matcher);
     assert_int_equal(bf_matcher_get_type(matcher),
                      BF_MATCHER_META_FLOW_PROBABILITY);
@@ -1687,24 +1767,27 @@ static void meta_flow_probability(void **state)
     bf_matcher_free(&matcher);
 
     // Test with 50%
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "50%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "50%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) == 50.0f);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with 100%
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "100%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "100%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) == 100.0f);
     bf_matcher_dump(matcher, &prefix);
     bf_matcher_free(&matcher);
 
     // Test with floating-point value
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "33.33%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "33.33%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) > 33.32f);
     assert_true(*(float *)bf_matcher_payload(matcher) < 33.34f);
@@ -1712,8 +1795,9 @@ static void meta_flow_probability(void **state)
     bf_matcher_free(&matcher);
 
     // Test with small floating-point value
-    assert_ok(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "0.1%"));
+    assert_ok(bf_matcher_new_from_raw(&matcher,
+                                      BF_MATCHER_META_FLOW_PROBABILITY,
+                                      BF_MATCHER_EQ, "0.1%", false));
     assert_non_null(matcher);
     assert_true(*(float *)bf_matcher_payload(matcher) > 0.09f);
     assert_true(*(float *)bf_matcher_payload(matcher) < 0.11f);
@@ -1727,20 +1811,24 @@ static void meta_flow_probability_invalid(void **state)
     (void)state;
 
     // Test with value over 100%
-    assert_err(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "101%"));
+    assert_err(bf_matcher_new_from_raw(&matcher,
+                                       BF_MATCHER_META_FLOW_PROBABILITY,
+                                       BF_MATCHER_EQ, "101%", false));
 
     // Test with value slightly over 100%
-    assert_err(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "100.01%"));
+    assert_err(bf_matcher_new_from_raw(&matcher,
+                                       BF_MATCHER_META_FLOW_PROBABILITY,
+                                       BF_MATCHER_EQ, "100.01%", false));
 
     // Test without % sign
-    assert_err(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "50"));
+    assert_err(bf_matcher_new_from_raw(&matcher,
+                                       BF_MATCHER_META_FLOW_PROBABILITY,
+                                       BF_MATCHER_EQ, "50", false));
 
     // Test with negative value
-    assert_err(bf_matcher_new_from_raw(
-        &matcher, BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, "-10%"));
+    assert_err(bf_matcher_new_from_raw(&matcher,
+                                       BF_MATCHER_META_FLOW_PROBABILITY,
+                                       BF_MATCHER_EQ, "-10%", false));
 }
 
 static void meta_flow_probability_pack_unpack(void **state)
@@ -1756,7 +1844,7 @@ static void meta_flow_probability_pack_unpack(void **state)
 
     // Test pack/unpack for EQ operator with integer percentage
     assert_ok(bf_matcher_new_from_raw(&source, BF_MATCHER_META_FLOW_PROBABILITY,
-                                      BF_MATCHER_EQ, "50%"));
+                                      BF_MATCHER_EQ, "50%", false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -1772,7 +1860,7 @@ static void meta_flow_probability_pack_unpack(void **state)
 
     // Test pack/unpack with floating-point percentage
     assert_ok(bf_matcher_new_from_raw(&source, BF_MATCHER_META_FLOW_PROBABILITY,
-                                      BF_MATCHER_EQ, "33.33%"));
+                                      BF_MATCHER_EQ, "33.33%", false));
     assert_ok(bf_wpack_new(&wpack));
     assert_ok(bf_matcher_pack(source, wpack));
     assert_ok(bf_wpack_get_data(wpack, &data, &data_len));
@@ -1791,6 +1879,8 @@ int main(void)
         cmocka_unit_test(getters),
         cmocka_unit_test(pack_and_unpack),
         cmocka_unit_test(pack_and_unpack_small_payload),
+        cmocka_unit_test(pack_and_unpack_with_negate),
+        cmocka_unit_test(unpack_without_negate_defaults_false),
         cmocka_unit_test(dump),
         cmocka_unit_test(dump_small_payload),
         cmocka_unit_test(dump_ipv4_addr),

--- a/tests/unit/libbpfilter/rule.c
+++ b/tests/unit/libbpfilter/rule.c
@@ -109,7 +109,7 @@ static void add_matcher(void **state)
     assert_non_null(matcher0 = bft_matcher_dummy("hello", 6));
     assert_ok(bf_rule_add_matcher(
         rule, bf_matcher_get_type(matcher0), bf_matcher_get_op(matcher0),
-        bf_matcher_payload(matcher0), bf_matcher_payload_len(matcher0)));
+        bf_matcher_payload(matcher0), bf_matcher_payload_len(matcher0), false));
     assert_int_equal(bf_list_size(&rule->matchers), 1);
     assert_true(bft_matcher_equal(
         matcher0, bf_list_node_get_data(bf_list_get_tail(&rule->matchers))));
@@ -117,7 +117,7 @@ static void add_matcher(void **state)
     assert_non_null(matcher1 = bft_matcher_dummy("", 1));
     assert_ok(bf_rule_add_matcher(
         rule, bf_matcher_get_type(matcher1), bf_matcher_get_op(matcher1),
-        bf_matcher_payload(matcher1), bf_matcher_payload_len(matcher1)));
+        bf_matcher_payload(matcher1), bf_matcher_payload_len(matcher1), false));
     assert_int_equal(bf_list_size(&rule->matchers), 2);
     assert_true(bft_matcher_equal(
         matcher1, bf_list_node_get_data(bf_list_get_tail(&rule->matchers))));


### PR DESCRIPTION

This supports the ability to negate a matcher by simply adding a "not" in
front of the matcher op, e.g. `tcp.sport not eq 80`.

This works for all matcher operations.

This also replaces/removes the "not" matcher operation but maintains
backward compatibility as `tcp.sport not 80` is also supported syntax and
translates to `not eq`.

The primary use-case is so we can create matchers for flags where we want
to match against one particular flag AND not match against another for the
same rule, e.g. has SYN and does not have ACK.

Made two decisions in the design:
1. Went with "not" instead of "!" because matchers are written in English
   sentences and not code so it's more natural to use "not".
2. The placement of "not" is right before the matcher op so it doesn't read
   as the whole matcher is negated (this is relevant for protocol guards
   which are not negated)