### PR TITLE
Embed counter snapshots in `bf_rule` and `bf_chain`

### DIFF
--- a/doc/developers/tests.rst
+++ b/doc/developers/tests.rst
@@ -135,7 +135,7 @@ Each matcher test is a C++ binary located under ``tests/e2e/matchers/`` that bui
 
         BFT_CHAIN_SET(
             bf::Chain("test_chain", test->hook(), BF_VERDICT_ACCEPT)
-            << bf::Rule(BF_VERDICT_DROP, true, {},
+            << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                         {bf::Matcher(BF_MATCHER_MY_TYPE, BF_MATCHER_EQ, {42})}));
 
         // Packet matching the rule -> DROP

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -114,16 +114,15 @@ int bfc_chain_get(const struct bfc_opts *opts)
 {
     _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
-    _clean_bf_list_ bf_list counters = bf_list_default(bf_counter_free, NULL);
     int r;
 
-    r = bf_chain_get(opts->name, &chain, &hookopts, &counters);
+    r = bf_chain_get(opts->name, &chain, &hookopts);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
         return bf_err_r(r, "unknown error");
 
-    bfc_chain_dump(chain, hookopts, &counters, opts->no_set_content);
+    bfc_chain_dump(chain, hookopts, opts->no_set_content);
 
     return 0;
 }
@@ -272,7 +271,6 @@ int bfc_chain_update_set(const struct bfc_opts *opts)
     _free_bf_set_ struct bf_set *to_remove = NULL;
     _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
-    _clean_bf_list_ bf_list counters = bf_list_default(bf_counter_free, NULL);
     struct bf_set *dest_set = NULL;
     int r;
 
@@ -280,7 +278,7 @@ int bfc_chain_update_set(const struct bfc_opts *opts)
         return bf_err_r(-EINVAL, "no elements to add or remove");
 
     // Fetch dest_set to get key format
-    r = bf_chain_get(opts->name, &chain, &hookopts, &counters);
+    r = bf_chain_get(opts->name, &chain, &hookopts);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -299,7 +299,7 @@ rule            : RULE matchers rule_options rule_verdict
                         bf_parse_err("failed to create a new bf_rule\n");
 
                     rule->log = $3.flags & BF_RULE_OPTION_LOG ? $3.log : 0;
-                    rule->counters = $3.flags & BF_RULE_OPTION_COUNTER ? $3.counter : false;
+                    rule->has_counters = $3.flags & BF_RULE_OPTION_COUNTER ? 1 : 0;
 
                     if ($3.flags & BF_RULE_OPTION_MARK)
                         bf_rule_mark_set(rule, $3.mark);

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -83,27 +83,13 @@ static void bf_dump_hex_local(const void *data, size_t len)
 }
 
 void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
-                    bf_list *counters, bool no_set_content)
+                    bool no_set_content)
 {
-    struct bf_counter *counter;
-    bf_list_node *counter_node, *policy_counter_node, *err_counter_node;
     bool need_comma = false;
     bool is_pkt_hook;
 
     assert(chain);
-    assert(counters);
 
-    if (bf_list_size(counters) != bf_list_size(&chain->rules) + 2) {
-        bf_err(
-            "chain %s is corrupted: total number of counters doesn't match the number of rules and chain counters",
-            chain->name);
-        return;
-    }
-
-    // Last counter is the error counter, the chain counter is second to last
-    counter_node = bf_list_get_head(counters);
-    err_counter_node = bf_list_get_tail(counters);
-    policy_counter_node = bf_list_node_prev(err_counter_node);
     is_pkt_hook = bf_hook_to_flavor(chain->hook) != BF_FLAVOR_CGROUP_SOCK_ADDR;
 
     (void)fprintf(stdout, "chain %s %s", chain->name,
@@ -140,21 +126,20 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
 
     (void)fprintf(stdout, " %s\n", bf_verdict_to_str(chain->policy));
 
-    counter = bf_list_node_get_data(policy_counter_node);
     if (is_pkt_hook) {
         (void)fprintf(stdout, "    counters policy %lu packets %lu bytes; ",
-                      counter->count, counter->size);
+                      chain->policy_counters.count,
+                      chain->policy_counters.size);
     } else {
         (void)fprintf(stdout, "    counters policy %lu calls; ",
-                      counter->count);
+                      chain->policy_counters.count);
     }
 
-    counter = bf_list_node_get_data(err_counter_node);
     if (is_pkt_hook) {
-        (void)fprintf(stdout, "error %lu packets %lu bytes\n", counter->count,
-                      counter->size);
+        (void)fprintf(stdout, "error %lu packets %lu bytes\n",
+                      chain->error_counters.count, chain->error_counters.size);
     } else {
-        (void)fprintf(stdout, "error %lu calls\n", counter->count);
+        (void)fprintf(stdout, "error %lu calls\n", chain->error_counters.count);
     }
 
     // Loop over named sets
@@ -299,17 +284,15 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
                           bf_rule_mark_get(rule));
 
         if (rule->has_counters) {
-            counter = bf_list_node_get_data(counter_node);
             if (is_pkt_hook) {
                 (void)fprintf(stdout,
                               "        counters %lu packets %lu bytes\n",
-                              counter->count, counter->size);
+                              rule->counters.count, rule->counters.size);
             } else {
                 (void)fprintf(stdout, "        counters %lu calls\n",
-                              counter->count);
+                              rule->counters.count);
             }
         }
-        counter_node = bf_list_node_next(counter_node);
 
         if (rule->verdict == BF_VERDICT_REDIRECT) {
             (void)fprintf(stdout, "        REDIRECT %u %s\n",
@@ -322,34 +305,26 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
     }
 }
 
-int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters,
-                     bool no_set_content)
+int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bool no_set_content)
 {
     struct bf_list_node *chain_node;
     struct bf_list_node *hookopts_node;
-    struct bf_list_node *counter_node;
 
     assert(chains);
     assert(hookopts);
-    assert(counters);
 
     if (bf_list_size(chains) != bf_list_size(hookopts))
-        return -EINVAL;
-    if (bf_list_size(counters) != bf_list_size(chains))
         return -EINVAL;
 
     chain_node = bf_list_get_head(chains);
     hookopts_node = bf_list_get_head(hookopts);
-    counter_node = bf_list_get_head(counters);
 
     while (chain_node) {
         bfc_chain_dump(bf_list_node_get_data(chain_node),
-                       bf_list_node_get_data(hookopts_node),
-                       bf_list_node_get_data(counter_node), no_set_content);
+                       bf_list_node_get_data(hookopts_node), no_set_content);
 
         chain_node = bf_list_node_next(chain_node);
         hookopts_node = bf_list_node_next(hookopts_node);
-        counter_node = bf_list_node_next(counter_node);
     }
 
     return 0;

--- a/src/bfcli/print.c
+++ b/src/bfcli/print.c
@@ -298,7 +298,7 @@ void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
             (void)fprintf(stdout, "        mark 0x%x\n",
                           bf_rule_mark_get(rule));
 
