### PR TITLE
cli: add --no-set-content flag to chain/ruleset get

### DIFF
--- a/doc/usage/bfcli.rst
+++ b/doc/usage/bfcli.rst
@@ -47,6 +47,9 @@ Chains with valid hook options defined are attached to their hook. Chains withou
 
 Print the ruleset: request all the chains and rules with counters values.
 
+**Options**
+  - ``--no-set-content``: omit set elements from the output. Sets are still printed with their name (if named) and key, but their content is replaced with the number of elements they contain. Useful when sets are large enough that printing every element makes the output unreadable.
+
 **Example**
 
 .. code:: shell
@@ -115,6 +118,7 @@ Print a chain.
 
 **Options**
   - ``--name NAME``: name of the chain to print.
+  - ``--no-set-content``: omit set elements from the output. Sets are still printed with their name (if named) and key, but their content is replaced with the number of elements they contain. Useful when sets are large enough that printing every element makes the output unreadable.
 
 **Examples**
 
@@ -125,6 +129,15 @@ Print a chain.
     $ sudo bfcli chain get --name my_input_chain
       chain my_input_chain BF_HOOK_NF_LOCAL_IN{priorities=101-102} ACCEPT
           counters policy 1161 packets 149423 bytes; error 0 packets 0 bytes
+
+    $ # Print a chain with a large set, eliding the set's content
+    $ sudo bfcli chain get --name my_filter --no-set-content
+      chain my_filter BF_HOOK_XDP{ifindex=2} ACCEPT
+          counters policy 0 packets 0 bytes; error 0 packets 0 bytes
+          set blocklist (ip4.saddr) in { /* 4096 elements, content elided */ }
+          rule
+              (ip4.saddr) in blocklist
+              DROP
 
 ``chain logs``
 ~~~~~~~~~~~~~~

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -123,7 +123,7 @@ int bfc_chain_get(const struct bfc_opts *opts)
     if (r)
         return bf_err_r(r, "unknown error");
 
-    bfc_chain_dump(chain, hookopts, &counters);
+    bfc_chain_dump(chain, hookopts, &counters, opts->no_set_content);
 
     return 0;
 }

--- a/src/bfcli/opts.c
+++ b/src/bfcli/opts.c
@@ -147,6 +147,7 @@ enum bfc_opts_option_id
     BFC_OPT_SET_ADD,
     BFC_OPT_SET_REMOVE,
     BFC_OPT_DRY_RUN,
+    BFC_OPT_NO_SET_CONTENT,
     _BFC_OPT_MAX,
 };
 
@@ -169,7 +170,8 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .name = "bfcli ruleset get",
         .object = BFC_OBJECT_RULESET,
         .action = BFC_ACTION_GET,
-        .valid_opts = BF_FLAGS(BFC_OPT_HELP, BFC_OPT_USAGE, BFC_OPT_VERSION),
+        .valid_opts = BF_FLAGS(BFC_OPT_HELP, BFC_OPT_USAGE, BFC_OPT_VERSION,
+                               BFC_OPT_NO_SET_CONTENT),
         .doc = "Print the ruleset.\vPrint the current ruleset.",
         .cb = bfc_ruleset_get,
     },
@@ -202,7 +204,7 @@ static const struct bfc_opts_cmd _bfc_opts_cmds[] = {
         .object = BFC_OBJECT_CHAIN,
         .action = BFC_ACTION_GET,
         .valid_opts = BF_FLAGS(BFC_OPT_HELP, BFC_OPT_USAGE, BFC_OPT_VERSION,
-                               BFC_OPT_CHAIN_NAME),
+                               BFC_OPT_CHAIN_NAME, BFC_OPT_NO_SET_CONTENT),
         .required_opts = BF_FLAGS(BFC_OPT_CHAIN_NAME),
         .doc =
             "Print an existing chain\vRequest the chain --name and print it.",
@@ -481,7 +483,16 @@ static void _bfc_opts_dry_run(struct argp_state *state, const char *arg,
     opts->dry_run = true;
 };
 
