### PR TITLE
doc: fix spacing and punctuation in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We actively welcome your pull requests.
 
 In order to accept your pull request, you need to submit a CLA. You only need to do this once to work on any of Meta's open source projects.
 
-Complete your CLA here: <http://code.facebook.com/cla>
+Complete your CLA here: <https://code.facebook.com/cla>
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
     <a href="README.md#key-features">Key features</a> •
     <a href="README.md#quick-start">Quick start</a> •
-  <a href="https://bpfilter.io/">Documentation</a>
+    <a href="https://bpfilter.io/">Documentation</a>
 </p>
 
 <p align="center">
@@ -40,7 +40,7 @@ Want to know more about **bpfilter**? Check the [user's guide](https://bpfilter.
 
 ### Install
 
-**bpfilter** is packaged for Fedora 40+, EPEL 9+ and supports Fedora 40+, CentOS Stream 9+, and Ubuntu 24.04+. The examples below use Fedora 41.
+**bpfilter** is packaged for Fedora 40+, EPEL 9+, and supports Fedora 40+, CentOS Stream 9+, and Ubuntu 24.04+. The examples below use Fedora 41.
 
 ```shell
 # Fedora 40+ or CentOS Stream 9+ (with EPEL)


### PR DESCRIPTION
Minor documentation improvements:

- Fix spacing inconsistency in README navigation links
- Add Oxford comma for consistency in package description
- Update CLA link from HTTP to HTTPS