-        if (rule->counters) {
+        if (rule->has_counters) {
             counter = bf_list_node_get_data(counter_node);
             if (is_pkt_hook) {
                 (void)fprintf(stdout,

--- a/src/bfcli/print.h
+++ b/src/bfcli/print.h
@@ -20,27 +20,21 @@ struct bf_hookopts;
  * @param chain Chain to print. Can't be NULL.
  * @param hookopts Chain's hook options. If NULL, it is assumed the chain is not
  *        attached to a hook.
- * @param counters List of counters for the chain. This function expects the
- *        first to entries in the list to be the policy and error counters.
- *        Then, every rule should have an entry in the list in the order they
- *        are defined, even if the rule doesn't have counters enabled.
  * @param no_set_content If true, the content of named and anonymous sets is
  *        omitted from the output. Only the element count is printed.
  */
 void bfc_chain_dump(struct bf_chain *chain, struct bf_hookopts *hookopts,
-                    bf_list *counters, bool no_set_content);
+                    bool no_set_content);
 
 /**
  * Print ruleset information and counters to the console.
  *
  * @param chains List of chains to print.
  * @param hookopts List of hookoptions to print.
- * @param counters List of counters to print.
  * @param no_set_content If true, the content of named and anonymous sets is
  *        omitted from the output. Only the element count is printed.
  */
-int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters,
-                     bool no_set_content);
+int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bool no_set_content);
 
 /**
  * @brief Print a logged packet published by a rule.

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -48,16 +48,15 @@ int bfc_ruleset_get(const struct bfc_opts *opts)
 {
     _clean_bf_list_ bf_list chains = bf_list_default(bf_chain_free, NULL);
     _clean_bf_list_ bf_list hookopts = bf_list_default(bf_hookopts_free, NULL);
-    _clean_bf_list_ bf_list counters = bf_list_default(bf_list_free, NULL);
     int r;
 
     assert(opts);
 
-    r = bf_ruleset_get(&chains, &hookopts, &counters);
+    r = bf_ruleset_get(&chains, &hookopts);
     if (r < 0)
         return bf_err_r(r, "failed to request ruleset");
 
-    r = bfc_ruleset_dump(&chains, &hookopts, &counters, opts->no_set_content);
+    r = bfc_ruleset_dump(&chains, &hookopts, opts->no_set_content);
     if (r)
         return bf_err_r(r, "failed to dump ruleset");
 

--- a/src/libbpfilter/cgen/cgen.c
+++ b/src/libbpfilter/cgen/cgen.c
@@ -23,6 +23,7 @@
 #include <bpfilter/hook.h>
 #include <bpfilter/logger.h>
 #include <bpfilter/pack.h>
+#include <bpfilter/rule.h>
 
 #include "cgen/dump.h"
 #include "cgen/handle.h"
@@ -248,6 +249,42 @@ void bf_cgen_dump(const struct bf_cgen *cgen, prefix_t *prefix)
     bf_dump_prefix_pop(prefix);
 
     bf_dump_prefix_pop(prefix);
+}
+
+int bf_cgen_load_counters(struct bf_cgen *cgen)
+{
+    int r;
+
+    assert(cgen);
+
+    bf_list_foreach (&cgen->chain->rules, rule_node) {
+        struct bf_rule *rule = bf_list_node_get_data(rule_node);
+
+        if (!rule->has_counters)
+            continue;
+
+        r = bf_cgen_get_counter(cgen, rule->index, &rule->counters);
+        if (r) {
+            return bf_err_r(r, "failed to load counter for rule %u",
+                            rule->index);
+        }
+    }
+
+    r = bf_cgen_get_counter(cgen, BF_COUNTER_POLICY,
+                            &cgen->chain->policy_counters);
+    if (r) {
+        return bf_err_r(r, "failed to load policy counters for '%s'",
+                        cgen->chain->name);
+    }
+
+    r = bf_cgen_get_counter(cgen, BF_COUNTER_ERRORS,
+                            &cgen->chain->error_counters);
+    if (r) {
+        return bf_err_r(r, "failed to load error counters for '%s'",
+                        cgen->chain->name);
+    }
+
+    return 0;
 }
 
 int bf_cgen_get_counter(const struct bf_cgen *cgen,
@@ -532,45 +569,4 @@ void bf_cgen_unload(struct bf_cgen *cgen, struct bf_lock *lock)
     unlinkat(lock->chain_fd, _BF_CTX_PIN_NAME, 0);
     bf_handle_unpin(cgen->handle, lock);
     bf_handle_unload(cgen->handle);
-}
-
-int bf_cgen_get_counters(const struct bf_cgen *cgen, bf_list *counters)
-{
-    bf_list _counters;
-    int r;
-
-    assert(cgen);
-    assert(counters);
-
-    _counters = bf_list_default_from(*counters);
-
-    /* Iterate over all the rules, then the policy counter (size(rules)) and
-     * the errors counters (sizeof(rules) + 1)*/
-    for (size_t i = 0; i < bf_list_size(&cgen->chain->rules) + 2; ++i) {
-        _free_bf_counter_ struct bf_counter *counter = NULL;
-        ssize_t idx = (ssize_t)i;
-
-        if (i == bf_list_size(&cgen->chain->rules))
-            idx = BF_COUNTER_POLICY;
-        else if (i == bf_list_size(&cgen->chain->rules) + 1)
-            idx = BF_COUNTER_ERRORS;
-
-        r = bf_counter_new(&counter, 0, 0);
-        if (r)
-            return r;
-
-        r = bf_cgen_get_counter(cgen, idx, counter);
-        if (r)
-            return r;
-
-        r = bf_list_add_tail(&_counters, counter);
-        if (r)
-            return r;
-
-        TAKE_PTR(counter);
-    }
-
-    *counters = bf_list_move(_counters);
-
-    return 0;
 }

--- a/src/libbpfilter/cgen/cgen.h
+++ b/src/libbpfilter/cgen/cgen.h
@@ -193,6 +193,39 @@ enum bf_counter_type
 };
 
 /**
+ * @brief Load the chain's counters from the BPF counters map.
+ *
+ * Refresh `cgen->chain` with the current counter values stored in the BPF
+ * counters map:
+ * - Rule counters are loaded into `bf_rule.counters` for rules with
+ *   `has_counters == 1` only; rules with `has_counters == 0` are left
+ *   untouched.
+ * - The chain's policy and error counters are always loaded into
+ *   `bf_chain.policy_counters` and `bf_chain.error_counters`, regardless of
+ *   any rule's `has_counters` value.
+ *
+ * On failure, `cgen->chain` may be partially updated: counters loaded before
+ * the failing lookup retain their new values, the others are left unchanged.
+ * Callers that need transactional semantics must snapshot the chain before
+ * the call.
+ *
+ * @pre
+ * - `cgen` is not NULL.
+ * - `cgen->handle->cmap` is populated, i.e. the chain has been loaded into
+ *   the kernel. Calling this function on a cgen without a counters map
+ *   returns an error.
+ * @post
+ * - On success: every rule with `has_counters == 1` has its `counters` field
+ *   refreshed, and the chain's `policy_counters` and `error_counters` are
+ *   refreshed.
+ * - On failure: `cgen->chain` may be partially updated (see above).
+ *
+ * @param cgen Codegen to load counters for.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_cgen_load_counters(struct bf_cgen *cgen);
+
+/**
  * Get packets and bytes counter at a specific index.
  *
  * Counters are referenced by their index in the counters map or the enum
@@ -211,21 +244,3 @@ enum bf_counter_type
 int bf_cgen_get_counter(const struct bf_cgen *cgen,
                         enum bf_counter_type counter_idx,
                         struct bf_counter *counter);
-
-/**
- * Get the counters for all the rules.
- *
- * Create a new `bf_counter` structure for each rule (and the policy/error
- * counters) and add it to the list.
- *
- * The caller owns the `bf_counter` in the list and is responsible for freeing
- * it.
- *
- * A `bf_counter` object will be created even if the rule has no counter
- * define, but it will be empty.
- *
- * @param cgen Codegen to fetch the counters for. Can't be NULL.
- * @param counters List of counters, filled by the function. Can't be NULL.
- * @return 0 on success, or a negative errno value on failure.
- */
-int bf_cgen_get_counters(const struct bf_cgen *cgen, bf_list *counters);

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -565,7 +565,7 @@ static int _bf_program_generate_rule(struct bf_program *program,
             return r;
     }
 
-    if (rule->counters) {
+    if (rule->has_counters) {
         EMIT(program, BPF_MOV64_REG(BPF_REG_1, BPF_REG_10));
         EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, BF_PROG_CTX_OFF(arg)));
         EMIT_LOAD_COUNTERS_FD_FIXUP(program, BPF_REG_2);

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -257,7 +257,7 @@ int bf_chain_new(struct bf_chain **chain, const char *name, enum bf_hook hook,
         return bf_err_r(-EINVAL, "invalid policy '%s'",
                         bf_verdict_to_str(policy));
 
-    _chain = malloc(sizeof(*_chain));
+    _chain = calloc(1, sizeof(*_chain));
     if (!_chain)
         return -ENOMEM;
 
@@ -406,6 +406,18 @@ void bf_chain_dump(const struct bf_chain *chain, prefix_t *prefix)
 
         bf_rule_dump(bf_list_node_get_data(rule_node), prefix);
     }
