### PR TITLE
[1.5/2] Add Bare `log` Option

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -409,14 +409,17 @@ Rules are defined such as:
     rule
         [$MATCHER...]
         [$SET...]
-        [log link,internet,transport]
+        [log [$HEADERS]]
         [counter]
         [mark $MARK]
         $VERDICT
 
 With:
   - ``$MATCHER``: zero or more matchers. Matchers are defined later.
-  - ``log``: optional. If set, log the requested protocol headers. ``link`` will log the link (layer 2) header, ``internet`` with log the internet (layer 3) header, and ``transport`` will log the transport (layer 4) header. At least one header type is required. ``log`` is **not** supported by ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks.
+  - ``log``: optional. Logging is not supported by ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks. Two forms are supported:
+
+    - ``log $HEADERS``: log specific packet headers. ``$HEADERS`` is a comma-separated list of ``link`` (layer 2), ``internet`` (layer 3), and/or ``transport`` (layer 4). Only supported by packet-based hooks (XDP, TC, NF, cgroup_skb).
+    - ``log``: log all available data for the hook type. For packet-based hooks, this is equivalent to ``log link,internet,transport``.
   - ``counter``: optional literal. If set, the filter will count the number of events matched by the rule. For packet-based hooks, this includes both the number of packets and the total bytes. For ``BF_HOOK_CGROUP_SOCK_ADDR_*`` hooks, this counts the number of socket operations (``connect()`` or ``sendmsg()`` calls).
   - ``mark``: optional, ``$MARK`` must be a valid decimal or hexadecimal 32-bits value. If set, write the packet's marker value. This marker can be used later on in a rule (see ``meta.mark``) or with a TC filter.
   - ``$VERDICT``: action taken by the rule if the packet is matched against **all** the criteria: either ``ACCEPT``, ``DROP``, ``CONTINUE``, ``NEXT``, or ``REDIRECT``.

--- a/src/bfcli/lexer.l
+++ b/src/bfcli/lexer.l
@@ -21,7 +21,6 @@
 %option nounput
 
 %s STATE_HOOK_OPTS
-%s STATE_LOG_OPTS
 %s STATE_MARK_OPTS
 %s STATE_REDIRECT_IFACE
 %s STATE_REDIRECT_DIR
@@ -96,14 +95,7 @@ mark            { BEGIN(STATE_MARK_OPTS); return MARK; }
 }
 
     /* Logs */
