### PR TITLE
build: enable AI review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yaml
+++ b/.github/workflows/claude-pr-review.yaml
@@ -8,15 +8,28 @@
 #   3. "post"   - reads the JSON and posts comments to the PR (write permissions)
 
 name: Claude PR Review
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
 concurrency:
-    group: claude-review-${{ github.event.pull_request.number }}
+    group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
     cancel-in-progress: true
 
 jobs:
     setup:
         runs-on: ubuntu-latest
+        if: >
+            (github.event_name == 'pull_request_target'
+              && contains(fromJSON('["OWNER","MEMBER"]'), github.event.pull_request.author_association))
+            ||
+            (github.event_name == 'issue_comment'
+              && github.event.issue.pull_request
+              && contains(github.event.comment.body, '@claude')
+              && contains(fromJSON('["OWNER","MEMBER"]'), github.event.comment.author_association))
         env:
-            PR_NUMBER: ${{ github.event.pull_request.number }}
+            PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         permissions:
             contents: read
             pull-requests: write
@@ -101,10 +114,9 @@ jobs:
                   role-session-name: GitHubActions-facebook-bpfilter-${{ github.run_id }}
                   aws-region: us-east-1
 
-            # TODO(@pzmarzly): Unpin once https://github.com/anthropics/claude-code-action/issues/1013 is fixed.
             - name: Run Claude Code
               id: claude
-              uses: anthropics/claude-code-action@v1.0.66
+              uses: anthropics/claude-code-action@main
               env:
                   REVIEW_SCHEMA: >-
                       {
@@ -154,8 +166,8 @@ jobs:
                   # Prompt
                   prompt: |
                       REPO: ${{ github.repository }}
-                      PR NUMBER: ${{ github.event.pull_request.number }}
-                      HEAD SHA: ${{ github.event.pull_request.head.sha }}
+                      PR NUMBER: ${{ needs.setup.outputs.pr_number }}
+                      HEAD SHA: ${{ needs.setup.outputs.head_sha }}
 
                       You are a code reviewer for the ${{ github.repository }} project. Review this pull request and
                       produce a structured JSON result containing your review. Do NOT attempt
@@ -168,7 +180,7 @@ jobs:
 
                       Use the GitHub MCP server tools to fetch PR data. For all tools, pass
                       owner `${{ github.repository_owner }}`, repo `${{ github.event.repository.name }}`,
-                      and pullNumber/issue_number ${{ github.event.pull_request.number }}:
+                      and pullNumber/issue_number ${{ needs.setup.outputs.pr_number }}:
                       - `mcp__github__get_pull_request_diff` to get the PR diff
                       - `mcp__github__get_pull_request` to get the PR title, body, and metadata
                       - `mcp__github__get_pull_request_comments` to get top-level PR comments
@@ -176,7 +188,7 @@ jobs:
                       - `mcp__github__get_pull_request_review_comments` to get inline review comments
 
                       Also fetch issue comments using `mcp__github__get_issue_comments` with
-                      issue_number ${{ github.event.pull_request.number }}.
+                      issue_number ${{ needs.setup.outputs.pr_number }}.
 
                       Look for an existing tracking comment (containing `<!-- claude-pr-review -->`)
                       in the issue comments. If one exists, you will use it as the basis for
@@ -319,9 +331,6 @@ jobs:
                         mcp__github__get_pull_request_status,
                         mcp__github__get_issue_comments,
                         "
-
-                  # Run even when triggered by 3rd party developer's PR
-                  allowed_non_write_users: "*"
 
                   # This requires "tag mode", which is currently bugged:
                   # https://github.com/anthropics/claude-code-action/issues/939


### PR DESCRIPTION
Following 5145f85, claude-pr-review.yaml has been modified to prevent repo secrets exfiltration:
- Maintainers PR are automatically reviewed by Claude
- External contributors PR are reviewed when a maintainer comments @claude on the PR
- The latest claude-code-action is used, instead of pinning an older version
- allowed_non_write_users="*" has been removed