+    bf_dump_prefix_pop(prefix);
+
+    DUMP(prefix, "policy_counters: struct bf_counter");
+    bf_dump_prefix_push(prefix);
+    DUMP(prefix, "count: %lu", chain->policy_counters.count);
+    DUMP(prefix, "size: %lu", chain->policy_counters.size);
+    bf_dump_prefix_pop(prefix);
+
+    DUMP(prefix, "error_counters: struct bf_counter");
+    bf_dump_prefix_push(prefix);
+    DUMP(prefix, "count: %lu", chain->error_counters.count);
+    DUMP(prefix, "size: %lu", chain->error_counters.size);
     bf_dump_prefix_pop(prefix);
 
     bf_dump_prefix_pop(prefix);

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -297,8 +297,8 @@ int bf_chain_new_from_pack(struct bf_chain **chain, bf_rpack_node_t node)
     enum bf_hook hook;
     enum bf_verdict policy;
     bf_rpack_node_t array, array_node;
-    bf_list rules = bf_list_default(bf_rule_free, bf_rule_pack);
-    bf_list sets = bf_list_default(bf_set_free, bf_set_pack);
+    _clean_bf_list_ bf_list rules = bf_list_default(bf_rule_free, bf_rule_pack);
+    _clean_bf_list_ bf_list sets = bf_list_default(bf_set_free, bf_set_pack);
     int r;
 
     r = bf_rpack_kv_str(node, "name", &name);

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -84,13 +84,12 @@ static int _bf_ruleset_flush(struct bf_lock *lock)
     return 0;
 }
 
-int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
+int bf_ruleset_get(bf_list *chains, bf_list *hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_list_ bf_list *cgens = NULL;
     _clean_bf_list_ bf_list _chains = bf_list_default_from(*chains);
     _clean_bf_list_ bf_list _hookopts = bf_list_default_from(*hookopts);
-    _clean_bf_list_ bf_list _counters = bf_list_default_from(*counters);
     int r;
 
     r = bf_lock_init(&lock, BF_LOCK_READ);
@@ -103,18 +102,18 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
 
     bf_list_foreach (cgens, cgen_node) {
         struct bf_cgen *cgen = bf_list_node_get_data(cgen_node);
-        _free_bf_chain_ struct bf_chain *chain = NULL;
         _free_bf_hookopts_ struct bf_hookopts *hookopts_copy = NULL;
-        _free_bf_list_ bf_list *cgen_counters = NULL;
 
-        r = bf_chain_new_from_copy(&chain, cgen->chain);
-        if (r)
-            return bf_err_r(r, "failed to copy chain");
+        r = bf_cgen_load_counters(cgen);
+        if (r) {
+            return bf_err_r(r, "failed to read counters for '%s'",
+                            cgen->chain->name);
+        }
 
-        r = bf_list_add_tail(&_chains, chain);
+        // cgen will be destroyed, we can steal the chain
+        r = bf_list_push(&_chains, (void **)&cgen->chain);
         if (r)
             return r;
-        TAKE_PTR(chain);
 
         if (cgen->handle->link && cgen->handle->link->hookopts) {
             r = copy_hookopts(&hookopts_copy, cgen->handle->link->hookopts);
@@ -125,25 +124,10 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters)
         if (r)
             return r;
         TAKE_PTR(hookopts_copy);
-
-        r = bf_list_new(&cgen_counters,
-                        &bf_list_ops_default(bf_counter_free, NULL));
-        if (r)
-            return r;
-
-        r = bf_cgen_get_counters(cgen, cgen_counters);
-        if (r)
-            return r;
-
-        r = bf_list_add_tail(&_counters, cgen_counters);
-        if (r)
-            return r;
-        TAKE_PTR(cgen_counters);
     }
 
     *chains = bf_list_move(_chains);
     *hookopts = bf_list_move(_hookopts);
-    *counters = bf_list_move(_counters);
 
     return 0;
 }
@@ -288,19 +272,17 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
 }
 
 int bf_chain_get(const char *name, struct bf_chain **chain,
-                 struct bf_hookopts **hookopts, bf_list *counters)
+                 struct bf_hookopts **hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_chain_ struct bf_chain *_chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *_hookopts = NULL;
-    _clean_bf_list_ bf_list _counters = bf_list_default_from(*counters);
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
     assert(name);
     assert(chain);
     assert(hookopts);
-    assert(counters);
 
     r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_READ, false);
     if (r)
@@ -310,9 +292,14 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
     if (r)
         return r;
 
-    r = bf_chain_new_from_copy(&_chain, cgen->chain);
-    if (r)
-        return r;
+    r = bf_cgen_load_counters(cgen);
+    if (r) {
+        return bf_err_r(r, "failed to load counters for '%s'",
+                        cgen->chain->name);
+    }
+
+    // cgen will be destroyed, we can steal the chain
+    _chain = TAKE_PTR(cgen->chain);
 
     if (cgen->handle->link && cgen->handle->link->hookopts) {
         r = copy_hookopts(&_hookopts, cgen->handle->link->hookopts);
@@ -320,13 +307,8 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
             return r;
     }
 
-    r = bf_cgen_get_counters(cgen, &_counters);
-    if (r)
-        return bf_err_r(r, "failed to get counters for '%s'", name);
-
     *chain = TAKE_PTR(_chain);
     *hookopts = TAKE_PTR(_hookopts);
-    *counters = bf_list_move(_counters);
 
     return 0;
 }

--- a/src/libbpfilter/include/bpfilter/bpfilter.h
+++ b/src/libbpfilter/include/bpfilter/bpfilter.h
@@ -45,10 +45,9 @@ struct bf_hookopts;
  *
  * @param chains List of `bf_chain` to be filled.
  * @param hookopts List of hook options objects.
- * @param counters List of `bf_counter` to be filled.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_ruleset_get(bf_list *chains, bf_list *hookopts, bf_list *counters);
+int bf_ruleset_get(bf_list *chains, bf_list *hookopts);
 
 /**
  * @brief Load a ruleset.
@@ -96,14 +95,11 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts);
  * @param hookopts On success, contains a pointer to the chain's hook options if
  *        the chain is attached, NULL otherwise. The caller is responsible for
  *        freeing it. Can't be NULL.
- * @param counters On success, the list contains the counters for every rule of
- *        the chain, and the policy and error counters. The caller is
- *        responsible for freeing it. Can't be NULL.
  * @return 0 on success, or a negative errno value on failure, including:
  * - `-ENOENT`: no chain found for this name.
  */
 int bf_chain_get(const char *name, struct bf_chain **chain,
-                 struct bf_hookopts **hookopts, bf_list *counters);
+                 struct bf_hookopts **hookopts);
 
 /**
  * @brief Get the file descriptor of a chain's program.

--- a/src/libbpfilter/include/bpfilter/chain.h
+++ b/src/libbpfilter/include/bpfilter/chain.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <bpfilter/core/list.h>
+#include <bpfilter/counter.h>
 #include <bpfilter/dump.h>
 #include <bpfilter/hook.h>
 #include <bpfilter/pack.h>
@@ -52,6 +53,12 @@ struct bf_chain
     enum bf_verdict policy;
     bf_list sets;
     bf_list rules;
+
+    /// Policy counters. Not serialized.
+    struct bf_counter policy_counters;
+
+    /// Error counters. Not serialized.
+    struct bf_counter error_counters;
 };
 
 /**

--- a/src/libbpfilter/include/bpfilter/rule.h
+++ b/src/libbpfilter/include/bpfilter/rule.h
@@ -63,7 +63,9 @@ struct bf_rule
      * See `bf_rule_mark_is_set`. */
     uint64_t mark;
 
