### PR TITLE
cgen(set): null-check set before dereferencing it

### DIFF
--- a/src/libbpfilter/cgen/matcher/set.c
+++ b/src/libbpfilter/cgen/matcher/set.c
@@ -20,15 +20,15 @@ static int _bf_matcher_generate_set_trie(struct bf_program *program,
 
     const struct bf_set *set =
         bf_chain_get_set_for_matcher(program->runtime.chain, matcher);
-    enum bf_matcher_type type = set->key[0];
-    const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
-    int r;
-
     if (!set) {
         return bf_err_r(-ENOENT, "set #%u not found in %s",
                         *(uint32_t *)bf_matcher_payload(matcher),
                         program->runtime.chain->name);
     }
+
+    enum bf_matcher_type type = set->key[0];
+    const struct bf_matcher_meta *meta = bf_matcher_get_meta(type);
+    int r;
 
     r = bf_stub_rule_check_protocol(program, meta);
     if (r)


### PR DESCRIPTION
## Summary

Fixes #501.

`_bf_matcher_generate_set_trie()` in `src/libbpfilter/cgen/matcher/set.c` assigned `type = set->key[0]` immediately after receiving `set` from `bf_chain_get_set_for_matcher()`, and only then checked `if (!set)` — so if `set` were ever NULL the dereference would segfault before we reached the error-return. As the issue notes, the current call sites validate existence before reaching this function, but that's a distance-to-crash of one file, and keeping the defensive branch in is the stated intent.

## Change

Trivial source-order swap:

- Move `if (!set) { ... }` **above** the `set->key[0]` dereference so the `-ENOENT` path actually runs when `set` is NULL.
- The three following declarations (`enum bf_matcher_type type`, `const struct bf_matcher_meta *meta`, `int r`) are relocated together to just after the null check; their types and initialization logic are unchanged, so nothing else in the function needs to change.

Diff is 4 insertions / 4 deletions.

## Testing

Minimal trivial source-order change — I did not spin up a Linux 6.6 + libbpf build environment for this PR; compilation and the regular e2e / unit suites will exercise it in CI. No runtime behavior change on the valid-`set` path (the only path exercised today); the only observable difference is that if a future caller passes a matcher for which no set exists, the function returns `-ENOENT` with the existing error message instead of dereferencing NULL.