-log             { BEGIN(STATE_LOG_OPTS); return LOG; }
-<STATE_LOG_OPTS>{
-    [0-9a-zA-Z]+(,[0-9a-zA-Z]+)* {
-        BEGIN(INITIAL);
-        yylval.sval = strdup(yytext);
-        return LOG_HEADERS;
-    }
-}
+log             { return LOG; }
 
     /* Sets */
 \([ \t\n\r\f\v]*([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)([ \t\n\r\f\v]*,[ \t\n\r\f\v]*([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+))*[ \t\n\r\f\v]*\) {

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -329,9 +329,9 @@ rule_option     : LOG LOG_HEADERS
                     uint8_t log = 0;
 
                     while ((token = strtok_r(tmp, ",", &saveptr))) {
-                        enum bf_pkthdr header;
+                        enum bf_log_opt header;
 
-                        if (bf_pkthdr_from_str(token, &header) < 0)
+                        if (bf_log_opt_from_str(token, &header) < 0)
                             bf_parse_err("unknown packet header '%s'", token);
 
                         log |= BF_FLAG(header);

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -103,7 +103,6 @@
 %token SET
 %token LOG COUNTER MARK
 %token REDIRECT_TOKEN
-%token <sval> LOG_HEADERS
 %token <sval> SET_TYPE
 %token <sval> SET_RAW_PAYLOAD
 %token <sval> STRING
@@ -139,6 +138,7 @@
 %type <list> rules
 %destructor { bf_list_free(&$$); } rules
 
+%type <u8> log_headers
 %type <rule_options> rule_option
 %type <rule_options> rule_options
 %type <rule> rule
@@ -320,27 +320,17 @@ rule            : RULE matchers rule_options rule_verdict
                 }
                 ;
 
-rule_option     : LOG LOG_HEADERS
+rule_option     : LOG
                 {
-                    _cleanup_free_ char *in = $2;
-                    char *tmp = in;
-                    char *saveptr;
-                    char *token;
-                    uint8_t log = 0;
-
-                    while ((token = strtok_r(tmp, ",", &saveptr))) {
-                        enum bf_log_opt header;
-
-                        if (bf_log_opt_from_str(token, &header) < 0)
-                            bf_parse_err("unknown packet header '%s'", token);
-
-                        log |= BF_FLAG(header);
-
-                        tmp = NULL;
-                    }
-
                     $$ = (struct bf_rule_options){
-                        .log = log,
+                        .log = BF_LOG_OPT_DEFAULT,
+                        .flags = BF_RULE_OPTION_LOG,
+                    };
+                }
+                | LOG log_headers
+                {
+                    $$ = (struct bf_rule_options){
+                        .log = $2,
                         .flags = BF_RULE_OPTION_LOG,
                     };
                 }
@@ -396,6 +386,28 @@ rule_options    : %empty { $$ = (struct bf_rule_options){}; }
 
                     $$ = $1;
                 }
+
+log_headers     : STRING
+                {
+                    _cleanup_free_ const char *name = $1;
+                    enum bf_log_opt header;
+
+                    if (bf_log_opt_from_str(name, &header) < 0)
+                        bf_parse_err("unknown packet header '%s'", name);
+
+                    $$ = BF_FLAG(header);
+                }
+                | log_headers ',' STRING
+                {
+                    _cleanup_free_ const char *name = $3;
+                    enum bf_log_opt header;
+
+                    if (bf_log_opt_from_str(name, &header) < 0)
+                        bf_parse_err("unknown packet header '%s'", name);
+
+                    $$ = $1 | BF_FLAG(header);
+                }
+                ;
 
 matchers        : matcher
                 {

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -261,17 +261,21 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
         }
 
         if (rule->log) {
-            uint8_t log = rule->log;
+            if (rule->log == BF_LOG_OPT_DEFAULT) {
+                (void)fprintf(stdout, "        log\n");
+            } else {
+                uint8_t log = rule->log;
 
-            (void)fprintf(stdout, "        log ");
+                (void)fprintf(stdout, "        log ");
 
-            for (enum bf_log_opt hdr = 0; hdr < _BF_LOG_OPT_MAX; ++hdr) {
-                if (!(log & BF_FLAG(hdr)))
-                    continue;
+                for (enum bf_log_opt hdr = 0; hdr < _BF_LOG_OPT_MAX; ++hdr) {
+                    if (!(log & BF_FLAG(hdr)))
+                        continue;
 
-                log &= ~BF_FLAG(hdr);
-                (void)fprintf(stdout, "%s%s", bf_log_opt_to_str(hdr),
-                              log ? "," : "\n");
+                    log &= ~BF_FLAG(hdr);
+                    (void)fprintf(stdout, "%s%s", bf_log_opt_to_str(hdr),
+                                  log ? "," : "\n");
+                }
             }
         }
 

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -265,12 +265,12 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
 
             (void)fprintf(stdout, "        log ");
 
-            for (enum bf_pkthdr hdr = 0; hdr < _BF_PKTHDR_MAX; ++hdr) {
+            for (enum bf_log_opt hdr = 0; hdr < _BF_LOG_OPT_MAX; ++hdr) {
                 if (!(log & BF_FLAG(hdr)))
                     continue;
 
                 log &= ~BF_FLAG(hdr);
-                (void)fprintf(stdout, "%s%s", bf_pkthdr_to_str(hdr),
+                (void)fprintf(stdout, "%s%s", bf_log_opt_to_str(hdr),
                               log ? "," : "\n");
             }
         }
@@ -383,7 +383,7 @@ static void _bf_chain_log_l2(const struct bf_log *log)
     struct ethhdr *ethhdr = (void *)log->pkt.l2hdr;
     const char *ethertype;
 
-    if (!(log->pkt.headers & (1 << BF_PKTHDR_LINK))) {
+    if (!(log->pkt.headers & (1 << BF_LOG_OPT_LINK))) {
         (void)fprintf(stdout, "  Ethernet  : <unknown header>\n");
         return;
     }
@@ -418,7 +418,7 @@ static void _bf_chain_log_l3(const struct bf_log *log)
     char dst_addr[INET6_ADDRSTRLEN];
     const char *protocol;
 
-    if (!(log->pkt.headers & (1 << BF_PKTHDR_INTERNET))) {
+    if (!(log->pkt.headers & (1 << BF_LOG_OPT_INTERNET))) {
         (void)fprintf(stdout, "  Internet  : <unknown header>\n");
         return;
     }
@@ -490,7 +490,7 @@ static void _bf_chain_log_l4(const struct bf_log *log)
     struct udphdr *udphdr;
     const char *tcp_flags_str;
 
-    if (!(log->pkt.headers & (1 << BF_PKTHDR_TRANSPORT))) {
+    if (!(log->pkt.headers & (1 << BF_LOG_OPT_TRANSPORT))) {
         (void)fprintf(stdout, "  Transport : <unknown header>\n");
         return;
     }
@@ -578,10 +578,10 @@ void bfc_print_log(const struct bf_log *log)
 
     _bf_chain_log_header(log);
 
-    if (log->pkt.req_headers & (1 << BF_PKTHDR_LINK))
+    if (log->pkt.req_headers & (1 << BF_LOG_OPT_LINK))
         _bf_chain_log_l2(log);
-    if (log->pkt.req_headers & (1 << BF_PKTHDR_INTERNET))
+    if (log->pkt.req_headers & (1 << BF_LOG_OPT_INTERNET))
         _bf_chain_log_l3(log);
-    if (log->pkt.req_headers & (1 << BF_PKTHDR_TRANSPORT))
+    if (log->pkt.req_headers & (1 << BF_LOG_OPT_TRANSPORT))
         _bf_chain_log_l4(log);
 }

--- a/src/libbpfilter/bpf/pkt_log.bpf.c
+++ b/src/libbpfilter/bpf/pkt_log.bpf.c
@@ -35,22 +35,22 @@ __u8 bf_pkt_log(struct bf_runtime *ctx, __u32 rule_id, __u8 headers,
     log->pkt.req_headers = headers;
     log->pkt.headers = 0;
 
-    if (headers & (1 << BF_PKTHDR_LINK) && ctx->l2_hdr &&
+    if (headers & (1 << BF_LOG_OPT_LINK) && ctx->l2_hdr &&
         ctx->l2_size <= BF_L2_SLICE_LEN) {
         bpf_probe_read_kernel(log->pkt.l2hdr, ctx->l2_size, ctx->l2_hdr);
-        log->pkt.headers |= (1 << BF_PKTHDR_LINK);
+        log->pkt.headers |= (1 << BF_LOG_OPT_LINK);
     }
 
-    if (headers & (1 << BF_PKTHDR_INTERNET) && ctx->l3_hdr &&
+    if (headers & (1 << BF_LOG_OPT_INTERNET) && ctx->l3_hdr &&
         ctx->l3_size <= BF_L3_SLICE_LEN) {
         bpf_probe_read_kernel(log->pkt.l3hdr, ctx->l3_size, ctx->l3_hdr);
-        log->pkt.headers |= (1 << BF_PKTHDR_INTERNET);
+        log->pkt.headers |= (1 << BF_LOG_OPT_INTERNET);
     }
 
-    if (headers & (1 << BF_PKTHDR_TRANSPORT) && ctx->l4_hdr &&
+    if (headers & (1 << BF_LOG_OPT_TRANSPORT) && ctx->l4_hdr &&
         ctx->l4_size <= BF_L4_SLICE_LEN) {
         bpf_probe_read_kernel(log->pkt.l4hdr, ctx->l4_size, ctx->l4_hdr);
-        log->pkt.headers |= (1 << BF_PKTHDR_TRANSPORT);
+        log->pkt.headers |= (1 << BF_LOG_OPT_TRANSPORT);
     }
 
     bpf_ringbuf_submit(log, 0);

--- a/src/libbpfilter/include/bpfilter/rule.h
+++ b/src/libbpfilter/include/bpfilter/rule.h
@@ -19,15 +19,15 @@
 #define BF_RULE_MARK_MASK (0x00000000ffffffffULL)
 
 /**
- * @brief Return the string representation of a `bf_pkthdr` enumeration value.
+ * @brief Return the string representation of a `bf_log_opt` enumeration value.
  *
- * @param hdr `bf_pkthdr` enumeration value.
+ * @param hdr `bf_log_opt` enumeration value.
  * @return A pointer to the C-string representation of `hdr`.
  */
-const char *bf_pkthdr_to_str(enum bf_pkthdr hdr);
+const char *bf_log_opt_to_str(enum bf_log_opt hdr);
 
 /**
- * @brief Return the `bf_pkthdr` enumeration value corresponding to a string.
+ * @brief Return the `bf_log_opt` enumeration value corresponding to a string.
  *
  * @pre
  * - `str` is a non-NULL pointer to a C-string.
@@ -35,12 +35,12 @@ const char *bf_pkthdr_to_str(enum bf_pkthdr hdr);
  * @post
  * - On failure, `hdr` is unchanged.
  *
- * @param str String to get the corresponding `bf_pkthdr` enumeration value for.
- * @param hdr On success, contains the `bf_pkthdr` enumeration value
+ * @param str String to get the corresponding `bf_log_opt` enumeration value for.
+ * @param hdr On success, contains the `bf_log_opt` enumeration value
  *        corresponding to `str`.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_pkthdr_from_str(const char *str, enum bf_pkthdr *hdr);
+int bf_log_opt_from_str(const char *str, enum bf_log_opt *hdr);
 
 #define _free_bf_rule_ __attribute__((__cleanup__(bf_rule_free)))
 
@@ -77,8 +77,8 @@ struct bf_rule
 };
 
 static_assert(
-    _BF_PKTHDR_MAX < 8,
-    "bf_pkthdr has more than 8 values, it won't fit in bf_rule.log's 8 bits");
+    _BF_LOG_OPT_MAX < 8,
+    "bf_log_opt has more than 8 values, it won't fit in bf_rule.log's 8 bits");
 
 /**
  * Allocated and initialise a new rule.

--- a/src/libbpfilter/include/bpfilter/runtime.h
+++ b/src/libbpfilter/include/bpfilter/runtime.h
@@ -69,17 +69,17 @@ static_assert(BF_L4_SLICE_LEN % 8 == 0,
 /**
  * @brief Types of network packet headers.
  */
-enum bf_pkthdr
+enum bf_log_opt
 {
     /**
      * Link layer header: Ethernet, ...
      */
-    BF_PKTHDR_LINK,
+    BF_LOG_OPT_LINK,
 
     /**
      * Internet header: IPv4, IPv6, ...
      */
-    BF_PKTHDR_INTERNET,
+    BF_LOG_OPT_INTERNET,
 
     /**
      * Transport header: TCP, UDP, ...
@@ -88,9 +88,9 @@ enum bf_pkthdr
      * IPv6 packet, so it's considered a transport layer (L4) header in
      * bpfilter.
      */
-    BF_PKTHDR_TRANSPORT,
+    BF_LOG_OPT_TRANSPORT,
 
-    _BF_PKTHDR_MAX,
+    _BF_LOG_OPT_MAX,
 };
 
 /**

--- a/src/libbpfilter/include/bpfilter/runtime.h
+++ b/src/libbpfilter/include/bpfilter/runtime.h
@@ -67,7 +67,7 @@ static_assert(BF_L4_SLICE_LEN % 8 == 0,
 #define BF_COMM_LEN 16
 
 /**
- * @brief Types of network packet headers.
+ * @brief Log option identifiers for per-rule logging.
  */
 enum bf_log_opt
 {
@@ -91,6 +91,9 @@ enum bf_log_opt
     BF_LOG_OPT_TRANSPORT,
 
     _BF_LOG_OPT_MAX,
+
+    /** Log all available data for the hook type. */
+    BF_LOG_OPT_DEFAULT = 0xFF,
 };
 
 /**

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -19,28 +19,28 @@
 #include "bpfilter/runtime.h"
 #include "bpfilter/verdict.h"
 
-static const char *_bf_pkthdr_strs[] = {
-    [BF_PKTHDR_LINK] = "link",
-    [BF_PKTHDR_INTERNET] = "internet",
-    [BF_PKTHDR_TRANSPORT] = "transport",
+static const char *_bf_log_opt_strs[] = {
+    [BF_LOG_OPT_LINK] = "link",
+    [BF_LOG_OPT_INTERNET] = "internet",
+    [BF_LOG_OPT_TRANSPORT] = "transport",
 };
-static_assert_enum_mapping(_bf_pkthdr_strs, _BF_PKTHDR_MAX);
+static_assert_enum_mapping(_bf_log_opt_strs, _BF_LOG_OPT_MAX);
 
-const char *bf_pkthdr_to_str(enum bf_pkthdr hdr)
+const char *bf_log_opt_to_str(enum bf_log_opt hdr)
 {
-    if (hdr < 0 || hdr >= _BF_PKTHDR_MAX)
-        return "<bf_pkthdr unknown>";
+    if (hdr < 0 || hdr >= _BF_LOG_OPT_MAX)
+        return "<bf_log_opt unknown>";
 
-    return _bf_pkthdr_strs[hdr];
+    return _bf_log_opt_strs[hdr];
 }
 
-int bf_pkthdr_from_str(const char *str, enum bf_pkthdr *hdr)
+int bf_log_opt_from_str(const char *str, enum bf_log_opt *hdr)
 {
     assert(hdr);
 
-    for (int i = 0; i < _BF_PKTHDR_MAX; ++i) {
-        if (bf_streq_i(str, _bf_pkthdr_strs[i])) {
-            *hdr = (enum bf_pkthdr)i;
+    for (int i = 0; i < _BF_LOG_OPT_MAX; ++i) {
+        if (bf_streq_i(str, _bf_log_opt_strs[i])) {
+            *hdr = (enum bf_log_opt)i;
             return 0;
         }
     }

--- a/tests/e2e/rules/log.sh
+++ b/tests/e2e/rules/log.sh
@@ -2,9 +2,30 @@
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 
+# Parser-only coverage for bare log lookahead and log header tokens.
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log DROP chain c2 BF_HOOK_TC_INGRESS ACCEPT rule ip4.proto icmp counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log
+DROP rule ip4.proto icmp counter ACCEPT"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log
+link,internet
+DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log link # hdrs
+DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log # bare
+DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log
+# bare
+DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_TC_INGRESS ACCEPT rule ip4.proto icmp log NEXT"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_TC_INGRESS ACCEPT rule ip4.proto icmp log REDIRECT 1 in"
+${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_TC_INGRESS ACCEPT rule ip4.proto icmp log mark 0x1 DROP"
+(! ${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log link,ip DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log link,,internet DROP")
+(! ${BFCLI} ruleset set --dry-run --from-str "chain c1 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log @DROP")
+
 make_sandbox
 
-(! ${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_3 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log counter DROP")
+${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_3 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log counter DROP"
 (! ${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_3 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log ip counter DROP")
 ${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_3 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log link counter DROP"
 ${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_3 BF_HOOK_XDP ACCEPT rule ip4.proto icmp log link,internet counter DROP"

--- a/tests/fuzz/keywords.dict
+++ b/tests/fuzz/keywords.dict
@@ -132,7 +132,7 @@
 "ipv4"
 "ipv6"
 
-# Log headers (bf_pkthdr)
+# Log headers (bf_log_opt)
 "link"
 "internet"
 "transport"

--- a/tests/harness/Rule.hpp
+++ b/tests/harness/Rule.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <bitset>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -21,8 +20,6 @@ extern "C" {
 namespace bf
 {
 
-using RuleLogBitset = std::bitset<_BF_LOG_OPT_MAX>;
-
 class Rule
 {
 private:
@@ -36,11 +33,11 @@ private:
 
     bf_verdict _verdict;
     bool _counters;
-    RuleLogBitset _log;
+    uint8_t _log;
     std::vector<Matcher> _matchers;
 
 public:
-    Rule(bf_verdict verdict, bool counters = false, RuleLogBitset log = {},
+    Rule(bf_verdict verdict, bool counters = false, uint8_t log = 0,
          std::vector<Matcher> matchers = {}):
         _verdict {verdict},
         _counters {counters},
@@ -63,7 +60,7 @@ public:
         if (r != 0)
             throw std::runtime_error("failed to create bf_rule");
 
-        rule->log = static_cast<uint8_t>(_log.to_ulong());
+        rule->log = _log;
         rule->counters = _counters;
         rule->verdict = _verdict;
 

--- a/tests/harness/Rule.hpp
+++ b/tests/harness/Rule.hpp
@@ -21,7 +21,7 @@ extern "C" {
 namespace bf
 {
 
-using RuleLogBitset = std::bitset<_BF_PKTHDR_MAX>;
+using RuleLogBitset = std::bitset<_BF_LOG_OPT_MAX>;
 
 class Rule
 {

--- a/tests/harness/fake.c
+++ b/tests/harness/fake.c
@@ -189,7 +189,7 @@ struct bf_rule *bft_rule_dummy(size_t n_matchers)
         return NULL;
 
     rule->index = 0;
-    rule->log = BF_FLAGS(BF_PKTHDR_INTERNET, BF_PKTHDR_TRANSPORT);
+    rule->log = BF_FLAGS(BF_LOG_OPT_INTERNET, BF_LOG_OPT_TRANSPORT);
     rule->mark = 0x17;
     rule->counters = true;
     rule->verdict = BF_VERDICT_ACCEPT;

--- a/tests/unit/libbpfilter/rule.c
+++ b/tests/unit/libbpfilter/rule.c
@@ -15,8 +15,9 @@ static void to_from_str(void **state)
 {
     (void)state;
 
-    assert_enum_to_from_str(enum bf_pkthdr, bf_pkthdr_to_str,
-                            bf_pkthdr_from_str, BF_PKTHDR_LINK, _BF_PKTHDR_MAX);
+    assert_enum_to_from_str(enum bf_log_opt, bf_log_opt_to_str,
+                            bf_log_opt_from_str, BF_LOG_OPT_LINK,
+                            _BF_LOG_OPT_MAX);
 }
 
 static void new_and_free(void **state)

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -240,8 +240,7 @@ BENCHMARK(single_rule__ip4_saddr_c);
 void single_rule__ip4_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false,
-                  bf::RuleLogBitset().set(BF_LOG_OPT_LINK),
+    chain << Rule(BF_VERDICT_DROP, false, BF_FLAG(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -418,8 +417,7 @@ BENCHMARK(single_rule__ip6_saddr_c);
 void single_rule__ip6_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false,
-                  bf::RuleLogBitset().set(BF_LOG_OPT_LINK),
+    chain << Rule(BF_VERDICT_DROP, false, BF_FLAG(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -241,7 +241,7 @@ void single_rule__ip4_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
     chain << Rule(BF_VERDICT_DROP, false,
-                  bf::RuleLogBitset().set(BF_PKTHDR_LINK),
+                  bf::RuleLogBitset().set(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -419,7 +419,7 @@ void single_rule__ip6_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
     chain << Rule(BF_VERDICT_DROP, false,
-                  bf::RuleLogBitset().set(BF_PKTHDR_LINK),
+                  bf::RuleLogBitset().set(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
Stack:
- #485
- #486
- -> #517 (didn't want to renumber all of them)
- #491

In order to add logging support for `CGROUP_SOCK_ADDR` hooks, we'd like to be able to log all of the data we have without needing to pass parameters to log. To do that, I was able to come up with three approaches:

1) Have this be purely on the parsing side and no "backend" changes. When the parser sees `log`, it just translates it to `log link,internet,transport`. However, this doesn't work too well for the new `CGROUP_SOCK_ADDR` logging, as it recognizes it as `log link,internet,transport`, so we'd need to accept that syntax as well, which isn't ideal.
2) Add some sentinel bit value in `rule->log` that signals "we want to log everything". This would work, but is a bit hacky and doesn't really encode the intent of what we're doing. It'd come along with a nice size comment that explains that the sentinel value means `ALL` but I could see this easily being a source of bugs in the future.
3) Add some way to distinguish between log options and the type of logging you want (none, all, or some). This requires a bit more work, but by pulling apart the options from logging "mode", we give ourselves alot more flexibility both now and in the future (we can add new modes that use the options for something else etc.).

Option 3 is a bit more code but seemed like the right choice due to the reasons included above.

### Summary
(Bulk of the changes are renaming in the tests.) Adds `enum bf_rule_log_mode` to `bf_rule`, separating the user's logging intent (`NONE`, `DEFAULT`, `PKT_HEADERS`) from the packet header bitmask (renamed `log` to `log_opts`). It also adds bare `log` keyword support in the parser and lexer.

### Tests
- Unit + e2e tests
- Manual Testing