### PR TITLE
lib: pack: fix uninitialized warning in `BF_NODE` macro

### DIFF
--- a/src/libbpfilter/pack.c
+++ b/src/libbpfilter/pack.c
@@ -279,7 +279,16 @@ void bf_rpack_free(bf_rpack_t **pack)
 }
 
 #define MP_NODE(node) (*(mpack_node_t *)&(node))
-#define BF_NODE(node) (*(bf_rpack_node_t *)(mpack_node_t[]) {node})
+#define BF_NODE(node)                                                          \
+    ({                                                                         \
+        union                                                                  \
+        {                                                                      \
+            mpack_node_t m;                                                    \
+            bf_rpack_node_t b;                                                 \
+        } _u_ = {0};                                                           \
+        _u_.m = (node);                                                        \
+        _u_.b;                                                                 \
+    })
 
 static_assert(sizeof(bf_rpack_node_t) >= sizeof(mpack_node_t),
               "bf_rpack_node_t too small for mpack_node_t");


### PR DESCRIPTION
Previously, `make -C build` gave these warnings:
```
/home/ystein/projects/bpfilter/src/libbpfilter/pack.c:282:24: warning: ‘<U2630>’ is used uninitialized [-Wuninitialized]
  282 | #define BF_NODE(node) (*(bf_rpack_node_t *)(mpack_node_t[]) {node})
      |                       ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/ystein/projects/bpfilter/src/libbpfilter/pack.c:289:12: note: in expansion of macro ‘BF_NODE’
  289 |     return BF_NODE(pack->root);
      |            ^~~~~~~
/home/ystein/projects/bpfilter/src/libbpfilter/pack.c:282:61: note: ‘({anonymous})’ declared here
  282 | #define BF_NODE(node) (*(bf_rpack_node_t *)(mpack_node_t[]) {node})
      |                                                             ^
/home/ystein/projects/bpfilter/src/libbpfilter/pack.c:289:12: note: in expansion of macro ‘BF_NODE’
  289 |     return BF_NODE(pack->root);
      |            ^~~~~~~
```

Now, we use union type-punning for `BF_NODE` instead of a compound literal pointer cast (which was causing the warnings). Union-based type-punning is well-defined in C99/C11 and also avoids the strict-aliasing violation in the original pointer cast.

This gets rid of the last `make` warnings (atleast on my machine)!