-    bool counters;
+    /** If set, the rule records matched elements count, and `bf_rule::counters`
+     * is valid. */
+    uint8_t has_counters:1;
 
     /** If true, skip this rule during flag calculation and code generation. */
     bool disabled;

--- a/src/libbpfilter/include/bpfilter/rule.h
+++ b/src/libbpfilter/include/bpfilter/rule.h
@@ -10,6 +10,7 @@
 #include <stdint.h>
 
 #include <bpfilter/core/list.h>
+#include <bpfilter/counter.h>
 #include <bpfilter/dump.h>
 #include <bpfilter/matcher.h>
 #include <bpfilter/pack.h>
@@ -66,6 +67,14 @@ struct bf_rule
     /** If set, the rule records matched elements count, and `bf_rule::counters`
      * is valid. */
     uint8_t has_counters:1;
+
+    /** Element and size counters for matched traffic. Only valid if
+     * `has_counters == 1`. This field is used when reading a chain, not when
+     * creating it. This field is not serialized.
+     *
+     * @todo Use this field to allow users to initialize the rule's counters
+     * to a specific value. */
+    struct bf_counter counters;
 
     /** If true, skip this rule during flag calculation and code generation. */
     bool disabled;

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -86,9 +86,17 @@ int bf_rule_new_from_pack(struct bf_rule **rule, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_rule.log");
 
-    r = bf_rpack_kv_bool(node, "has_counters", &has_counters);
-    if (r)
-        return bf_rpack_key_err(r, "bf_rule.has_counters");
+    if (bf_rpack_kv_contains(node, "has_counters")) {
+        r = bf_rpack_kv_bool(node, "has_counters", &has_counters);
+        if (r)
+            return bf_rpack_key_err(r, "bf_rule.has_counters");
+    } else if (bf_rpack_kv_contains(node, "counters")) {
+        r = bf_rpack_kv_bool(node, "counters", &has_counters);
+        if (r)
+            return bf_rpack_key_err(r, "bf_rule.counters");
+    } else {
+        return bf_err_r(-ENOENT, "missing bf_rule counters flag in pack");
+    }
     _rule->has_counters = has_counters;
 
     r = bf_rpack_kv_u64(node, "mark", &_rule->mark);
@@ -187,7 +195,16 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
     bf_dump_prefix_pop(prefix);
 
     DUMP(prefix, "log: %02x", rule->log);
+
     DUMP(prefix, "has_counters: %s", rule->has_counters ? "yes" : "no");
+    if (rule->has_counters) {
+        DUMP(prefix, "counters: struct bf_counter");
+        bf_dump_prefix_push(prefix);
+        DUMP(prefix, "count: %lu", rule->counters.count);
+        DUMP(prefix, "size: %lu", rule->counters.size);
+        bf_dump_prefix_pop(prefix);
+    }
+
     DUMP(prefix, "disabled: %s", rule->disabled ? "yes" : "no");
     DUMP(prefix, "mark: 0x%" PRIx64, rule->mark);
     DUMP(prefix, "verdict: %s", bf_verdict_to_str(rule->verdict));

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -69,6 +69,7 @@ int bf_rule_new_from_pack(struct bf_rule **rule, bf_rpack_node_t node)
 {
     _free_bf_rule_ struct bf_rule *_rule = NULL;
     bf_rpack_node_t m_nodes, m_node;
+    bool has_counters;
     int r;
 
     assert(rule);
@@ -85,9 +86,10 @@ int bf_rule_new_from_pack(struct bf_rule **rule, bf_rpack_node_t node)
     if (r)
         return bf_rpack_key_err(r, "bf_rule.log");
 
-    r = bf_rpack_kv_bool(node, "counters", &_rule->counters);
+    r = bf_rpack_kv_bool(node, "has_counters", &has_counters);
     if (r)
-        return bf_rpack_key_err(r, "bf_rule.counters");
+        return bf_rpack_key_err(r, "bf_rule.has_counters");
+    _rule->has_counters = has_counters;
 
     r = bf_rpack_kv_u64(node, "mark", &_rule->mark);
     if (r)
@@ -149,7 +151,7 @@ int bf_rule_pack(const struct bf_rule *rule, bf_wpack_t *pack)
 
     bf_wpack_kv_u32(pack, "index", rule->index);
     bf_wpack_kv_u8(pack, "log", rule->log);
-    bf_wpack_kv_bool(pack, "counters", rule->counters);
+    bf_wpack_kv_bool(pack, "has_counters", rule->has_counters);
     bf_wpack_kv_u64(pack, "mark", rule->mark);
     bf_wpack_kv_int(pack, "verdict", rule->verdict);
     bf_wpack_kv_u32(pack, "redirect_ifindex", rule->redirect_ifindex);
@@ -185,7 +187,7 @@ void bf_rule_dump(const struct bf_rule *rule, prefix_t *prefix)
     bf_dump_prefix_pop(prefix);
 
     DUMP(prefix, "log: %02x", rule->log);
-    DUMP(prefix, "counters: %s", rule->counters ? "yes" : "no");
+    DUMP(prefix, "has_counters: %s", rule->has_counters ? "yes" : "no");
     DUMP(prefix, "disabled: %s", rule->disabled ? "yes" : "no");
     DUMP(prefix, "mark: 0x%" PRIx64, rule->mark);
     DUMP(prefix, "verdict: %s", bf_verdict_to_str(rule->verdict));

--- a/tests/e2e/matchers/icmp_code.cpp
+++ b/tests/e2e/matchers/icmp_code.cpp
@@ -26,7 +26,7 @@ static void icmp_code_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ, {3})}));
 
     // ICMP code=3 should match the rule -> DROP
@@ -57,7 +57,7 @@ static void icmp_code_eq(void **state)
 
     // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ,
                                            {3}, true)}));
 
@@ -89,7 +89,7 @@ static void icmp_code_eq(void **state)
     bft_assert_counter_eq("test_icmp_code", 0, 1, -1);
 
     BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMP_CODE, BF_MATCHER_EQ,
                                            {3}, true)}));
 
@@ -133,7 +133,7 @@ static void icmp_code_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
                   << set
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 
@@ -166,7 +166,7 @@ static void icmp_code_in(void **state)
     // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_icmp_code", test->hook(), BF_VERDICT_ACCEPT)
                   << set
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0}, true)}));
 

--- a/tests/e2e/matchers/icmp_type.cpp
+++ b/tests/e2e/matchers/icmp_type.cpp
@@ -25,7 +25,7 @@ static void icmp_type_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_icmp_type", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ, {8})}));
 
     // ICMP type=8 (echo request) should match the rule -> DROP
@@ -56,7 +56,7 @@ static void icmp_type_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_icmp_type", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMP_TYPE, BF_MATCHER_EQ,
                                            {8}, true)}));
 
@@ -100,7 +100,7 @@ static void icmp_type_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_icmp_type", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/icmpv6_code.cpp
+++ b/tests/e2e/matchers/icmpv6_code.cpp
@@ -25,7 +25,7 @@ static void icmpv6_code_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_icmpv6_code", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_ICMPV6_CODE, BF_MATCHER_EQ, {3})}));
 
     // ICMPv6 code=3 should match -> DROP
@@ -56,7 +56,7 @@ static void icmpv6_code_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_code", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMPV6_CODE,
                                            BF_MATCHER_EQ, {3}, true)}));
 
@@ -100,7 +100,7 @@ static void icmpv6_code_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_code", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/icmpv6_type.cpp
+++ b/tests/e2e/matchers/icmpv6_type.cpp
@@ -24,7 +24,7 @@ static void icmpv6_type_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_type", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMPV6_TYPE,
                                            BF_MATCHER_EQ, {128})}));
 
@@ -56,7 +56,7 @@ static void icmpv6_type_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_type", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_ICMPV6_TYPE,
                                            BF_MATCHER_EQ, {128}, true)}));
 
@@ -100,7 +100,7 @@ static void icmpv6_type_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_icmpv6_type", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip4_daddr.cpp
+++ b/tests/e2e/matchers/ip4_daddr.cpp
@@ -22,7 +22,7 @@ static void ip4_daddr_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_daddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,
                                            {192, 0, 2, 2})}));
 