-struct bfc_opts_opt
+static void _bfc_opts_no_set_content(struct argp_state *state, const char *arg,
+                                     struct bfc_opts *opts)
+{
+    (void)state;
+    (void)arg;
+
+    opts->no_set_content = true;
+};
+
+static struct bfc_opts_opt
 {
     enum bfc_opts_option_id id;
     int key;
@@ -597,6 +608,15 @@ struct bfc_opts_opt
         .arg = NULL,
         .doc = "dry-run",
         .parser = _bfc_opts_dry_run,
+    },
+    {
+        .id = BFC_OPT_NO_SET_CONTENT,
+        .key = BFC_OPT_LONG_FLAG_ONLY(BFC_OPT_NO_SET_CONTENT),
+        .name = "no-set-content",
+        .arg = NULL,
+        .doc = "Omit set elements from the output, print only the element "
+               "count.",
+        .parser = _bfc_opts_no_set_content,
     },
 };
 

--- a/src/bfcli/opts.h
+++ b/src/bfcli/opts.h
@@ -80,6 +80,7 @@ struct bfc_opts
     bf_list set_remove;
 
     bool dry_run;
+    bool no_set_content;
 
     bool with_bpf_token;
     const char *bpffs_path;

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -34,6 +34,8 @@
 #include <bpfilter/set.h>
 #include <bpfilter/verdict.h>
 
+#include "bpfilter/core/hashset.h"
+
 struct bfc_chain_opts;
 
 #define INET6_ADDRSTRLEN 46
@@ -81,7 +83,7 @@ static void bf_dump_hex_local(const void *data, size_t len)
 }
 
 void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
-                    bf_list *counters)
+                    bf_list *counters, bool no_set_content)
 {
     struct bf_counter *counter;
     bf_list_node *counter_node, *policy_counter_node, *err_counter_node;
@@ -169,6 +171,14 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
             if (i != set->n_comps - 1)
                 (void)fprintf(stdout, ", ");
         }
+
+        if (no_set_content) {
+            (void)fprintf(stdout,
+                          ") in { /* %zu elements, content elided */ }\n",
+                          bf_hashset_size(&set->elems));
+            continue;
+        }
+
         (void)fprintf(stdout, ") in {\n");
 
         bf_hashset_foreach (&set->elems, node) {
@@ -219,6 +229,10 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
 
                 if (set->name) {
                     (void)fprintf(stdout, ") %s %s", in_str, set->name);
+                } else if (no_set_content) {
+                    (void)fprintf(stdout,
+                                  ") in { /* %zu elements, content elided */ }",
+                                  bf_hashset_size(&set->elems));
                 } else {
                     (void)fprintf(stdout, ") %s {\n", in_str);
 
@@ -308,7 +322,8 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
     }
 }
 
-int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters)
+int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters,
+                     bool no_set_content)
 {
     struct bf_list_node *chain_node;
     struct bf_list_node *hookopts_node;
@@ -330,7 +345,7 @@ int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters)
     while (chain_node) {
         bfc_chain_dump(bf_list_node_get_data(chain_node),
                        bf_list_node_get_data(hookopts_node),
-                       bf_list_node_get_data(counter_node));
+                       bf_list_node_get_data(counter_node), no_set_content);
 
         chain_node = bf_list_node_next(chain_node);
         hookopts_node = bf_list_node_next(hookopts_node);

--- a/src/bfcli/print.h
+++ b/src/bfcli/print.h
@@ -24,9 +24,11 @@ struct bf_hookopts;
  *        first to entries in the list to be the policy and error counters.
  *        Then, every rule should have an entry in the list in the order they
  *        are defined, even if the rule doesn't have counters enabled.
+ * @param no_set_content If true, the content of named and anonymous sets is
+ *        omitted from the output. Only the element count is printed.
  */
 void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
-                    bf_list *counters);
+                    bf_list *counters, bool no_set_content);
 
 /**
  * Print ruleset information and counters to the console.
@@ -34,8 +36,11 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
  * @param chains List of chains to print.
  * @param hookopts List of hookoptions to print.
  * @param counters List of counters to print.
+ * @param no_set_content If true, the content of named and anonymous sets is
+ *        omitted from the output. Only the element count is printed.
  */
