### PR TITLE
build: disable AI review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -8,11 +8,6 @@
 #   3. "post"   - reads the JSON and posts comments to the PR (write permissions)
 
 name: Claude PR Review
-on:
-    # _target gives forks access to upstream's secrets and identity.
-    pull_request_target:
-        types: [opened, synchronize]
-        branches: [main]
 concurrency:
     group: claude-review-${{ github.event.pull_request.number }}
     cancel-in-progress: true


### PR DESCRIPTION
pull_request_target is unsafe, as it has access to the repository's secrets, coupled with allowed_non_write_users="*", it could be abused to exfiltrate secrets.

Disable AI review workflow until a better setup is implemented.