@@ -44,7 +44,7 @@ static void ip4_daddr_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip4_daddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_DADDR, BF_MATCHER_EQ,
                                            {192, 0, 2, 2}, true)}));
 
@@ -80,7 +80,7 @@ static void ip4_daddr_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_daddr", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip4_dnet.cpp
+++ b/tests/e2e/matchers/ip4_dnet.cpp
@@ -24,7 +24,7 @@ static void ip4_dnet_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(24, 192, 0, 2, 0))}));
 
@@ -65,7 +65,7 @@ static void ip4_dnet_eq(void **state)
     // /32 (single host): exercises the no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(32, 192, 0, 2, 2))}));
 
@@ -90,7 +90,7 @@ static void ip4_dnet_eq(void **state)
     // /0 (match all): mask=0 causes all addresses to AND to 0, matching any
     // destination address.
     BFT_CHAIN_SET(bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                            bft_ip4_lpm_key(0, 0, 0, 0, 0))}));
 
@@ -107,7 +107,7 @@ static void ip4_dnet_eq(void **state)
     // /24 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
 
@@ -133,7 +133,7 @@ static void ip4_dnet_eq(void **state)
     // ACCEPT
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(32, 192, 0, 2, 2), true)}));
 
@@ -158,7 +158,7 @@ static void ip4_dnet_eq(void **state)
     // matches.
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(0, 0, 0, 0, 0), true)}));
 
@@ -186,7 +186,7 @@ static void ip4_dnet_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_dnet", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip4_dscp.cpp
+++ b/tests/e2e/matchers/ip4_dscp.cpp
@@ -28,7 +28,7 @@ static void ip4_dscp_eq(void **state)
     // DSCP 8 (CS1): raw 6-bit value, maps to TOS byte 0x20 when ECN=0
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dscp", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_DSCP, BF_MATCHER_EQ, {8})}));
 
     // tos=0x20 (DSCP=8, ECN=0) matches -> DROP
@@ -63,7 +63,7 @@ static void ip4_dscp_eq(void **state)
     // Negation
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_dscp", test->hook(), BF_VERDICT_ACCEPT) << bf::Rule(
-            BF_VERDICT_DROP, true, {},
+            BF_VERDICT_DROP, bf_counter(), {},
             {bf::Matcher(BF_MATCHER_IP4_DSCP, BF_MATCHER_EQ, {8}, true)}));
 
     // tos=0x20 (DSCP=8) matches the reference value, not eq does not fire -> ACCEPT

--- a/tests/e2e/matchers/ip4_proto.cpp
+++ b/tests/e2e/matchers/ip4_proto.cpp
@@ -24,7 +24,7 @@ static void ip4_proto_eq(void **state)
     // IPPROTO_TCP = 6
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
 
     // TCP packet -> protocol=6 -> DROP
@@ -47,7 +47,7 @@ static void ip4_proto_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip4_proto", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ,
                                            {6}, true)}));
 
@@ -84,7 +84,7 @@ static void ip4_proto_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_proto", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip4_saddr.cpp
+++ b/tests/e2e/matchers/ip4_saddr.cpp
@@ -22,7 +22,7 @@ static void ip4_saddr_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_saddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                                            {192, 0, 2, 1})}));
 
@@ -46,7 +46,7 @@ static void ip4_saddr_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip4_saddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                                            {192, 0, 2, 1}, true)}));
 
@@ -84,7 +84,7 @@ static void ip4_saddr_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_saddr", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip4_snet.cpp
+++ b/tests/e2e/matchers/ip4_snet.cpp
@@ -26,7 +26,7 @@ static void ip4_snet_eq(void **state)
     // 192.0.2.0/24
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(24, 192, 0, 2, 0))}));
 
@@ -67,7 +67,7 @@ static void ip4_snet_eq(void **state)
     // Try with negation: 192.0.2.0/24
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
 
@@ -93,7 +93,7 @@ static void ip4_snet_eq(void **state)
     // bf_cmp_masked_value(), comparing the address directly without AND.
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(32, 192, 0, 2, 1))}));
 
@@ -118,7 +118,7 @@ static void ip4_snet_eq(void **state)
     // /0 (match all): mask=0 causes both sides to AND to 0, matching every
     // source address.
     BFT_CHAIN_SET(bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                            bft_ip4_lpm_key(0, 0, 0, 0, 0))}));
 
@@ -135,7 +135,7 @@ static void ip4_snet_eq(void **state)
     // /24 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(24, 192, 0, 2, 0), true)}));
 
@@ -160,7 +160,7 @@ static void ip4_snet_eq(void **state)
     // /32 not eq: saddr exactly matching the host -> does not match -> ACCEPT
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(32, 192, 0, 2, 1), true)}));
 
@@ -185,7 +185,7 @@ static void ip4_snet_eq(void **state)
     // matches.
     BFT_CHAIN_SET(
         bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_SNET, BF_MATCHER_EQ,
                                  bft_ip4_lpm_key(0, 0, 0, 0, 0), true)}));
 
@@ -213,7 +213,7 @@ static void ip4_snet_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip4_snet", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip6_daddr.cpp
+++ b/tests/e2e/matchers/ip6_daddr.cpp
@@ -22,7 +22,7 @@ static void ip6_daddr_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_daddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
                                            bft_ipv6_addr("2001:db8::2"))}));
 
@@ -45,7 +45,7 @@ static void ip6_daddr_eq(void **state)
     // Negation
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_daddr", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DADDR, BF_MATCHER_EQ,
                                  bft_ipv6_addr("2001:db8::2"), true)}));
 
@@ -80,7 +80,7 @@ static void ip6_daddr_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_daddr", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip6_dnet.cpp
+++ b/tests/e2e/matchers/ip6_dnet.cpp
@@ -24,7 +24,7 @@ static void ip6_dnet_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(32, "2001:db8::"))}));
 
@@ -57,7 +57,7 @@ static void ip6_dnet_eq(void **state)
     // /128 (single host): exercises the no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(128, "2001:db8::2"))}));
 
@@ -81,7 +81,7 @@ static void ip6_dnet_eq(void **state)
 
     // /0 (match all): any destination address matches.
     BFT_CHAIN_SET(bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                            bft_ip6_lpm_key(0, "::"))}));
 
@@ -98,7 +98,7 @@ static void ip6_dnet_eq(void **state)
     // Negation: /32 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(32, "2001:db8::"), true)}));
 
@@ -123,7 +123,7 @@ static void ip6_dnet_eq(void **state)
     // no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(128, "2001:db8::2"), true)}));
 
@@ -146,7 +146,7 @@ static void ip6_dnet_eq(void **state)
     // /0 not eq: /0 covers the entire address space; not eq /0 never
     // matches.
     BFT_CHAIN_SET(bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_DNET, BF_MATCHER_EQ,
                                            bft_ip6_lpm_key(0, "::"), true)}));
 
@@ -174,7 +174,7 @@ static void ip6_dnet_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_dnet", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip6_dscp.cpp
+++ b/tests/e2e/matchers/ip6_dscp.cpp
@@ -28,7 +28,7 @@ static void ip6_dscp_eq(void **state)
     // DSCP 8 (CS1): raw 6-bit value, maps to traffic class byte 0x20 when ECN=0
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dscp", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_DSCP, BF_MATCHER_EQ, {8})}));
 
     // traffic_class=0x20 (DSCP=8, ECN=0) matches -> DROP
@@ -64,7 +64,7 @@ static void ip6_dscp_eq(void **state)
     // Negation
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_dscp", test->hook(), BF_VERDICT_ACCEPT) << bf::Rule(
-            BF_VERDICT_DROP, true, {},
+            BF_VERDICT_DROP, bf_counter(), {},
             {bf::Matcher(BF_MATCHER_IP6_DSCP, BF_MATCHER_EQ, {8}, true)}));
 
     // traffic_class=0x20 (DSCP=8) matches the reference value, not eq does