-int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters);
+int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters,
+                     bool no_set_content);
 
 /**
  * @brief Print a logged packet published by a rule.

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -51,13 +51,13 @@ int bfc_ruleset_get(const struct bfc_opts *opts)
     _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
     int r;
 
-    (void)opts;
+    assert(opts);
 
     r = bf_ruleset_get(&chains, &hookopts, &counters);
     if (r < 0)
         return bf_err_r(r, "failed to request ruleset");
 
-    r = bfc_ruleset_dump(&chains, &hookopts, &counters);
+    r = bfc_ruleset_dump(&chains, &hookopts, &counters, opts->no_set_content);
     if (r)
         return bf_err_r(r, "failed to dump ruleset");
 

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -83,6 +83,7 @@ add_custom_target(e2e
 )
 
 bf_add_e2e_shell_test(e2e cli/chain_attach.sh ROOT)
+bf_add_e2e_shell_test(e2e cli/chain_get_no_set_content.sh ROOT)
 bf_add_e2e_shell_test(e2e cli/chain_load.sh ROOT)
 bf_add_e2e_shell_test(e2e cli/chain_set.sh ROOT)
 bf_add_e2e_shell_test(e2e cli/chain_update.sh ROOT)

--- a/tests/e2e/cli/chain_get_no_set_content.sh
+++ b/tests/e2e/cli/chain_get_no_set_content.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")"/../e2e_test_util.sh
+
+make_sandbox
+
+${FROM_NS} ${BFCLI} chain set --from-str "chain test_xdp BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT
+    set blocked_ips (ip4.saddr) in {
+        10.0.0.1;
+        10.0.0.2;
+        10.0.0.3
+    }
+    rule
+        (ip4.saddr) in blocked_ips
+        DROP
+    rule
+        (ip4.saddr) in {
+            192.168.1.1;
+            192.168.1.2
+        }
+        DROP
+"
+
+# Without --no-set-content, all elements are printed
+chain_output=$(${FROM_NS} ${BFCLI} chain get --name test_xdp)
+echo "$chain_output"
+echo "$chain_output" | grep -q '10.0.0.1'
+echo "$chain_output" | grep -q '192.168.1.1'
+(! echo "$chain_output" | grep -q 'elided')
+
+# With --no-set-content, elements are replaced by an element count
+chain_output=$(${FROM_NS} ${BFCLI} chain get --name test_xdp --no-set-content)
+echo "$chain_output"
+(! echo "$chain_output" | grep -q '10.0.0.1')
+(! echo "$chain_output" | grep -q '192.168.1.1')
+# Set name and key are still printed so users can identify the set
+echo "$chain_output" | grep -q 'blocked_ips (ip4.saddr)'
+# Counts are correct
+echo "$chain_output" | grep -q '3 elements, content elided'
+echo "$chain_output" | grep -q '2 elements, content elided'
+
+# ruleset get --no-set-content honors the flag too
+ruleset_output=$(${FROM_NS} ${BFCLI} ruleset get --no-set-content)
+echo "$ruleset_output"
+(! echo "$ruleset_output" | grep -q '10.0.0.1')
+(! echo "$ruleset_output" | grep -q '192.168.1.1')
+echo "$ruleset_output" | grep -q '3 elements, content elided'
+echo "$ruleset_output" | grep -q '2 elements, content elided'
+
+# ruleset get without the flag still prints elements
+ruleset_output=$(${FROM_NS} ${BFCLI} ruleset get)
+echo "$ruleset_output"
+echo "$ruleset_output" | grep -q '10.0.0.1'
+echo "$ruleset_output" | grep -q '192.168.1.1'
+(! echo "$ruleset_output" | grep -q 'elided')
+
+${FROM_NS} ${BFCLI} chain flush --name test_xdp


### PR DESCRIPTION
Printing a chain or ruleset that contains large sets produces output too long to be useful: a set with thousands of elements drowns out the rules around it. Add a `--no-set-content` flag to "bfcli chain get" and "bfcli ruleset get" that elides set elements and prints only the element count, while keeping the set name and key visible so the set remains identifiable.

Without `--no-set-content`:
```
$ bfcli chain get --name test_xdp
chain test_xdp BF_HOOK_XDP{ifindex=2} ACCEPT
    counters policy 274 packets 31542 bytes; error 0 packets 0 bytes
    set blocked_ips (ip4.saddr) in {
        10.0.0.1
        10.0.0.2
        10.0.0.3
    }
    rule
        (ip4.saddr) in blocked_ips
        DROP
    rule
        (ip4.saddr) in {
            192.168.1.1
            192.168.1.2
        }
        DROP
```

With `--no-set-content`:
```
$ bfcli chain get --name test_xdp --no-set-content chain test_xdp BF_HOOK_XDP{ifindex=2} ACCEPT
    counters policy 417 packets 47594 bytes; error 0 packets 0 bytes
    set blocked_ips (ip4.saddr) in { /* 3 elements, content elided */ }
    rule
        (ip4.saddr) in blocked_ips
        DROP
    rule
        (ip4.saddr) in { /* 2 elements, content elided */ }
        DROP
```