### PR TITLE
doc: Fix `make doc` in nix environment

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -58,6 +58,7 @@ GENERATE_PERLMOD        = NO
 INCLUDE_PATH            = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests"
 MACRO_EXPANSION         = YES
 PREDEFINED              = bf_aligned(x)= \
+                          __attribute__(x)= \
                           DOXYGEN
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Doxygen 1.16.0 ignores the PREDEFINED = bf_aligned(x)= override and instead expands the macro using the source definition (#define bf_aligned(x) __attribute__((aligned(x)))). This produces __attribute__((aligned(8))) in the XML output, which Sphinx's C domain parser can't handle — it misinterprets the attribute as a function declaration.

The fix adds __attribute__(x)= to PREDEFINED in doc/Doxyfile.in. This strips __attribute__((...)) after expansion, so even though bf_aligned isn't caught at the first level, the resulting __attribute__ is eliminated before it reaches Breathe/Sphinx.