--- a/tests/e2e/matchers/ip6_nexthdr.cpp
+++ b/tests/e2e/matchers/ip6_nexthdr.cpp
@@ -24,7 +24,7 @@ static void ip6_nexthdr_eq(void **state)
     // IPPROTO_TCP = 6
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_nexthdr", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_EQ, {6})}));
 
     // TCP over IPv6 -> nexthdr=6 -> DROP
@@ -47,7 +47,7 @@ static void ip6_nexthdr_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_ip6_nexthdr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_NEXTHDR,
                                            BF_MATCHER_EQ, {6}, true)}));
 
@@ -85,7 +85,7 @@ static void ip6_nexthdr_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_nexthdr", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip6_saddr.cpp
+++ b/tests/e2e/matchers/ip6_saddr.cpp
@@ -22,7 +22,7 @@ static void ip6_saddr_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                                            bft_ipv6_addr("2001:db8::1"))}));
 
@@ -45,7 +45,7 @@ static void ip6_saddr_eq(void **state)
     // Try with negation
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                                  bft_ipv6_addr("2001:db8::1"), true)}));
 
@@ -69,7 +69,7 @@ static void ip6_saddr_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                                  bft_ipv6_addr("2001:db8::1"), true)}));
 
@@ -104,7 +104,7 @@ static void ip6_saddr_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_saddr", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/ip6_snet.cpp
+++ b/tests/e2e/matchers/ip6_snet.cpp
@@ -26,7 +26,7 @@ static void ip6_snet_eq(void **state)
     // 2001:db8::/32
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(32, "2001:db8::"))}));
 
@@ -60,7 +60,7 @@ static void ip6_snet_eq(void **state)
     // bf_cmp_masked_value(), comparing both 64-bit halves directly without AND.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(128, "2001:db8::1"))}));
 
@@ -85,7 +85,7 @@ static void ip6_snet_eq(void **state)
     // /0 (match all): mask=0 causes all addresses to AND to 0, matching any
     // source address.
     BFT_CHAIN_SET(bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                            bft_ip6_lpm_key(0, "::"))}));
 
@@ -102,7 +102,7 @@ static void ip6_snet_eq(void **state)
     // Negation: /32 not eq
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(32, "2001:db8::"), true)}));
 
@@ -129,7 +129,7 @@ static void ip6_snet_eq(void **state)
     // no-masking code path.
     BFT_CHAIN_SET(
         bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                  bft_ip6_lpm_key(128, "2001:db8::1"), true)}));
 
@@ -152,7 +152,7 @@ static void ip6_snet_eq(void **state)
     // /0 not eq: /0 covers the entire address space; not eq /0 never
     // matches.
     BFT_CHAIN_SET(bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_IP6_SNET, BF_MATCHER_EQ,
                                            bft_ip6_lpm_key(0, "::"), true)}));
 
@@ -179,7 +179,7 @@ static void ip6_snet_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_ip6_snet", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 

--- a/tests/e2e/matchers/meta_dport.cpp
+++ b/tests/e2e/matchers/meta_dport.cpp
@@ -23,7 +23,7 @@ static void meta_dport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_meta_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(80))}));
 
@@ -72,7 +72,7 @@ static void meta_dport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_meta_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(80), true)}));
 
@@ -112,7 +112,7 @@ static void meta_dport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_meta_dport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_DPORT, BF_MATCHER_RANGE,
                                  bft_port_range(80, 443))}));
 

--- a/tests/e2e/matchers/meta_flow_hash.cpp
+++ b/tests/e2e/matchers/meta_flow_hash.cpp
@@ -24,7 +24,7 @@ static void meta_flow_hash_eq(void **state)
     // eq UINT32_MAX — extremely unlikely to match actual hash -> ACCEPT
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fhash", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_EQ,
                                  bft_u32_payload(UINT_MAX))}));
 
@@ -41,7 +41,7 @@ static void meta_flow_hash_eq(void **state)
     // UINT32_MAX
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fhash", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_EQ,
                                  bft_u32_payload(UINT_MAX), true)}));
 
@@ -64,7 +64,7 @@ static void meta_flow_hash_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fhash", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_RANGE,
                                  bft_u32_range(0, UINT_MAX))}));
 
@@ -80,7 +80,7 @@ static void meta_flow_hash_range(void **state)
     // Range [UINT_MAX, UINT_MAX] should not match
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fhash", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_RANGE,
                                  bft_u32_range(UINT_MAX, UINT_MAX))}));
 

--- a/tests/e2e/matchers/meta_flow_probability.cpp
+++ b/tests/e2e/matchers/meta_flow_probability.cpp
@@ -25,7 +25,7 @@ static void meta_flow_probability_eq(void **state)
     // 100.0f always matches
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
                                  BF_MATCHER_EQ, bft_float_payload(100.0f))}));
 
@@ -41,7 +41,7 @@ static void meta_flow_probability_eq(void **state)
     // 0.0f should never match
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
                                  BF_MATCHER_EQ, bft_float_payload(0.0f))}));
 
@@ -56,7 +56,7 @@ static void meta_flow_probability_eq(void **state)
 
     // Negated 100.0f should never match
     BFT_CHAIN_SET(bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
                                            BF_MATCHER_EQ,
                                            bft_float_payload(100.0f), true)}));
@@ -72,7 +72,7 @@ static void meta_flow_probability_eq(void **state)
 
     // Negated 0.0f should always match
     BFT_CHAIN_SET(bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
                                            BF_MATCHER_EQ,
                                            bft_float_payload(0.0f), true)}));
@@ -91,7 +91,7 @@ static void meta_flow_probability_eq(void **state)
     // not fire even at 100% probability.
     BFT_CHAIN_SET(
         bf::Chain("test_meta_fprob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_FLOW_PROBABILITY,
                                  BF_MATCHER_EQ, bft_float_payload(100.0f))}));
 

--- a/tests/e2e/matchers/meta_iface.cpp
+++ b/tests/e2e/matchers/meta_iface.cpp
@@ -22,7 +22,7 @@ static void meta_iface_eq(void **state)
 
     // eq UINT32_MAX — no real interface has this index -> ACCEPT
     BFT_CHAIN_SET(bf::Chain("test_meta_iface", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_IFACE, BF_MATCHER_EQ,
                                            bft_u32_payload(UINT_MAX))}));
 

--- a/tests/e2e/matchers/meta_l3_proto.cpp
+++ b/tests/e2e/matchers/meta_l3_proto.cpp
@@ -24,7 +24,7 @@ static void meta_l3_proto_eq(void **state)
     // ETH_P_IP = 0x0800
     BFT_CHAIN_SET(
         bf::Chain("test_meta_l3_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_L3_PROTO, BF_MATCHER_EQ,
                                  bft_u16_payload(0x0800))}));
 
@@ -49,7 +49,7 @@ static void meta_l3_proto_eq(void **state)
     // ETH_P_IPV6 = 0x86DD
     BFT_CHAIN_SET(
         bf::Chain("test_meta_l3_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_L3_PROTO, BF_MATCHER_EQ,
                                  bft_u16_payload(0x86DD))}));
 

--- a/tests/e2e/matchers/meta_l4_proto.cpp
+++ b/tests/e2e/matchers/meta_l4_proto.cpp
@@ -22,7 +22,7 @@ static void meta_l4_proto_eq(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_meta_l4_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_L4_PROTO, BF_MATCHER_EQ,
                                  bft_u16_payload(6))}));
 
@@ -47,7 +47,7 @@ static void meta_l4_proto_eq(void **state)
     // Negation
     BFT_CHAIN_SET(
         bf::Chain("test_meta_l4_proto", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_L4_PROTO, BF_MATCHER_EQ,
                                  bft_u16_payload(6), true)}));
 

--- a/tests/e2e/matchers/meta_mark.cpp
+++ b/tests/e2e/matchers/meta_mark.cpp
@@ -23,7 +23,7 @@ static void meta_mark_eq(void **state)
 
     // BPF_PROG_TEST_RUN gives mark=0; match eq 0
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
                                            bft_u32_payload(0))}));
 
