### PR TITLE
tests: check: use find_program for iwyu_tool

### DIFF
--- a/.github/fedora-43.Dockerfile
+++ b/.github/fedora-43.Dockerfile
@@ -32,6 +32,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora,updates --nodocs --setopt=install_we
     python3-linuxdoc \
     python3-scapy \
     python3-sphinx \
+    include-what-you-use \
     sed \
     xxd && \
     dnf clean all -y

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,12 @@ jobs:
         run: ctest --test-dir $GITHUB_WORKSPACE/build -L integration --verbose
       - name: Run checks
         run: ctest --test-dir $GITHUB_WORKSPACE/build -L check --verbose
+
+      - name: Run IWYU
+        run: |
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build-iwyu -DWITH_IWYU=1 -DNO_BENCHMARKS=1
+          make -C $GITHUB_WORKSPACE/build-iwyu -j `nproc`
       - name: Generate the coverage report
         run: make -C $GITHUB_WORKSPACE/build coverage
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ option(NO_TESTS "Disable unit, end-to-end, and integration tests" 0)
 option(NO_CHECKS "Disable the check target (clang-tidy and clang-format" 0)
 option(NO_BENCHMARKS "Disable the benchmark" 0)
 option(WITH_COVERAGE "Build with code coverage support. Disabled by default" 0)
+option(WITH_IWYU "Build with include-what-you-use checks. Disabled by default" 0)
+
+if (WITH_IWYU)
+    find_program(IWYU_BIN NAMES include-what-you-use iwyu REQUIRED)
+    set(CMAKE_C_INCLUDE_WHAT_YOU_USE "${IWYU_BIN};-Xiwyu;--error")
+endif ()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/tests/check/CMakeLists.txt
+++ b/tests/check/CMakeLists.txt
@@ -27,13 +27,6 @@ add_test(NAME "check.lint"
             ${bf_srcs}
 )
 
-add_test(NAME "check.iwyu"
-    COMMAND
-        /usr/bin/iwyu_tool.py
-            -p ${CMAKE_BINARY_DIR}
-            ${CMAKE_SOURCE_DIR}/src/libbpfilter/cgen/program.c
-)
-
 set_tests_properties("check.lint" PROPERTIES
     LABELS "check"
 )


### PR DESCRIPTION
Use `find_program` instead of the absolute path for iwyu. This fixes an issue where this binary can't be found in a nix shell.

Tested locally and now the iwyu tests pass and the binary can be located.