@@ -39,7 +39,7 @@ static void meta_mark_eq(void **state)
 
     // eq 42 should not match since mark is 0
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
                                            bft_u32_payload(42))}));
 
@@ -54,7 +54,7 @@ static void meta_mark_eq(void **state)
 
     // not eq 0 should NOT match since mark=0
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
                                            bft_u32_payload(0), true)}));
 
@@ -69,7 +69,7 @@ static void meta_mark_eq(void **state)
 
     // not eq 42 should match since mark=0 != 42
     BFT_CHAIN_SET(bf::Chain("test_meta_mark", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_MARK, BF_MATCHER_EQ,
                                            bft_u32_payload(42), true)}));
 

--- a/tests/e2e/matchers/meta_probability.cpp
+++ b/tests/e2e/matchers/meta_probability.cpp
@@ -24,7 +24,7 @@ static void meta_probability_eq(void **state)
     // 100.0f always matches
     BFT_CHAIN_SET(
         bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
                                  bft_float_payload(100.0f))}));
 
@@ -40,7 +40,7 @@ static void meta_probability_eq(void **state)
     // 0.0f should never match
     BFT_CHAIN_SET(
         bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
                                  bft_float_payload(0.0f))}));
 
@@ -56,7 +56,7 @@ static void meta_probability_eq(void **state)
     // Negated 100.0f should never match
     BFT_CHAIN_SET(
         bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
                                  bft_float_payload(100.0f), true)}));
 
@@ -72,7 +72,7 @@ static void meta_probability_eq(void **state)
     // Negated 0.0f should always match
     BFT_CHAIN_SET(
         bf::Chain("test_meta_prob", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_PROBABILITY, BF_MATCHER_EQ,
                                  bft_float_payload(0.0f), true)}));
 

--- a/tests/e2e/matchers/meta_sport.cpp
+++ b/tests/e2e/matchers/meta_sport.cpp
@@ -22,7 +22,7 @@ static void meta_sport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_meta_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345))}));
 
@@ -71,7 +71,7 @@ static void meta_sport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_meta_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345), true)}));
 
@@ -111,7 +111,7 @@ static void meta_sport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_meta_sport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_RANGE,
                                  bft_port_range(1000, 2000))}));
 

--- a/tests/e2e/matchers/tcp_dport.cpp
+++ b/tests/e2e/matchers/tcp_dport.cpp
@@ -23,7 +23,7 @@ static void tcp_dport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_tcp_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(80))}));
 
@@ -63,7 +63,7 @@ static void tcp_dport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(80), true)}));
 
@@ -107,7 +107,7 @@ static void tcp_dport_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_tcp_dport", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 
@@ -149,7 +149,7 @@ static void tcp_dport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_tcp_dport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_TCP_DPORT, BF_MATCHER_RANGE,
                                  bft_port_range(80, 443))}));
 

--- a/tests/e2e/matchers/tcp_flags.cpp
+++ b/tests/e2e/matchers/tcp_flags.cpp
@@ -23,7 +23,7 @@ static void tcp_flags_eq(void **state)
 
     // SYN = 0x02
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_EQ,
                                            {0x02})}));
 
@@ -55,7 +55,7 @@ static void tcp_flags_eq(void **state)
 
     // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_EQ,
                                            {0x02}, true)}));
 
@@ -89,7 +89,7 @@ static void tcp_flags_any(void **state)
 
     // SYN|ACK = 0x12
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY,
                                            {0x12})}));
 
@@ -121,7 +121,7 @@ static void tcp_flags_any(void **state)
 
     // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ANY,
                                            {0x12}, true)}));
 
@@ -155,7 +155,7 @@ static void tcp_flags_all(void **state)
 
     // SYN|ACK = 0x12
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ALL,
                                            {0x12})}));
 
@@ -191,7 +191,7 @@ static void tcp_flags_all(void **state)
 
     // Try with negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_flags", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_FLAGS, BF_MATCHER_ALL,
                                            {0x12}, true)}));
 

--- a/tests/e2e/matchers/tcp_sport.cpp
+++ b/tests/e2e/matchers/tcp_sport.cpp
@@ -23,7 +23,7 @@ static void tcp_sport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345))}));
 
@@ -63,7 +63,7 @@ static void tcp_sport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345), true)}));
 
@@ -107,7 +107,7 @@ static void tcp_sport_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 
@@ -149,7 +149,7 @@ static void tcp_sport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_RANGE,
                                  bft_port_range(1000, 2000))}));
 
@@ -198,7 +198,7 @@ static void tcp_sport_range(void **state)
     // Try with negation
     BFT_CHAIN_SET(
         bf::Chain("test_tcp_sport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_RANGE,
                                  bft_port_range(1000, 2000), true)}));
 

--- a/tests/e2e/matchers/udp_dport.cpp
+++ b/tests/e2e/matchers/udp_dport.cpp
@@ -23,7 +23,7 @@ static void udp_dport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_udp_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(53))}));
 
@@ -61,7 +61,7 @@ static void udp_dport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_udp_dport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_UDP_DPORT, BF_MATCHER_EQ,
                                            bft_port_be(53), true)}));
 
@@ -103,7 +103,7 @@ static void udp_dport_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_udp_dport", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 
@@ -143,7 +143,7 @@ static void udp_dport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_udp_dport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_UDP_DPORT, BF_MATCHER_RANGE,
                                  bft_port_range(50, 100))}));
 

--- a/tests/e2e/matchers/udp_sport.cpp
+++ b/tests/e2e/matchers/udp_sport.cpp
@@ -23,7 +23,7 @@ static void udp_sport_eq(void **state)
     auto *test = static_cast<MatcherTest *>(*state);
 
     BFT_CHAIN_SET(bf::Chain("test_udp_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_UDP_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345))}));
 
@@ -61,7 +61,7 @@ static void udp_sport_eq(void **state)
 
     // Negation
     BFT_CHAIN_SET(bf::Chain("test_udp_sport", test->hook(), BF_VERDICT_ACCEPT)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_UDP_SPORT, BF_MATCHER_EQ,
                                            bft_port_be(12345), true)}));
 
@@ -103,7 +103,7 @@ static void udp_sport_in(void **state)
 
     BFT_CHAIN_SET(bf::Chain("test_udp_sport", test->hook(), BF_VERDICT_ACCEPT)
                   << std::move(set)
-                  << bf::Rule(BF_VERDICT_DROP, true, {},
+                  << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                               {bf::Matcher(BF_MATCHER_SET, BF_MATCHER_IN,
                                            {0, 0, 0, 0})}));
 
@@ -143,7 +143,7 @@ static void udp_sport_range(void **state)
 
     BFT_CHAIN_SET(
         bf::Chain("test_udp_sport", test->hook(), BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_UDP_SPORT, BF_MATCHER_RANGE,
                                  bft_port_range(1000, 2000))}));
 

--- a/tests/e2e/verdicts/next.cpp
+++ b/tests/e2e/verdicts/next.cpp
@@ -46,7 +46,7 @@ static void next_rule_verdict(void **state)
         // IPPROTO_TCP = 6
         BFT_CHAIN_SET(
             bf::Chain("test_next", hook, BF_VERDICT_DROP) << bf::Rule(
-                BF_VERDICT_NEXT, false, {},
+                BF_VERDICT_NEXT, std::nullopt, {},
                 {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
 
         bft_assert_prog_run("test_next", hook,
@@ -77,7 +77,7 @@ static void next_policy(void **state)
         // IPPROTO_TCP = 6
         BFT_CHAIN_SET(
             bf::Chain("test_next", hook, BF_VERDICT_NEXT) << bf::Rule(
-                BF_VERDICT_DROP, false, {},
+                BF_VERDICT_DROP, std::nullopt, {},
                 {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
 
         bft_assert_prog_run("test_next", hook,
@@ -105,9 +105,9 @@ static void next_is_terminal(void **state)
     // IPPROTO_TCP = 6
     BFT_CHAIN_SET(
         bf::Chain("test_next_term", BF_HOOK_TC_INGRESS, BF_VERDICT_ACCEPT)
-        << bf::Rule(BF_VERDICT_NEXT, true, {},
+        << bf::Rule(BF_VERDICT_NEXT, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})})
-        << bf::Rule(BF_VERDICT_DROP, true, {},
+        << bf::Rule(BF_VERDICT_DROP, bf_counter(), {},
                     {bf::Matcher(BF_MATCHER_IP4_PROTO, BF_MATCHER_EQ, {6})}));
 
     bft_assert_prog_run("test_next_term", BF_HOOK_TC_INGRESS,

--- a/tests/fuzz/fuzz_parser.c
+++ b/tests/fuzz/fuzz_parser.c
@@ -22,11 +22,11 @@ void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...)
 }
 
 // Stub for ruleset dumping - not used during parsing
-int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bf_list *counters)
+int bfc_ruleset_dump(bf_list *chains, bf_list *hookopts, bool no_set_content)
 {
     (void)chains;
     (void)hookopts;
-    (void)counters;
+    (void)no_set_content;
 
     return 0;
 }

--- a/tests/harness/Rule.hpp
+++ b/tests/harness/Rule.hpp
@@ -6,12 +6,14 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
 #include "Matcher.hpp"
 
 extern "C" {
+#include <bpfilter/counter.h>
 #include <bpfilter/rule.h>
 #include <bpfilter/runtime.h>
 #include <bpfilter/verdict.h>
@@ -32,13 +34,14 @@ private:
     };
 
     bf_verdict _verdict;
-    bool _counters;
+    std::optional<struct bf_counter> _counters;
     uint8_t _log;
     std::vector<Matcher> _matchers;
 
 public:
-    Rule(bf_verdict verdict, bool counters = false, uint8_t log = 0,
-         std::vector<Matcher> matchers = {}):
+    Rule(bf_verdict verdict,
+         std::optional<struct bf_counter> counters = std::nullopt,
+         uint8_t log = 0, std::vector<Matcher> matchers = {}):
         _verdict {verdict},
         _counters {counters},
         _log {log},
@@ -61,7 +64,7 @@ public:
             throw std::runtime_error("failed to create bf_rule");
 
         rule->log = _log;
-        rule->counters = _counters;
+        rule->has_counters = _counters.has_value();
         rule->verdict = _verdict;
 
         for (const Matcher &matcher: _matchers) {

--- a/tests/harness/fake.c
+++ b/tests/harness/fake.c
@@ -191,7 +191,7 @@ struct bf_rule *bft_rule_dummy(size_t n_matchers)
     rule->index = 0;
     rule->log = BF_FLAGS(BF_LOG_OPT_INTERNET, BF_LOG_OPT_TRANSPORT);
     rule->mark = 0x17;
-    rule->counters = true;
+    rule->has_counters = 1;
     rule->verdict = BF_VERDICT_ACCEPT;
 
     for (size_t i = 0; i < n_matchers; ++i) {

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -292,7 +292,8 @@ bool bft_chain_equal(const struct bf_chain *chain0,
 bool bft_rule_equal(const struct bf_rule *rule0, const struct bf_rule *rule1)
 {
     return rule0->index == rule1->index && rule0->log == rule1->log &&
-           rule0->mark == rule1->mark && rule0->counters == rule1->counters &&
+           rule0->mark == rule1->mark &&
+           rule0->has_counters == rule1->has_counters &&
            rule0->verdict == rule1->verdict &&
            rule0->redirect_ifindex == rule1->redirect_ifindex &&
            rule0->redirect_dir == rule1->redirect_dir &&

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -25,18 +25,18 @@ void bft_assert_counter_eq(const char *chain_name, size_t rule_idx,
 {
     _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hopts = NULL;
-    _clean_bf_list_ bf_list counters = bf_list_default(bf_counter_free, NULL);
-    struct bf_counter *counter;
+    struct bf_rule *rule;
 
     assert_non_null(chain_name);
 
-    assert_ok(bf_chain_get(chain_name, &chain, &hopts, &counters));
+    assert_ok(bf_chain_get(chain_name, &chain, &hopts));
 
-    counter = bf_list_get_at(&counters, rule_idx);
-    assert_non_null(counter);
-    assert_int_equal(packets, counter->count);
+    rule = bf_list_get_at(&chain->rules, rule_idx);
+    assert_non_null(rule);
+    assert_true(rule->has_counters);
+    assert_int_equal(packets, rule->counters.count);
     if (bytes >= 0)
-        assert_int_equal((uint64_t)bytes, counter->size);
+        assert_int_equal((uint64_t)bytes, rule->counters.size);
 }
 
 int btf_setup_redirect_streams(void **state)

--- a/tests/harness/test.h
+++ b/tests/harness/test.h
@@ -109,6 +109,15 @@ bool bft_set_eq_ordered(const struct bf_set *lhs, const struct bf_set *rhs);
 bool bft_counter_eq(const struct bf_counter *lhs, const struct bf_counter *rhs);
 bool bft_chain_equal(const struct bf_chain *chain0,
                      const struct bf_chain *chain1);
+
+/**
+ * @brief Compares two rules for equality.
+ *
+ * @note `has_counters` is used in the comparison, but the counters values are
+ * ignored.
+ *
+ * @return True if the rules are identical, false otherwise.
+ */
 bool bft_rule_equal(const struct bf_rule *rule0, const struct bf_rule *rule1);
 bool bft_matcher_equal(const struct bf_matcher *matcher0,
                        const struct bf_matcher *matcher1);

--- a/tests/unit/libbpfilter/cli.c
+++ b/tests/unit/libbpfilter/cli.c
@@ -28,12 +28,10 @@ static void ruleset_get(void **state)
         // Empty ruleset
         _clean_bf_list_ bf_list chains = bf_list_default(NULL, NULL);
         _clean_bf_list_ bf_list hookopts = bf_list_default(NULL, NULL);
-        _clean_bf_list_ bf_list counters = bf_list_default(NULL, NULL);
 
-        assert_ok(bf_ruleset_get(&chains, &hookopts, &counters));
+        assert_ok(bf_ruleset_get(&chains, &hookopts));
         assert_int_equal(bf_list_size(&chains), 0);
         assert_int_equal(bf_list_size(&hookopts), 0);
-        assert_int_equal(bf_list_size(&counters), 0);
     }
 
     {
@@ -41,7 +39,6 @@ static void ruleset_get(void **state)
         struct bft_tmpdir *tmpdir = *state;
         _clean_bf_list_ bf_list chains = bf_list_default(NULL, NULL);
         _clean_bf_list_ bf_list hookopts = bf_list_default(NULL, NULL);
-        _clean_bf_list_ bf_list counters = bf_list_default(NULL, NULL);
         char path[PATH_MAX];
 
         /* A chain dir with no `bf_ctx` map looks valid to readdir() but cannot be
@@ -54,10 +51,9 @@ static void ruleset_get(void **state)
                        tmpdir->dir_path);
         assert_ok(mkdir(path, 0755));
 
-        assert_ok(bf_ruleset_get(&chains, &hookopts, &counters));
+        assert_ok(bf_ruleset_get(&chains, &hookopts));
         assert_int_equal(bf_list_size(&chains), 0);
         assert_int_equal(bf_list_size(&hookopts), 0);
-        assert_int_equal(bf_list_size(&counters), 0);
     }
 }
 
@@ -96,11 +92,10 @@ static void chain_get(void **state)
 {
     _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
-    _clean_bf_list_ struct bf_list counters = bf_list_default(NULL, NULL);
 
     (void)state;
 
-    assert_err(bf_chain_get("invalid_chain", &chain, &hookopts, &counters));
+    assert_err(bf_chain_get("invalid_chain", &chain, &hookopts));
 }
 
 static void chain_prog_fd(void **state)


### PR DESCRIPTION
Counter values were previously delivered alongside chains as a parallel `bf_list` parameter on `bf_chain_get` / `bf_ruleset_get`, requiring every consumer to walk two lists in lockstep and to re-derive which slot belonged to which rule. This series moves the snapshots into the data model and refreshes them on the read path.