### PR TITLE
Remove global context

### DIFF
--- a/doc/developers/style.rst
+++ b/doc/developers/style.rst
@@ -64,7 +64,7 @@ Naming conventions
 Functions and variables
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-- Lowercase with underscores: ``bf_chain_new()``, ``bf_ctx_setup()``
+- Lowercase with underscores: ``bf_chain_new()``, ``bf_ctx_new()``
 - Prefix with module name: ``bf_chain_*``, ``bf_program_*``, ``bf_ctx_*``
 - Static functions and variables use leading underscore: ``_bf_ctx_free()``
 - CLI utilities use ``bfc_`` prefix: ``bfc_parse_file()``

--- a/src/bfcli/chain.c
+++ b/src/bfcli/chain.c
@@ -81,7 +81,7 @@ static int _bfc_get_chain_from_ruleset(const struct bfc_ruleset *ruleset,
     return 0;
 }
 
-int bfc_chain_set(const struct bfc_opts *opts)
+int bfc_chain_set(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
@@ -100,7 +100,7 @@ int bfc_chain_set(const struct bfc_opts *opts)
         return r;
 
     if (!opts->dry_run) {
-        r = bf_chain_set(chain, hookopts);
+        r = bf_chain_set(ctx, chain, hookopts);
         if (r)
             return bf_err_r(r, "unknown error");
     } else {
@@ -110,13 +110,13 @@ int bfc_chain_set(const struct bfc_opts *opts)
     return 0;
 }
 
-int bfc_chain_get(const struct bfc_opts *opts)
+int bfc_chain_get(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     _free_bf_chain_ struct bf_chain *chain = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
     int r;
 
-    r = bf_chain_get(opts->name, &chain, &hookopts);
+    r = bf_chain_get(ctx, opts->name, &chain, &hookopts);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
@@ -139,13 +139,13 @@ static int _bf_handle_rb_log(void *ctx, void *data, size_t data_size)
     return 0;
 }
 
-int bfc_chain_logs(const struct bfc_opts *opts)
+int bfc_chain_logs(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     _cleanup_close_ int fd = -1;
     struct ring_buffer *rb;
     int r;
 
-    fd = bf_chain_logs_fd(opts->name);
+    fd = bf_chain_logs_fd(ctx, opts->name);
     if (fd < 0) {
         return bf_err_r(fd, "failed to request '%s' logs buffer FD",
                         opts->name);
@@ -171,7 +171,7 @@ int bfc_chain_logs(const struct bfc_opts *opts)
     return r;
 }
 
-int bfc_chain_load(const struct bfc_opts *opts)
+int bfc_chain_load(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
@@ -193,7 +193,7 @@ int bfc_chain_load(const struct bfc_opts *opts)
         bf_warn("Hook options are ignored when loading a chain");
 
     if (!opts->dry_run) {
-        r = bf_chain_load(chain);
+        r = bf_chain_load(ctx, chain);
         if (r)
             return bf_err_r(r, "unknown error");
     } else {
@@ -203,11 +203,11 @@ int bfc_chain_load(const struct bfc_opts *opts)
     return 0;
 }
 
-int bfc_chain_attach(const struct bfc_opts *opts)
+int bfc_chain_attach(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     int r;
 
-    r = bf_chain_attach(opts->name, &opts->hookopts);
+    r = bf_chain_attach(ctx, opts->name, &opts->hookopts);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
@@ -216,7 +216,7 @@ int bfc_chain_attach(const struct bfc_opts *opts)
     return r;
 }
 
-int bfc_chain_update(const struct bfc_opts *opts)
+int bfc_chain_update(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     struct bf_chain *chain = NULL;
     struct bf_hookopts *hookopts = NULL;
@@ -237,7 +237,7 @@ int bfc_chain_update(const struct bfc_opts *opts)
     if (hookopts)
         bf_warn("Hook options are ignored when updating a chain");
     if (!opts->dry_run) {
-        r = bf_chain_update(chain);
+        r = bf_chain_update(ctx, chain);
         if (r == -ENOENT)
             return bf_err_r(r, "chain '%s' not found", chain->name);
         if (r == -ENOLINK)
@@ -252,11 +252,11 @@ int bfc_chain_update(const struct bfc_opts *opts)
     return r;
 }
 
-int bfc_chain_flush(const struct bfc_opts *opts)
+int bfc_chain_flush(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     int r;
 
-    r = bf_chain_flush(opts->name);
+    r = bf_chain_flush(ctx, opts->name);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
@@ -265,7 +265,7 @@ int bfc_chain_flush(const struct bfc_opts *opts)
     return r;
 }
 
-int bfc_chain_update_set(const struct bfc_opts *opts)
+int bfc_chain_update_set(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     _free_bf_set_ struct bf_set *to_add = NULL;
     _free_bf_set_ struct bf_set *to_remove = NULL;
@@ -278,7 +278,7 @@ int bfc_chain_update_set(const struct bfc_opts *opts)
         return bf_err_r(-EINVAL, "no elements to add or remove");
 
     // Fetch dest_set to get key format
-    r = bf_chain_get(opts->name, &chain, &hookopts);
+    r = bf_chain_get(ctx, opts->name, &chain, &hookopts);
     if (r == -ENOENT)
         return bf_err_r(r, "chain '%s' not found", opts->name);
     if (r)
@@ -313,7 +313,7 @@ int bfc_chain_update_set(const struct bfc_opts *opts)
             return bf_err_r(r, "failed to parse set element '%s'", raw_elem);
     }
 
-    r = bf_chain_update_set(opts->name, to_add, to_remove);
+    r = bf_chain_update_set(ctx, opts->name, to_add, to_remove);
     if (r)
         return bf_err_r(r, "failed to update set '%s' in chain '%s'",
                         opts->set_name, opts->name);

--- a/src/bfcli/chain.h
+++ b/src/bfcli/chain.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+struct bf_ctx;
 struct bfc_opts;
 
-int bfc_chain_set(const struct bfc_opts *opts);
-int bfc_chain_get(const struct bfc_opts *opts);
-int bfc_chain_logs(const struct bfc_opts *opts);
-int bfc_chain_load(const struct bfc_opts *opts);
-int bfc_chain_attach(const struct bfc_opts *opts);
-int bfc_chain_update(const struct bfc_opts *opts);
-int bfc_chain_update_set(const struct bfc_opts *opts);
-int bfc_chain_flush(const struct bfc_opts *opts);
+int bfc_chain_set(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_get(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_logs(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_load(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_attach(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_update(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_update_set(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_chain_flush(const struct bfc_opts *opts, const struct bf_ctx *ctx);

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -35,6 +35,7 @@ static void _bfc_print_version(FILE *stream, struct argp_state *state)
 int main(int argc, char *argv[])
 {
     _clean_bfc_opts_ struct bfc_opts opts = bfc_opts_default();
+    _free_bf_ctx_ struct bf_ctx *ctx = NULL;
     int r;
 
     argp_program_version_hook = &_bfc_print_version;
@@ -46,18 +47,15 @@ int main(int argc, char *argv[])
     if (r < 0)
         return r;
 
+    bf_logger_set_verbose(opts.verbose);
+
     if (!opts.dry_run) {
-        r = bf_ctx_setup(opts.with_bpf_token, opts.bpffs_path, opts.verbose);
+        r = bf_ctx_new(&ctx, opts.with_bpf_token, opts.bpffs_path);
         if (r < 0)
             return r;
     }
 
-    r = opts.cmd->cb(&opts);
-
-    if (!opts.dry_run)
-        bf_ctx_teardown();
-
-    return r;
+    return opts.cmd->cb(&opts, ctx);
 }
 
 void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...)

--- a/src/bfcli/opts.h
+++ b/src/bfcli/opts.h
@@ -10,6 +10,8 @@
 
 #include <bpfilter/hook.h>
 
+struct bf_ctx;
+
 /**
  * @file opts.h
  *
@@ -95,7 +97,7 @@ struct bfc_opts_cmd
     uint32_t valid_opts;
     uint32_t required_opts;
     const char *doc;
-    int (*cb)(const struct bfc_opts *opts);
+    int (*cb)(const struct bfc_opts *opts, const struct bf_ctx *ctx);
 };
 
 /**

--- a/src/bfcli/ruleset.c
+++ b/src/bfcli/ruleset.c
@@ -21,7 +21,7 @@ void bfc_ruleset_clean(struct bfc_ruleset *ruleset)
     bf_list_clean(&ruleset->sets);
 }
 
-int bfc_ruleset_set(const struct bfc_opts *opts)
+int bfc_ruleset_set(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     _clean_bfc_ruleset_ struct bfc_ruleset ruleset = bfc_ruleset_default();
     int r;
@@ -34,7 +34,7 @@ int bfc_ruleset_set(const struct bfc_opts *opts)
         return bf_err_r(r, "failed to parse ruleset");
 
     if (!opts->dry_run) {
-        r = bf_ruleset_set(&ruleset.chains, &ruleset.hookopts);
+        r = bf_ruleset_set(ctx, &ruleset.chains, &ruleset.hookopts);
         if (r)
             bf_err_r(r, "failed to set ruleset");
     } else {
@@ -44,7 +44,7 @@ int bfc_ruleset_set(const struct bfc_opts *opts)
     return r;
 }
 
-int bfc_ruleset_get(const struct bfc_opts *opts)
+int bfc_ruleset_get(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     _clean_bf_list_ bf_list chains = bf_list_default(bf_chain_free, NULL);
     _clean_bf_list_ bf_list hookopts = bf_list_default(bf_hookopts_free, NULL);
@@ -52,7 +52,7 @@ int bfc_ruleset_get(const struct bfc_opts *opts)
 
     assert(opts);
 
-    r = bf_ruleset_get(&chains, &hookopts);
+    r = bf_ruleset_get(ctx, &chains, &hookopts);
     if (r < 0)
         return bf_err_r(r, "failed to request ruleset");
 
@@ -63,9 +63,9 @@ int bfc_ruleset_get(const struct bfc_opts *opts)
     return 0;
 }
 
-int bfc_ruleset_flush(const struct bfc_opts *opts)
+int bfc_ruleset_flush(const struct bfc_opts *opts, const struct bf_ctx *ctx)
 {
     (void)opts;
 
-    return bf_ruleset_flush();
+    return bf_ruleset_flush(ctx);
 }

--- a/src/bfcli/ruleset.h
+++ b/src/bfcli/ruleset.h
@@ -27,10 +27,11 @@ struct bfc_ruleset
     bf_list hookopts;
 };
 
+struct bf_ctx;
 struct bfc_opts;
 
 void bfc_ruleset_clean(struct bfc_ruleset *ruleset);
 
-int bfc_ruleset_set(const struct bfc_opts *opts);
-int bfc_ruleset_get(const struct bfc_opts *opts);
-int bfc_ruleset_flush(const struct bfc_opts *opts);
+int bfc_ruleset_set(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_ruleset_get(const struct bfc_opts *opts, const struct bf_ctx *ctx);
+int bfc_ruleset_flush(const struct bfc_opts *opts, const struct bf_ctx *ctx);

--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -39,7 +39,7 @@ set(libbpfilter_srcs
     ${CMAKE_CURRENT_SOURCE_DIR}/chain.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cli.c
     ${CMAKE_CURRENT_SOURCE_DIR}/counter.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/ctx.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/ctx.h              ${CMAKE_CURRENT_SOURCE_DIR}/ctx.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dump.c
     ${CMAKE_CURRENT_SOURCE_DIR}/cgen/elfstub.c
     ${CMAKE_CURRENT_SOURCE_DIR}/flavor.c

--- a/src/libbpfilter/btf.c
+++ b/src/libbpfilter/btf.c
@@ -11,67 +11,54 @@
 #include <errno.h>
 #include <limits.h>
 #include <stddef.h>
-#include <stdlib.h>
 
 #include "bpfilter/helper.h"
 #include "bpfilter/logger.h"
 
-static struct btf *_bf_btf = NULL;
-
-int bf_btf_setup(void)
-{
-    _bf_btf = btf__load_vmlinux_btf();
-    if (!_bf_btf)
-        return bf_err_r(errno, "failed to load vmlinux BTF");
-
-    return 0;
-}
-
-void bf_btf_teardown(void)
-{
-    btf__free(_bf_btf);
-    _bf_btf = NULL;
-}
-
-int bf_btf_get_id(const char *name)
+int bf_btf_get_id(const struct btf *btf, const char *name)
 {
     int id;
 
+    assert(btf);
     assert(name);
 
-    id = btf__find_by_name(_bf_btf, name);
+    id = btf__find_by_name(btf, name);
     if (id < 0)
         return bf_err_r(errno, "failed to find BTF type for \"%s\"", name);
 
     return id;
 }
 
-const char *bf_btf_get_name(int id)
+const char *bf_btf_get_name(const struct btf *btf, int id)
 {
     const struct btf_type *type;
 
-    type = btf__type_by_id(_bf_btf, id);
+    assert(btf);
+
+    type = btf__type_by_id(btf, id);
     if (!type) {
         bf_warn("can't find BTF type ID %d", id);
         return NULL;
     }
 
-    return btf__name_by_offset(_bf_btf, type->name_off);
+    return btf__name_by_offset(btf, type->name_off);
 }
 
-int bf_btf_kernel_has_token(void)
+int bf_btf_kernel_has_token(const struct btf *btf)
 {
     int bpf_attr_id;
     const struct btf_type *bpf_attr_type;
     const struct btf_member *bpf_attr_members;
 
-    bpf_attr_id = btf__find_by_name_kind(_bf_btf, "bpf_attr", BTF_KIND_UNION);
+    assert(btf);
+
+    bpf_attr_id = btf__find_by_name_kind(btf, "bpf_attr", BTF_KIND_UNION);
     if (bpf_attr_id < 0) {
         return bf_err_r(bpf_attr_id,
                         "can't find structure 'bpf_attr' in kernel BTF");
     }
 
-    bpf_attr_type = btf__type_by_id(_bf_btf, bpf_attr_id);
+    bpf_attr_type = btf__type_by_id(btf, bpf_attr_id);
     if (!bpf_attr_type)
         return bf_err_r(-EINVAL, "failed to request 'bpf_attr' BTF type");
 
@@ -79,7 +66,7 @@ int bf_btf_kernel_has_token(void)
     // Iterate through union members
     for (unsigned short i = 0; i < btf_vlen(bpf_attr_type); i++) {
         const struct btf_type *member_type =
-            btf__type_by_id(_bf_btf, bpf_attr_members[i].type);
+            btf__type_by_id(btf, bpf_attr_members[i].type);
         const struct btf_member *m_members = btf_members(member_type);
 
         // We are looking for an anonymous structure
@@ -88,7 +75,7 @@ int bf_btf_kernel_has_token(void)
 
         for (int j = 0; j < btf_vlen(member_type); j++) {
             const char *member_name =
-                btf__name_by_offset(_bf_btf, m_members[j].name_off);
+                btf__name_by_offset(btf, m_members[j].name_off);
 
             if (member_name && bf_streq(member_name, "prog_token_fd"))
                 return 0;
@@ -105,20 +92,23 @@ int bf_btf_kernel_has_token(void)
 /**
  * @brief Find the offset of `field_name` in BTF type ID `compound_id`.
  *
+ * @param btf Loaded kernel BTF object. Can't be NULL.
  * @param compound_id Compound BTF type id.
  * @param field_name Name of the field to find the offset of. Can't be NULL.
  * @return Offset (in bits) of `field_name` in `compound_id` BTF type.
  */
-static ssize_t _bf_btf_offset_in_compound(uint32_t compound_id,
+static ssize_t _bf_btf_offset_in_compound(const struct btf *btf,
+                                          uint32_t compound_id,
                                           const char *field_name)
 {
     ssize_t offset;
     const struct btf_type *compound_type, *member_type;
     const struct btf_member *member;
 
+    assert(btf);
     assert(field_name);
 
-    compound_type = btf__type_by_id(_bf_btf, compound_id);
+    compound_type = btf__type_by_id(btf, compound_id);
     if (!compound_type)
         return -errno;
 
@@ -127,15 +117,15 @@ static ssize_t _bf_btf_offset_in_compound(uint32_t compound_id,
 
     member = (const struct btf_member *)(compound_type + 1);
     for (size_t i = 0; i < BTF_INFO_VLEN(compound_type->info); ++i, ++member) {
-        const char *name = btf__name_by_offset(_bf_btf, member->name_off);
+        const char *name = btf__name_by_offset(btf, member->name_off);
 
-        member_type = btf__type_by_id(_bf_btf, member->type);
+        member_type = btf__type_by_id(btf, member->type);
         if (!member_type)
             return -errno;
 
         // Member is an anonymous compound type? Check its members
         if (*name == '\0' && _bf_btf_type_is_compound(member_type)) {
-            offset = _bf_btf_offset_in_compound(member->type, field_name);
+            offset = _bf_btf_offset_in_compound(btf, member->type, field_name);
             if (offset < 0)
                 continue;
 
@@ -166,36 +156,40 @@ static ssize_t _bf_btf_offset_in_compound(uint32_t compound_id,
     return -EINVAL;
 }
 
-static int _bf_btf_get_compound_type_id(const char *name)
+static int _bf_btf_get_compound_type_id(const struct btf *btf, const char *name)
 {
     int compound_id;
 
-    compound_id = btf__find_by_name_kind(_bf_btf, name, BTF_KIND_STRUCT);
+    assert(btf);
+
+    compound_id = btf__find_by_name_kind(btf, name, BTF_KIND_STRUCT);
     if (compound_id < 0 && compound_id != -ENOENT)
         return compound_id;
     if (compound_id >= 0)
         return compound_id;
 
-    compound_id = btf__find_by_name_kind(_bf_btf, name, BTF_KIND_UNION);
+    compound_id = btf__find_by_name_kind(btf, name, BTF_KIND_UNION);
     if (compound_id < 0 && compound_id != -ENOENT)
         return compound_id;
 
     return compound_id;
 }
 
-int bf_btf_get_field_off(const char *struct_name, const char *field_name)
+int bf_btf_get_field_off(const struct btf *btf, const char *struct_name,
+                         const char *field_name)
 {
     int id;
     ssize_t offset;
 
+    assert(btf);
     assert(struct_name);
     assert(field_name);
 
-    id = _bf_btf_get_compound_type_id(struct_name);
+    id = _bf_btf_get_compound_type_id(btf, struct_name);
     if (id < 0)
         return bf_err_r(id, "failed to find BTF type ID for '%s'", struct_name);
 
-    offset = _bf_btf_offset_in_compound(id, field_name);
+    offset = _bf_btf_offset_in_compound(btf, id, field_name);
     if (offset < 0) {
         return bf_err_r((int)offset, "failed to find offset of %s.%s",
                         struct_name, field_name);

--- a/src/libbpfilter/cgen/cgen.c
+++ b/src/libbpfilter/cgen/cgen.c
@@ -30,6 +30,7 @@
 #include "cgen/prog/link.h"
 #include "cgen/prog/map.h"
 #include "cgen/program.h"
+#include "core/ctx.h"
 #include "core/lock.h"
 
 #define _BF_PROG_NAME "bf_prog"
@@ -72,8 +73,8 @@ static int _bf_cgen_persist(const struct bf_cgen *cgen, int dir_fd)
     if (r)
         return bf_err_r(r, "failed to get data from bf_cgen wpack");
 
-    r = bf_map_new(&map, _BF_CTX_PIN_NAME, BF_MAP_TYPE_CTX, sizeof(uint32_t),
-                   data_len, 1);
+    r = bf_map_new(&map, cgen->ctx->token_fd, _BF_CTX_PIN_NAME, BF_MAP_TYPE_CTX,
+                   sizeof(uint32_t), data_len, 1);
     if (r)
         return bf_err_r(r, "failed to create context map");
 
@@ -98,19 +99,23 @@ static int _bf_cgen_persist(const struct bf_cgen *cgen, int dir_fd)
     return 0;
 }
 
-static int _bf_cgen_new_from_pack(struct bf_cgen **cgen, struct bf_lock *lock,
-                                  bf_rpack_node_t node)
+static int _bf_cgen_new_from_pack(struct bf_cgen **cgen,
+                                  const struct bf_ctx *ctx,
+                                  struct bf_lock *lock, bf_rpack_node_t node)
 {
     _free_bf_cgen_ struct bf_cgen *_cgen = NULL;
     bf_rpack_node_t child;
     int r;
 
     assert(cgen);
+    assert(ctx);
     assert(lock);
 
     _cgen = calloc(1, sizeof(*_cgen));
     if (!_cgen)
         return -ENOMEM;
+
+    _cgen->ctx = ctx;
 
     r = bf_rpack_kv_obj(node, "chain", &child);
     if (r)
@@ -133,7 +138,8 @@ static int _bf_cgen_new_from_pack(struct bf_cgen **cgen, struct bf_lock *lock,
     return 0;
 }
 
-int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, struct bf_lock *lock)
+int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, const struct bf_ctx *ctx,
+                            struct bf_lock *lock)
 {
     _free_bf_rpack_ bf_rpack_t *pack = NULL;
     _cleanup_close_ int map_fd = -1;
@@ -143,6 +149,7 @@ int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, struct bf_lock *lock)
     int r;
 
     assert(cgen);
+    assert(ctx);
     assert(lock);
 
     r = bf_bpf_obj_get(_BF_CTX_PIN_NAME, lock->chain_fd, &map_fd);
@@ -168,25 +175,28 @@ int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, struct bf_lock *lock)
     if (r)
         return bf_err_r(r, "failed to create rpack for bf_cgen");
 
-    r = _bf_cgen_new_from_pack(cgen, lock, bf_rpack_root(pack));
+    r = _bf_cgen_new_from_pack(cgen, ctx, lock, bf_rpack_root(pack));
     if (r)
         return bf_err_r(r, "failed to deserialize cgen from context map");
 
     return 0;
 }
 
-int bf_cgen_new(struct bf_cgen **cgen, struct bf_chain **chain)
+int bf_cgen_new(struct bf_cgen **cgen, const struct bf_ctx *ctx,
+                struct bf_chain **chain)
 {
     _free_bf_cgen_ struct bf_cgen *_cgen = NULL;
     int r;
 
     assert(cgen);
+    assert(ctx);
     assert(chain);
 
     _cgen = calloc(1, sizeof(*_cgen));
     if (!_cgen)
         return -ENOMEM;
 
+    _cgen->ctx = ctx;
     _cgen->chain = TAKE_PTR(*chain);
 
     r = bf_handle_new(&_cgen->handle, _BF_PROG_NAME);
@@ -317,7 +327,7 @@ int bf_cgen_set(struct bf_cgen *cgen, struct bf_hookopts **hookopts,
     assert(cgen);
     assert(lock);
 
-    r = bf_program_new(&prog, cgen->chain, cgen->handle);
+    r = bf_program_new(&prog, cgen->ctx, cgen->chain, cgen->handle);
     if (r < 0)
         return r;
 
@@ -357,7 +367,7 @@ int bf_cgen_load(struct bf_cgen *cgen, struct bf_lock *lock)
     assert(cgen);
     assert(lock);
 
-    r = bf_program_new(&prog, cgen->chain, cgen->handle);
+    r = bf_program_new(&prog, cgen->ctx, cgen->chain, cgen->handle);
     if (r < 0)
         return r;
 
@@ -484,7 +494,7 @@ int bf_cgen_update(struct bf_cgen *cgen, struct bf_chain **new_chain,
     if (r)
         return r;
 
-    r = bf_program_new(&new_prog, *new_chain, new_handle);
+    r = bf_program_new(&new_prog, cgen->ctx, *new_chain, new_handle);
     if (r < 0)
         return bf_err_r(r, "failed to create a new bf_program");
 

--- a/src/libbpfilter/cgen/cgen.h
+++ b/src/libbpfilter/cgen/cgen.h
@@ -13,6 +13,7 @@
 #include <bpfilter/pack.h>
 
 struct bf_chain;
+struct bf_ctx;
 struct bf_handle;
 struct bf_hookopts;
 struct bf_lock;
@@ -27,6 +28,11 @@ struct bf_lock;
  */
 struct bf_cgen
 {
+    /// Runtime context the cgen was created with. Borrowed pointer used to
+    /// reach context-level state (token fd, ELF stubs, verbose flags) from
+    /// the generated `bf_program`.
+    const struct bf_ctx *ctx;
+
     /// Chain containing the rules, sets, and policy.
     struct bf_chain *chain;
 
@@ -38,16 +44,27 @@ struct bf_cgen
 };
 
 /**
- * Allocate and initialise a new codegen.
+ * @brief Allocate and initialise a new codegen.
  *
- * @param cgen Codegen to allocate and initialise. Can't be NULL.
+ * @pre
+ *  - `cgen` is not NULL.
+ *  - `ctx` is not NULL and has been initialized.
+ *  - `chain` is not NULL and `*chain` points to a valid `bf_chain`.
+ * @post
+ *  - On success: `*cgen` owns the chain (`*chain == NULL`) and stores
+ *    `ctx` as a borrowed pointer.
+ *  - On failure: `*cgen` and `*chain` are unchanged.
+ *
+ * @param cgen Codegen to allocate and initialise.
+ * @param ctx Runtime context the new codegen will hold a borrowed pointer
+ *        to.
  * @param chain Chain containing the codegen's rules, sets, and policy. On
- *        success, the new codegen will take ownership of the chain, and
- *        @c *chain will be NULL. Can't be NULL, and @c *chain must point to
- *        a valid @ref bf_chain .
- * @return 0 on success, or negative errno value on failure.
+ *        success, the new codegen takes ownership of the chain and
+ *        `*chain` is set to NULL.
+ * @return 0 on success, or a negative errno value on failure.
  */
-int bf_cgen_new(struct bf_cgen **cgen, struct bf_chain **chain);
+int bf_cgen_new(struct bf_cgen **cgen, const struct bf_ctx *ctx,
+                struct bf_chain **chain);
 
 /**
  * @brief Allocate and initialize a codegen from a pinned context map.
@@ -55,12 +72,22 @@ int bf_cgen_new(struct bf_cgen **cgen, struct bf_chain **chain);
  * Opens the `bf_ctx` context map pinned in the chain directory referenced by
  * `lock`, reads the serialized cgen data, and deserializes it.
  *
- * @param cgen Codegen to allocate and initialize. Can't be NULL.
- * @param lock Lock providing the chain directory file descriptor. Must hold
- *        a valid `chain_fd`. Can't be NULL.
+ * @pre
+ *  - `cgen` is not NULL.
+ *  - `ctx` is not NULL.
+ *  - `lock` is not NULL and has a valid `chain_fd`.
+ * @post
+ *  - On success: `*cgen` stores `ctx` as a borrowed pointer.
+ *  - On failure: `*cgen` is unchanged.
+ *
+ * @param cgen Codegen to allocate and initialize.
+ * @param ctx Runtime context the new codegen will hold a borrowed pointer
+ *        to.
+ * @param lock Lock providing the chain directory file descriptor.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, struct bf_lock *lock);
+int bf_cgen_new_from_dir_fd(struct bf_cgen **cgen, const struct bf_ctx *ctx,
+                            struct bf_lock *lock);
 
 /**
  * Free a codegen.

--- a/src/libbpfilter/cgen/cgroup_skb.c
+++ b/src/libbpfilter/cgen/cgroup_skb.c
@@ -23,6 +23,7 @@
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "cgen/swich.h"
+#include "core/ctx.h"
 #include "filter.h"
 #include "linux/bpf.h"
 
@@ -51,7 +52,8 @@ static int _bf_cgroup_skb_gen_inline_prologue(struct bf_program *program)
      * @c ingress_ifindex will contain @c 1 but @c ifindex will contains @c 2 .
      * For egress, only @c ifindex is used.
      */
-    if ((r = bf_btf_get_field_off("__sk_buff", "ifindex")) < 0)
+    if ((r = bf_btf_get_field_off(program->ctx->btf, "__sk_buff", "ifindex")) <
+        0)
         return r;
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1, r));
     EMIT(program,
@@ -61,7 +63,8 @@ static int _bf_cgroup_skb_gen_inline_prologue(struct bf_program *program)
      * so we can't parse it and discover the L3 protocol ID.
      * Instead, we use the __sk_buff.family value and convert it to the
      * corresponding ethertype. */
-    if ((offset = bf_btf_get_field_off("__sk_buff", "family")) < 0)
+    if ((offset = bf_btf_get_field_off(program->ctx->btf, "__sk_buff",
+                                       "family")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1, offset));
 

--- a/src/libbpfilter/cgen/dump.c
+++ b/src/libbpfilter/cgen/dump.c
@@ -19,6 +19,7 @@
 #include <bpfilter/logger.h>
 
 #include "cgen/program.h"
+#include "core/ctx.h"
 #include "disasm.h"
 
 #define SYM_MAX_NAME 256
@@ -26,6 +27,7 @@
 struct bf_dump_data
 {
     prefix_t *prefix;
+    const struct btf *btf;
     char scratch_buff[SYM_MAX_NAME + 8];
     unsigned long address_call_base;
     size_t idx;
@@ -56,7 +58,7 @@ static const char *_bf_print_call(void *private_data,
                        insn->imm);
     } else {
         (void)snprintf(bfdd->scratch_buff, sizeof(bfdd->scratch_buff), "%s",
-                       bf_btf_get_name(insn->imm));
+                       bf_btf_get_name(bfdd->btf, insn->imm));
     }
 
     return bfdd->scratch_buff;
@@ -92,6 +94,7 @@ void bf_program_dump_bytecode(const struct bf_program *program)
     prefix_t prefix = {};
     struct bf_dump_data bfdd = {
         .prefix = &prefix,
+        .btf = program->ctx->btf,
     };
     struct bpf_insn_cbs callbacks = {
         .cb_print = _bf_print_insn,

--- a/src/libbpfilter/cgen/elfstub.c
+++ b/src/libbpfilter/cgen/elfstub.c
@@ -43,7 +43,7 @@ static void _bf_printk_str_free(struct bf_printk_str **pstr)
     freep((void *)pstr);
 }
 
-static int _bf_elfstub_prepare(struct bf_elfstub *stub,
+static int _bf_elfstub_prepare(struct bf_elfstub *stub, const struct btf *btf,
                                const struct bf_rawstub *raw)
 {
     const Elf64_Ehdr *ehdr = raw->elf;
@@ -145,7 +145,7 @@ static int _bf_elfstub_prepare(struct bf_elfstub *stub,
                 uint32_t name_idx = symbols[sym_idx].st_name;
                 if (name_idx < symstrtab->sh_size) {
                     const char *name = &sym_strtab[name_idx];
-                    int id = bf_btf_get_id(name);
+                    int id = bf_btf_get_id(btf, name);
                     if (id < 0)
                         return bf_err_r(id, "function %s not found", name);
 
@@ -183,12 +183,14 @@ static int _bf_elfstub_prepare(struct bf_elfstub *stub,
     return 0;
 }
 
-int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id)
+int bf_elfstub_new(struct bf_elfstub **stub, const struct btf *btf,
+                   enum bf_elfstub_id id)
 {
     _free_bf_elfstub_ struct bf_elfstub *_stub = NULL;
     int r;
 
     assert(stub);
+    assert(btf);
 
     _stub = calloc(1, sizeof(*_stub));
     if (!_stub)
@@ -196,7 +198,7 @@ int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id)
 
     _stub->strs = bf_list_default(_bf_printk_str_free, NULL);
 
-    r = _bf_elfstub_prepare(_stub, &_bf_rawstubs[id]);
+    r = _bf_elfstub_prepare(_stub, btf, &_bf_rawstubs[id]);
     if (r)
         return r;
 

--- a/src/libbpfilter/cgen/nf.c
+++ b/src/libbpfilter/cgen/nf.c
@@ -28,6 +28,7 @@
 #include "cgen/program.h"
 #include "cgen/stub.h"
 #include "cgen/swich.h"
+#include "core/ctx.h"
 #include "filter.h"
 
 #define BF_NF_PRIO_EVEN 2
@@ -50,20 +51,24 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
     assert(program);
 
     // Copy the ifindex from to bpf_nf_ctx.state.{in,out}.ifindex the runtime context
-    if ((offset = bf_btf_get_field_off("bpf_nf_ctx", "state")) < 0)
+    if ((offset = bf_btf_get_field_off(program->ctx->btf, "bpf_nf_ctx",
+                                       "state")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_1, offset));
     if (_bf_nf_hook_is_ingress(program->runtime.chain->hook)) {
-        if ((offset = bf_btf_get_field_off("nf_hook_state", "in")) < 0)
+        if ((offset = bf_btf_get_field_off(program->ctx->btf, "nf_hook_state",
+                                           "in")) < 0)
             return offset;
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_3, BPF_REG_2, offset));
     } else {
-        if ((offset = bf_btf_get_field_off("nf_hook_state", "out")) < 0)
+        if ((offset = bf_btf_get_field_off(program->ctx->btf, "nf_hook_state",
+                                           "out")) < 0)
             return offset;
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_3, BPF_REG_2, offset));
     }
 
-    if ((offset = bf_btf_get_field_off("net_device", "ifindex")) < 0)
+    if ((offset = bf_btf_get_field_off(program->ctx->btf, "net_device",
+                                       "ifindex")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_4, BPF_REG_3, offset));
     EMIT(program,
@@ -73,7 +78,8 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
      * so we can't parse it and discover the L3 protocol ID.
      * Instead, we use the __sk_buff.family value and convert it to the
      * corresponding ethertype. */
-    if ((offset = bf_btf_get_field_off("nf_hook_state", "pf")) < 0)
+    if ((offset = bf_btf_get_field_off(program->ctx->btf, "nf_hook_state",
+                                       "pf")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_B, BPF_REG_3, BPF_REG_2, offset));
 
@@ -95,10 +101,12 @@ static int _bf_nf_gen_inline_prologue(struct bf_program *program)
     EMIT(program, BPF_ST_MEM(BPF_W, BPF_REG_10, BF_PROG_CTX_OFF(l3_offset), 0));
 
     // Calculate the packet size (+ETH_HLEN) and store it into the runtime context
-    if ((offset = bf_btf_get_field_off("bpf_nf_ctx", "skb")) < 0)
+    if ((offset =
+             bf_btf_get_field_off(program->ctx->btf, "bpf_nf_ctx", "skb")) < 0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_1, offset));
-    if ((offset = bf_btf_get_field_off("sk_buff", "len")) < 0)
+    if ((offset = bf_btf_get_field_off(program->ctx->btf, "sk_buff", "len")) <
+        0)
         return offset;
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1, offset));
     EMIT(program, BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, ETH_HLEN));
@@ -139,10 +147,12 @@ static int _bf_nf_gen_inline_matcher(struct bf_program *program,
     case BF_MATCHER_META_MARK:
         EMIT(program,
              BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_10, BF_PROG_CTX_OFF(arg)));
-        if ((offset = bf_btf_get_field_off("bpf_nf_ctx", "skb")) < 0)
+        if ((offset = bf_btf_get_field_off(program->ctx->btf, "bpf_nf_ctx",
+                                           "skb")) < 0)
             return offset;
         EMIT(program, BPF_LDX_MEM(BPF_DW, BPF_REG_2, BPF_REG_1, offset));
-        if ((offset = bf_btf_get_field_off("sk_buff", "mark")) < 0)
+        if ((offset = bf_btf_get_field_off(program->ctx->btf, "sk_buff",
+                                           "mark")) < 0)
             return offset;
         EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_2, offset));
 

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -60,7 +60,7 @@ static void _bf_btf_free(struct bf_btf **btf)
     freep((void *)btf);
 }
 
-static int _bf_btf_load(struct bf_btf *btf)
+static int _bf_btf_load(struct bf_btf *btf, int token_fd)
 {
     union bpf_attr attr = {};
     const void *raw;
@@ -72,7 +72,7 @@ static int _bf_btf_load(struct bf_btf *btf)
     if (!raw)
         return bf_err_r(errno, "failed to request BTF raw data");
 
-    r = bf_bpf_btf_load(raw, attr.btf_size, bf_ctx_token());
+    r = bf_bpf_btf_load(raw, attr.btf_size, token_fd);
     if (r < 0)
         return r;
 
@@ -89,7 +89,7 @@ static int _bf_btf_load(struct bf_btf *btf)
  * @return A @ref bf_btf structure on success, or NULL on error. The
  *         @ref bf_btf structure is owned by the caller.
  */
-static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
+static struct bf_btf *_bf_map_make_btf(const struct bf_map *map, int token_fd)
 {
     _free_bf_btf_ struct bf_btf *btf = NULL;
     struct btf *kbtf;
@@ -122,7 +122,7 @@ static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
         return NULL;
     }
 
-    r = _bf_btf_load(btf);
+    r = _bf_btf_load(btf, token_fd);
     if (r) {
         bf_warn_r(r, "failed to load BTF data for %s, ignoring", map->name);
         return NULL;
@@ -131,7 +131,7 @@ static struct bf_btf *_bf_map_make_btf(const struct bf_map *map)
     return TAKE_PTR(btf);
 }
 
-static int _bf_map_new(struct bf_map **map, const char *name,
+static int _bf_map_new(struct bf_map **map, int token_fd, const char *name,
                        enum bf_map_type type, enum bf_bpf_map_type bpf_type,
                        size_t key_size, size_t value_size, size_t n_elems)
 {
@@ -173,11 +173,10 @@ static int _bf_map_new(struct bf_map **map, const char *name,
 
     bf_strncpy(_map->name, BPF_OBJ_NAME_LEN, name);
 
-    btf = _bf_map_make_btf(_map);
+    btf = _bf_map_make_btf(_map, token_fd);
 
-    fd =
-        bf_bpf_map_create(_map->name, _map->bpf_type, _map->key_size,
-                          _map->value_size, _map->n_elems, btf, bf_ctx_token());
+    fd = bf_bpf_map_create(_map->name, _map->bpf_type, _map->key_size,
+                           _map->value_size, _map->n_elems, btf, token_fd);
     if (fd < 0)
         return bf_err_r(fd, "bf_map %s: failed to create map", name);
 
@@ -187,8 +186,9 @@ static int _bf_map_new(struct bf_map **map, const char *name,
     return 0;
 }
 
-int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
-               size_t key_size, size_t value_size, size_t n_elems)
+int bf_map_new(struct bf_map **map, int token_fd, const char *name,
+               enum bf_map_type type, size_t key_size, size_t value_size,
+               size_t n_elems)
 {
     static enum bf_bpf_map_type _map_type_to_bpf[_BF_MAP_TYPE_MAX] = {
         [BF_MAP_TYPE_COUNTERS] = BF_BPF_MAP_TYPE_ARRAY,
@@ -206,11 +206,11 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
             "use bf_map_new_from_set() to create a bf_map from a bf_set");
     }
 
-    return _bf_map_new(map, name, type, _map_type_to_bpf[type], key_size,
-                       value_size, n_elems);
+    return _bf_map_new(map, token_fd, name, type, _map_type_to_bpf[type],
+                       key_size, value_size, n_elems);
 }
 
-int bf_map_new_from_set(struct bf_map **map, const char *name,
+int bf_map_new_from_set(struct bf_map **map, int token_fd, const char *name,
                         const struct bf_set *set, size_t n_elems,
                         size_t value_size)
 {
@@ -218,7 +218,7 @@ int bf_map_new_from_set(struct bf_map **map, const char *name,
     assert(name);
     assert(set);
 
-    return _bf_map_new(map, name, BF_MAP_TYPE_SET,
+    return _bf_map_new(map, token_fd, name, BF_MAP_TYPE_SET,
                        set->use_trie ? BF_BPF_MAP_TYPE_LPM_TRIE :
                                        BF_BPF_MAP_TYPE_HASH,
                        set->elem_size, value_size, n_elems);

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -86,6 +86,8 @@ static int _bf_btf_load(struct bf_btf *btf, int token_fd)
  *
  * @param map Map to create the BTF data for. @c map.type will define the
  *        exact content of the BTF object. Can't be NULL.
+ * @param token_fd BPF token file descriptor passed to the kernel BTF-load
+ *        syscall. `-1` if no token is to be used.
  * @return A @ref bf_btf structure on success, or NULL on error. The
  *         @ref bf_btf structure is owned by the caller.
  */

--- a/src/libbpfilter/cgen/prog/map.h
+++ b/src/libbpfilter/cgen/prog/map.h
@@ -49,6 +49,8 @@ struct bf_map
  * @param map BPF map object to allocate and initialize. Can't be NULL. On
  *        success, `*map` points to a valid `bf_map`. On failure,
  *        `*map` remain unchanged.
+ * @param token_fd BPF token file descriptor passed to the kernel
+ *        map-creation syscall. `-1` if no token is to be used.
  * @param name Name of the map. Will be used as the name of the BPF object, but
  *        also as filename when pinning the map to the system. Can't be NULL or
  *        empty.
@@ -58,8 +60,9 @@ struct bf_map
  * @param n_elems Number of elements to reserve room for in the map.
  * @return 0 on success, or a negative errno value on error.
  */
-int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
-               size_t key_size, size_t value_size, size_t n_elems);
+int bf_map_new(struct bf_map **map, int token_fd, const char *name,
+               enum bf_map_type type, size_t key_size, size_t value_size,
+               size_t n_elems);
 
 /**
  * @brief Allocate and initialise a new BPF map object, from a set.
@@ -67,6 +70,8 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
  * @param map BPF map object to allocate and initialize. Can't be NULL. On
  *        success, `*map` points to a valid `bf_map`. On failure, `*map`
  *        remain unchanged. Can't be NULL.
+ * @param token_fd BPF token file descriptor passed to the kernel
+ *        map-creation syscall. `-1` if no token is to be used.
  * @param name Name of the map. Will be used as the name of the BPF object, but
  *        also as filename when pinning the map to the system. Can't be NULL or
  *        empty.
@@ -75,7 +80,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
  * @param value_size Size (in bytes) of the value field.
  * @return 0 on success, or a negative error value on error.
  */
-int bf_map_new_from_set(struct bf_map **map, const char *name,
+int bf_map_new_from_set(struct bf_map **map, int token_fd, const char *name,
                         const struct bf_set *set, size_t n_elems,
                         size_t value_size);
 

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -698,7 +698,7 @@ int bf_program_emit_kfunc_call(struct bf_program *program, const char *name)
     assert(program);
     assert(name);
 
-    r = bf_btf_get_id(name);
+    r = bf_btf_get_id(program->ctx->btf, name);
     if (r < 0)
         return r;
 

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -50,6 +50,7 @@
 #include "cgen/stub.h"
 #include "cgen/tc.h"
 #include "cgen/xdp.h"
+#include "core/ctx.h"
 #include "filter.h"
 
 #define _BF_LOG_BUF_SIZE                                                       \
@@ -252,13 +253,14 @@ static const struct bf_flavor_ops *bf_flavor_ops_get(enum bf_flavor flavor)
     return flavor_ops[flavor];
 }
 
-int bf_program_new(struct bf_program **program, const struct bf_chain *chain,
-                   struct bf_handle *handle)
+int bf_program_new(struct bf_program **program, const struct bf_ctx *ctx,
+                   const struct bf_chain *chain, struct bf_handle *handle)
 {
     _free_bf_program_ struct bf_program *_program = NULL;
     int r;
 
     assert(program);
+    assert(ctx);
     assert(chain);
     assert(handle);
 
@@ -266,6 +268,7 @@ int bf_program_new(struct bf_program **program, const struct bf_chain *chain,
     if (!_program)
         return -ENOMEM;
 
+    _program->ctx = ctx;
     _program->flavor = bf_hook_to_flavor(chain->hook);
     _program->runtime.ops = bf_flavor_ops_get(_program->flavor);
     _program->runtime.chain = chain;
@@ -630,7 +633,7 @@ static int _bf_program_generate_elfstubs(struct bf_program *program)
 
         bf_dbg("generate ELF stub for ID %d", fixup->attr.elfstub_id);
 
-        elfstub = bf_ctx_get_elfstub(fixup->attr.elfstub_id);
+        elfstub = program->ctx->stubs[fixup->attr.elfstub_id];
         if (!elfstub) {
             return bf_err_r(-ENOENT, "no ELF stub found for ID %d",
                             fixup->attr.elfstub_id);
@@ -842,8 +845,9 @@ static int _bf_program_load_printer_map(struct bf_program *program)
     if (r)
         return bf_err_r(r, "failed to assemble printer map string");
 
-    r = bf_map_new(&program->handle->pmap, _BF_PRINTER_MAP_NAME,
-                   BF_MAP_TYPE_PRINTER, sizeof(uint32_t), pstr_len, 1);
+    r = bf_map_new(&program->handle->pmap, program->ctx->token_fd,
+                   _BF_PRINTER_MAP_NAME, BF_MAP_TYPE_PRINTER, sizeof(uint32_t),
+                   pstr_len, 1);
     if (r)
         return bf_err_r(r, "failed to create the printer bf_map object");
 
@@ -864,8 +868,8 @@ static int _bf_program_load_counters_map(struct bf_program *program)
 
     assert(program);
 
-    r = bf_map_new(&program->handle->cmap, _BF_COUNTER_MAP_NAME,
-                   BF_MAP_TYPE_COUNTERS, sizeof(uint32_t),
+    r = bf_map_new(&program->handle->cmap, program->ctx->token_fd,
+                   _BF_COUNTER_MAP_NAME, BF_MAP_TYPE_COUNTERS, sizeof(uint32_t),
                    sizeof(struct bf_counter),
                    bf_list_size(&program->runtime.chain->rules) + 2);
     if (r)
@@ -888,8 +892,8 @@ static int _bf_program_load_log_map(struct bf_program *program)
     if (!(program->runtime.chain->flags & BF_FLAG(BF_CHAIN_LOG)))
         return 0;
 
-    r = bf_map_new(&program->handle->lmap, _BF_LOG_MAP_NAME, BF_MAP_TYPE_LOG, 0,
-                   0, _BF_LOG_MAP_SIZE);
+    r = bf_map_new(&program->handle->lmap, program->ctx->token_fd,
+                   _BF_LOG_MAP_NAME, BF_MAP_TYPE_LOG, 0, 0, _BF_LOG_MAP_SIZE);
     if (r)
         return bf_err_r(r, "failed to create the log bf_map object");
 
@@ -944,8 +948,8 @@ static int _bf_program_load_sets_maps(struct bf_program *new_prog)
         (void)snprintf(name, BPF_OBJ_NAME_LEN, _BF_SET_MAP_PREFIX "%04x",
                        (uint16_t)map_idx++);
 
-        r = bf_map_new_from_set(&new_map, name, key_set, total_elems,
-                                value_size);
+        r = bf_map_new_from_set(&new_map, new_prog->ctx->token_fd, name,
+                                key_set, total_elems, value_size);
         if (r)
             return r;
 
@@ -1017,7 +1021,7 @@ int bf_program_load(struct bf_program *prog)
                          prog->img.data, prog->img.size,
                          bf_hook_to_bpf_attach_type(prog->runtime.chain->hook),
                          log_buf, log_buf ? _BF_LOG_BUF_SIZE : 0,
-                         bf_ctx_token(), &prog->handle->prog_fd);
+                         prog->ctx->token_fd, &prog->handle->prog_fd);
     if (r) {
         return bf_err_r(r, "failed to load bf_program (%lu insns):\n%s\nerrno:",
                         prog->img.size, log_buf ? log_buf : "<NO LOG BUFFER>");

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -1001,7 +1001,7 @@ int bf_program_load(struct bf_program *prog)
     if (r)
         return bf_err_r(r, "failed to load the log map");
 
-    if (bf_ctx_is_verbose(BF_VERBOSE_DEBUG)) {
+    if (bf_logger_is_verbose(BF_VERBOSE_DEBUG)) {
         log_buf = malloc(_BF_LOG_BUF_SIZE);
         if (!log_buf) {
             return bf_err_r(-ENOMEM,
@@ -1009,7 +1009,7 @@ int bf_program_load(struct bf_program *prog)
         }
     }
 
-    if (bf_ctx_is_verbose(BF_VERBOSE_BYTECODE))
+    if (bf_logger_is_verbose(BF_VERBOSE_BYTECODE))
         bf_program_dump_bytecode(prog);
 
     r = bf_bpf_prog_load(prog->handle->prog_name,

--- a/src/libbpfilter/cgen/program.h
+++ b/src/libbpfilter/cgen/program.h
@@ -188,6 +188,7 @@
 
 struct bf_chain;
 struct bf_counter;
+struct bf_ctx;
 struct bf_hookopts;
 struct bf_handle;
 struct bf_set;
@@ -195,6 +196,11 @@ struct bf_set_group;
 
 struct bf_program
 {
+    /// Runtime context the program was generated for. Borrowed pointer
+    /// used to reach context-level state (token fd, ELF stubs, verbose
+    /// flags) during generation and load.
+    const struct bf_ctx *ctx;
+
     enum bf_flavor flavor;
 
     /// Log messages printer
@@ -235,14 +241,24 @@ struct bf_program
 /**
  * @brief Allocate and initialize a new `bf_program` object.
  *
- * @param program `bf_program` object to allocate and initialize. Can't be NULL.
- * @param chain Chain the program is generated from. Can't be NULL.
+ * @pre
+ *  - `program` is not NULL.
+ *  - `ctx` is not NULL.
+ *  - `chain` is not NULL.
+ *  - `handle` is not NULL.
+ * @post
+ *  - On success: `*program` stores `ctx` as a borrowed pointer.
+ *  - On failure: `*program` is unchanged.
+ *
+ * @param program `bf_program` object to allocate and initialize.
+ * @param ctx Runtime context the program will hold a borrowed pointer to.
+ * @param chain Chain the program is generated from.
  * @param handle Handle to store BPF object references in. The program borrows
- *        this pointer (non-owning). Can't be NULL.
+ *        this pointer (non-owning).
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_program_new(struct bf_program **program, const struct bf_chain *chain,
-                   struct bf_handle *handle);
+int bf_program_new(struct bf_program **program, const struct bf_ctx *ctx,
+                   const struct bf_chain *chain, struct bf_handle *handle);
 
 void bf_program_free(struct bf_program **program);
 

--- a/src/libbpfilter/cgen/stub.c
+++ b/src/libbpfilter/cgen/stub.c
@@ -74,7 +74,7 @@ static int _bf_stub_make_ctx_dynptr(struct bf_program *program, int arg_reg,
              BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
         EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
-        if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
+        if (bf_logger_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create a new dynamic pointer");
 
         r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
@@ -135,7 +135,7 @@ int bf_stub_parse_l2_ethhdr(struct bf_program *program)
              BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
         EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
-        if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
+        if (bf_logger_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L2 dynamic pointer slice");
 
         r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
@@ -212,7 +212,7 @@ int bf_stub_parse_l3_hdr(struct bf_program *program)
              BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
         EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
-        if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
+        if (bf_logger_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L3 dynamic pointer slice");
 
         r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);
@@ -373,7 +373,7 @@ int bf_stub_parse_l4_hdr(struct bf_program *program)
              BPF_MOV32_IMM(BPF_REG_3, bf_program_error_counter_idx(program)));
         EMIT_FIXUP_ELFSTUB(program, BF_ELFSTUB_UPDATE_COUNTERS);
 
-        if (bf_ctx_is_verbose(BF_VERBOSE_BPF))
+        if (bf_logger_is_verbose(BF_VERBOSE_BPF))
             EMIT_PRINT(program, "failed to create L4 dynamic pointer slice");
 
         r = program->runtime.ops->get_verdict(BF_VERDICT_ACCEPT, &ret_code);

--- a/src/libbpfilter/cgen/tc.c
+++ b/src/libbpfilter/cgen/tc.c
@@ -22,6 +22,7 @@
 #include "cgen/packet.h"
 #include "cgen/program.h"
 #include "cgen/stub.h"
+#include "core/ctx.h"
 #include "filter.h"
 
 static int _bf_tc_gen_inline_prologue(struct bf_program *program)
@@ -44,7 +45,8 @@ static int _bf_tc_gen_inline_prologue(struct bf_program *program)
      * @c ingress_ifindex will contain @c 1 but @c ifindex will contains @c 2 .
      * For egress, only @c ifindex is used.
      */
-    if ((r = bf_btf_get_field_off("__sk_buff", "ifindex")) < 0)
+    if ((r = bf_btf_get_field_off(program->ctx->btf, "__sk_buff", "ifindex")) <
+        0)
         return r;
     EMIT(program, BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1, r));
     EMIT(program,

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -49,19 +49,19 @@ static int copy_hookopts(struct bf_hookopts **dest,
 /**
  * @brief Unload every chain currently pinned in the pin directory.
  *
- * The caller must already hold a `BF_LOCK_WRITE` lock on the pin directory
- * (typically via `bf_lock_init(BF_LOCK_WRITE)`). For each chain entry, a
- * per-chain `BF_LOCK_WRITE` lock is acquired (so the chain dir is removed
- * by `bf_lock_release_chain` after unload).
+ * The caller must already hold a `BF_LOCK_WRITE` lock on the pin directory.
+ * For each chain entry, a per-chain `BF_LOCK_WRITE` lock is acquired (so
+ * the chain dir is removed by `bf_lock_release_chain` after unload).
  */
-static int _bf_ruleset_flush(struct bf_lock *lock)
+static int _bf_ruleset_flush(const struct bf_ctx *ctx, struct bf_lock *lock)
 {
     _free_bf_list_ bf_list *cgens = NULL;
     int r;
 
+    assert(ctx);
     assert(lock);
 
-    r = bf_ctx_get_cgens(lock, &cgens);
+    r = bf_ctx_get_cgens(ctx, lock, &cgens);
     if (r)
         return bf_err_r(r, "failed to discover chains during flush");
 
@@ -85,7 +85,7 @@ static int _bf_ruleset_flush(struct bf_lock *lock)
     return 0;
 }
 
-int bf_ruleset_get(bf_list *chains, bf_list *hookopts)
+int bf_ruleset_get(const struct bf_ctx *ctx, bf_list *chains, bf_list *hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_list_ bf_list *cgens = NULL;
@@ -93,11 +93,13 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts)
     _clean_bf_list_ bf_list _hookopts = bf_list_default_from(*hookopts);
     int r;
 
-    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ);
+    assert(ctx);
+
+    r = bf_lock_init(&lock, ctx->bpffs_path, BF_LOCK_READ);
     if (r)
         return bf_err_r(r, "failed to acquire READ lock for ruleset get");
 
-    r = bf_ctx_get_cgens(&lock, &cgens);
+    r = bf_ctx_get_cgens(ctx, &lock, &cgens);
     if (r < 0)
         return bf_err_r(r, "failed to get cgen list");
 
@@ -133,21 +135,23 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts)
     return 0;
 }
 
-int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
+int bf_ruleset_set(const struct bf_ctx *ctx, bf_list *chains, bf_list *hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     struct bf_list_node *chain_node = bf_list_get_head(chains);
     struct bf_list_node *hookopts_node = bf_list_get_head(hookopts);
     int r;
 
+    assert(ctx);
+
     if (bf_list_size(chains) != bf_list_size(hookopts))
         return -EINVAL;
 
-    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
+    r = bf_lock_init(&lock, ctx->bpffs_path, BF_LOCK_WRITE);
     if (r)
         return bf_err_r(r, "failed to acquire WRITE lock for ruleset set");
 
-    r = _bf_ruleset_flush(&lock);
+    r = _bf_ruleset_flush(ctx, &lock);
     if (r)
         return r;
 
@@ -169,7 +173,7 @@ int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
                 goto err_load;
         }
 
-        r = bf_cgen_new(&cgen, _bf_ctx_global(), &chain_copy);
+        r = bf_cgen_new(&cgen, ctx, &chain_copy);
         if (r)
             goto err_load;
 
@@ -197,23 +201,26 @@ int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
     return 0;
 
 err_load:
-    _bf_ruleset_flush(&lock);
+    _bf_ruleset_flush(ctx, &lock);
     return r;
 }
 
-int bf_ruleset_flush(void)
+int bf_ruleset_flush(const struct bf_ctx *ctx)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     int r;
 
-    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
+    assert(ctx);
+
+    r = bf_lock_init(&lock, ctx->bpffs_path, BF_LOCK_WRITE);
     if (r)
         return bf_err_r(r, "failed to acquire WRITE lock for ruleset flush");
 
-    return _bf_ruleset_flush(&lock);
+    return _bf_ruleset_flush(ctx, &lock);
 }
 
-int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
+int bf_chain_set(const struct bf_ctx *ctx, struct bf_chain *chain,
+                 struct bf_hookopts *hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *old_cgen = NULL;
@@ -222,13 +229,14 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
     _free_bf_hookopts_ struct bf_hookopts *hookopts_copy = NULL;
     int r;
 
+    assert(ctx);
     assert(chain);
 
     /* bf_chain_set is a namespace mutator: the previous chain (if any) is
      * destroyed and a fresh one is published under the same name. Take
      * pindir WRITE for the whole operation so the flush-then-load
      * sequence is atomic w.r.t. every other libbpfilter caller. */
-    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
+    r = bf_lock_init(&lock, ctx->bpffs_path, BF_LOCK_WRITE);
     if (r)
         return r;
 
@@ -236,7 +244,7 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
      * entry so stage-and-rename can publish the new one. */
     r = bf_lock_acquire_chain(&lock, chain->name, BF_LOCK_WRITE, false);
     if (r == 0) {
-        r = bf_ctx_get_cgen(&lock, &old_cgen);
+        r = bf_ctx_get_cgen(ctx, &lock, &old_cgen);
         if (r && r != -ENOENT) {
             bf_lock_release_chain(&lock);
             return r;
@@ -260,7 +268,7 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
             return r;
     }
 
-    r = bf_cgen_new(&new_cgen, _bf_ctx_global(), &chain_copy);
+    r = bf_cgen_new(&new_cgen, ctx, &chain_copy);
     if (r)
         return r;
 
@@ -272,8 +280,8 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
     return bf_cgen_set(new_cgen, hookopts_copy ? &hookopts_copy : NULL, &lock);
 }
 
-int bf_chain_get(const char *name, struct bf_chain **chain,
-                 struct bf_hookopts **hookopts)
+int bf_chain_get(const struct bf_ctx *ctx, const char *name,
+                 struct bf_chain **chain, struct bf_hookopts **hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_chain_ struct bf_chain *_chain = NULL;
@@ -281,16 +289,17 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
     assert(chain);
     assert(hookopts);
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_READ,
+                               BF_LOCK_READ, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -315,20 +324,21 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
     return 0;
 }
 
-int bf_chain_prog_fd(const char *name)
+int bf_chain_prog_fd(const struct bf_ctx *ctx, const char *name)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_READ,
+                               BF_LOCK_READ, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -338,20 +348,21 @@ int bf_chain_prog_fd(const char *name)
     return dup(cgen->handle->prog_fd);
 }
 
-int bf_chain_logs_fd(const char *name)
+int bf_chain_logs_fd(const struct bf_ctx *ctx, const char *name)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_READ,
+                               BF_LOCK_READ, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -361,20 +372,21 @@ int bf_chain_logs_fd(const char *name)
     return dup(cgen->handle->lmap->fd);
 }
 
-int bf_chain_load(struct bf_chain *chain)
+int bf_chain_load(const struct bf_ctx *ctx, struct bf_chain *chain)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     _free_bf_chain_ struct bf_chain *chain_copy = NULL;
     int r;
 
+    assert(ctx);
     assert(chain);
 
     /* chain_load is a namespace mutator: pindir WRITE + chain WRITE on the
      * staged inode. Stage-and-rename (I3) returns `-EEXIST` if another
      * creator already claimed the name, which replaces the former
      * check-then-create sequence atomically. */
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), chain->name,
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, chain->name,
                                BF_LOCK_WRITE, BF_LOCK_WRITE, true);
     if (r)
         return r;
@@ -383,29 +395,31 @@ int bf_chain_load(struct bf_chain *chain)
     if (r)
         return r;
 
-    r = bf_cgen_new(&cgen, _bf_ctx_global(), &chain_copy);
+    r = bf_cgen_new(&cgen, ctx, &chain_copy);
     if (r)
         return r;
 
     return bf_cgen_load(cgen, &lock);
 }
 
-int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
+int bf_chain_attach(const struct bf_ctx *ctx, const char *name,
+                    const struct bf_hookopts *hookopts)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     _free_bf_hookopts_ struct bf_hookopts *hookopts_copy = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
     assert(hookopts);
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_READ, BF_LOCK_WRITE, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_READ,
+                               BF_LOCK_WRITE, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -427,21 +441,22 @@ int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
     return 0;
 }
 
-int bf_chain_update(const struct bf_chain *chain)
+int bf_chain_update(const struct bf_ctx *ctx, const struct bf_chain *chain)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_chain_ struct bf_chain *chain_copy = NULL;
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(chain);
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), chain->name,
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, chain->name,
                                BF_LOCK_READ, BF_LOCK_WRITE, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -486,7 +501,8 @@ static int copy_set(struct bf_set **dest, const struct bf_set *src)
     return bf_set_new_from_pack(dest, child);
 }
 
-int bf_chain_update_set(const char *name, const struct bf_set *to_add,
+int bf_chain_update_set(const struct bf_ctx *ctx, const char *name,
+                        const struct bf_set *to_add,
                         const struct bf_set *to_remove)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
@@ -497,6 +513,7 @@ int bf_chain_update_set(const char *name, const struct bf_set *to_add,
     _free_bf_set_ struct bf_set *remove_copy = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
     assert(to_add);
     assert(to_remove);
@@ -504,12 +521,12 @@ int bf_chain_update_set(const char *name, const struct bf_set *to_add,
     if (!bf_streq(to_add->name, to_remove->name))
         return bf_err_r(-EINVAL, "to_add->name must match to_remove->name");
 
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_READ, BF_LOCK_WRITE, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_READ,
+                               BF_LOCK_WRITE, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 
@@ -545,22 +562,23 @@ int bf_chain_update_set(const char *name, const struct bf_set *to_add,
     return 0;
 }
 
-int bf_chain_flush(const char *name)
+int bf_chain_flush(const struct bf_ctx *ctx, const char *name)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_cgen_ struct bf_cgen *cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(name);
 
     /* chain_flush removes the chain dir from the pindir namespace, so it
      * needs pindir WRITE (I2). */
-    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
-                               BF_LOCK_WRITE, BF_LOCK_WRITE, false);
+    r = bf_lock_init_for_chain(&lock, ctx->bpffs_path, name, BF_LOCK_WRITE,
+                               BF_LOCK_WRITE, false);
     if (r)
         return r;
 
-    r = bf_ctx_get_cgen(&lock, &cgen);
+    r = bf_ctx_get_cgen(ctx, &lock, &cgen);
     if (r)
         return r;
 

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -21,6 +21,7 @@
 #include "cgen/handle.h"
 #include "cgen/prog/link.h"
 #include "cgen/prog/map.h"
+#include "core/ctx.h"
 #include "core/lock.h"
 
 static int copy_hookopts(struct bf_hookopts **dest,
@@ -92,7 +93,7 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts)
     _clean_bf_list_ bf_list _hookopts = bf_list_default_from(*hookopts);
     int r;
 
-    r = bf_lock_init(&lock, BF_LOCK_READ);
+    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ);
     if (r)
         return bf_err_r(r, "failed to acquire READ lock for ruleset get");
 
@@ -142,7 +143,7 @@ int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
     if (bf_list_size(chains) != bf_list_size(hookopts))
         return -EINVAL;
 
-    r = bf_lock_init(&lock, BF_LOCK_WRITE);
+    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
     if (r)
         return bf_err_r(r, "failed to acquire WRITE lock for ruleset set");
 
@@ -168,7 +169,7 @@ int bf_ruleset_set(bf_list *chains, bf_list *hookopts)
                 goto err_load;
         }
 
-        r = bf_cgen_new(&cgen, &chain_copy);
+        r = bf_cgen_new(&cgen, _bf_ctx_global(), &chain_copy);
         if (r)
             goto err_load;
 
@@ -205,7 +206,7 @@ int bf_ruleset_flush(void)
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     int r;
 
-    r = bf_lock_init(&lock, BF_LOCK_WRITE);
+    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
     if (r)
         return bf_err_r(r, "failed to acquire WRITE lock for ruleset flush");
 
@@ -227,7 +228,7 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
      * destroyed and a fresh one is published under the same name. Take
      * pindir WRITE for the whole operation so the flush-then-load
      * sequence is atomic w.r.t. every other libbpfilter caller. */
-    r = bf_lock_init(&lock, BF_LOCK_WRITE);
+    r = bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE);
     if (r)
         return r;
 
@@ -259,7 +260,7 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts)
             return r;
     }
 
-    r = bf_cgen_new(&new_cgen, &chain_copy);
+    r = bf_cgen_new(&new_cgen, _bf_ctx_global(), &chain_copy);
     if (r)
         return r;
 
@@ -284,7 +285,8 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
     assert(chain);
     assert(hookopts);
 
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_READ, BF_LOCK_READ, false);
     if (r)
         return r;
 
@@ -321,7 +323,8 @@ int bf_chain_prog_fd(const char *name)
 
     assert(name);
 
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_READ, BF_LOCK_READ, false);
     if (r)
         return r;
 
@@ -343,7 +346,8 @@ int bf_chain_logs_fd(const char *name)
 
     assert(name);
 
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_READ, false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_READ, BF_LOCK_READ, false);
     if (r)
         return r;
 
@@ -370,8 +374,8 @@ int bf_chain_load(struct bf_chain *chain)
      * staged inode. Stage-and-rename (I3) returns `-EEXIST` if another
      * creator already claimed the name, which replaces the former
      * check-then-create sequence atomically. */
-    r = bf_lock_init_for_chain(&lock, chain->name, BF_LOCK_WRITE, BF_LOCK_WRITE,
-                               true);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), chain->name,
+                               BF_LOCK_WRITE, BF_LOCK_WRITE, true);
     if (r)
         return r;
 
@@ -379,7 +383,7 @@ int bf_chain_load(struct bf_chain *chain)
     if (r)
         return r;
 
-    r = bf_cgen_new(&cgen, &chain_copy);
+    r = bf_cgen_new(&cgen, _bf_ctx_global(), &chain_copy);
     if (r)
         return r;
 
@@ -396,7 +400,8 @@ int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts)
     assert(name);
     assert(hookopts);
 
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_WRITE, false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_READ, BF_LOCK_WRITE, false);
     if (r)
         return r;
 
@@ -431,8 +436,8 @@ int bf_chain_update(const struct bf_chain *chain)
 
     assert(chain);
 
-    r = bf_lock_init_for_chain(&lock, chain->name, BF_LOCK_READ, BF_LOCK_WRITE,
-                               false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), chain->name,
+                               BF_LOCK_READ, BF_LOCK_WRITE, false);
     if (r)
         return r;
 
@@ -499,7 +504,8 @@ int bf_chain_update_set(const char *name, const struct bf_set *to_add,
     if (!bf_streq(to_add->name, to_remove->name))
         return bf_err_r(-EINVAL, "to_add->name must match to_remove->name");
 
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_READ, BF_LOCK_WRITE, false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_READ, BF_LOCK_WRITE, false);
     if (r)
         return r;
 
@@ -549,8 +555,8 @@ int bf_chain_flush(const char *name)
 
     /* chain_flush removes the chain dir from the pindir namespace, so it
      * needs pindir WRITE (I2). */
-    r = bf_lock_init_for_chain(&lock, name, BF_LOCK_WRITE, BF_LOCK_WRITE,
-                               false);
+    r = bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), name,
+                               BF_LOCK_WRITE, BF_LOCK_WRITE, false);
     if (r)
         return r;
 

--- a/src/libbpfilter/core/ctx.h
+++ b/src/libbpfilter/core/ctx.h
@@ -35,3 +35,14 @@ struct bf_ctx
     /// Path to the bpffs mountpoint, owned by the context.
     char *bpffs_path;
 };
+
+/**
+ * @brief Return the legacy global context.
+ *
+ * Transitional bridge used by the public API entry points in `cli.c`
+ * while the global context is being phased out. Returns the same pointer
+ * that `bf_ctx_setup()` populated, or NULL if no setup has occurred.
+ *
+ * @return Pointer to the global context, or NULL.
+ */
+struct bf_ctx *_bf_ctx_global(void);

--- a/src/libbpfilter/core/ctx.h
+++ b/src/libbpfilter/core/ctx.h
@@ -34,7 +34,4 @@ struct bf_ctx
 
     /// Path to the bpffs mountpoint, owned by the context.
     char *bpffs_path;
-
-    /// Verbose flag bitmask.
-    uint16_t verbose;
 };

--- a/src/libbpfilter/core/ctx.h
+++ b/src/libbpfilter/core/ctx.h
@@ -40,14 +40,3 @@ struct bf_ctx
     /// vmlinux BTF object, owned by the context.
     struct btf *btf;
 };
-
-/**
- * @brief Return the legacy global context.
- *
- * Transitional bridge used by the public API entry points in `cli.c`
- * while the global context is being phased out. Returns the same pointer
- * that `bf_ctx_setup()` populated, or NULL if no setup has occurred.
- *
- * @return Pointer to the global context, or NULL.
- */
-struct bf_ctx *_bf_ctx_global(void);

--- a/src/libbpfilter/core/ctx.h
+++ b/src/libbpfilter/core/ctx.h
@@ -10,6 +10,8 @@
 
 #include <bpfilter/elfstub.h>
 
+struct btf;
+
 /**
  * @file core/ctx.h
  *
@@ -34,6 +36,9 @@ struct bf_ctx
 
     /// Path to the bpffs mountpoint, owned by the context.
     char *bpffs_path;
+
+    /// vmlinux BTF object, owned by the context.
+    struct btf *btf;
 };
 
 /**

--- a/src/libbpfilter/core/ctx.h
+++ b/src/libbpfilter/core/ctx.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <bpfilter/elfstub.h>
+
+/**
+ * @file core/ctx.h
+ *
+ * Internal definition of `struct bf_ctx`.
+ *
+ * The public header `bpfilter/ctx.h` only forward-declares this type so
+ * library users can hold and pass pointers without depending on any
+ * particular layout. Modules inside `libbpfilter` that need to read fields
+ * include this header.
+ */
+
+struct bf_ctx
+{
+    /// BPF token file descriptor.
+    int token_fd;
+
+    /// ELF stubs indexed by @ref bf_elfstub_id.
+    struct bf_elfstub *stubs[_BF_ELFSTUB_MAX];
+
+    /// Pass a token to BPF system calls, obtained from bpffs.
+    bool with_bpf_token;
+
+    /// Path to the bpffs mountpoint, owned by the context.
+    char *bpffs_path;
+
+    /// Verbose flag bitmask.
+    uint16_t verbose;
+};

--- a/src/libbpfilter/core/lock.c
+++ b/src/libbpfilter/core/lock.c
@@ -250,17 +250,14 @@ static int _bf_lock_open_existing(int pindir_fd, const char *name,
         name, BF_LOCK_MAX_RETRIES);
 }
 
-int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode)
+int bf_lock_init(struct bf_lock *lock, const char *bpffs_path,
+                 enum bf_lock_mode mode)
 {
     _clean_bf_lock_ struct bf_lock _lock = bf_lock_default();
-    const char *bpffs_path;
     int r;
 
     assert(lock);
-
-    bpffs_path = bf_ctx_get_bpffs_path();
-    if (!bpffs_path)
-        return bf_err_r(-EINVAL, "context is not initialized");
+    assert(bpffs_path);
 
     _lock.bpffs_fd = bf_opendir(bpffs_path);
     if (_lock.bpffs_fd < 0) {
@@ -287,14 +284,15 @@ int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode)
     return 0;
 }
 
-int bf_lock_init_for_chain(struct bf_lock *lock, const char *name,
-                           enum bf_lock_mode pindir_mode,
+int bf_lock_init_for_chain(struct bf_lock *lock, const char *bpffs_path,
+                           const char *name, enum bf_lock_mode pindir_mode,
                            enum bf_lock_mode chain_mode, bool create)
 {
     _clean_bf_lock_ struct bf_lock _lock = bf_lock_default();
     int r;
 
     assert(lock);
+    assert(bpffs_path);
     assert(name);
 
     if (create && pindir_mode != BF_LOCK_WRITE) {
@@ -303,7 +301,7 @@ int bf_lock_init_for_chain(struct bf_lock *lock, const char *name,
             "creating a chain requires BF_LOCK_WRITE on the pin directory");
     }
 
-    r = bf_lock_init(&_lock, pindir_mode);
+    r = bf_lock_init(&_lock, bpffs_path, pindir_mode);
     if (r)
         return r;
 

--- a/src/libbpfilter/core/lock.h
+++ b/src/libbpfilter/core/lock.h
@@ -187,19 +187,21 @@ struct bf_lock
  * bpffs mount.
  *
  * @pre
- *  - The runtime context has been initialized.
+ *  - `bpffs_path` is not NULL.
  *  - `lock` is not NULL, and contains sane defaults (see `bf_lock_default()`).
  * @post
- *  - On success: `lock` holds a valid file descriptor on the bpffs, a valid
- *    file descriptor on the pin directory, and an `flock(2)` of mode `mode`
- *    on the pin directory. `lock->pindir_lock == mode`.
+ *  - On success: `lock` holds a valid file descriptor on the bpffs, a
+ *    valid file descriptor on the pin directory, and an `flock(2)` of
+ *    mode `mode` on the pin directory. `lock->pindir_lock == mode`.
  *  - On failure: `lock` is unchanged.
  *
  * @param lock Handle to populate. Must be initialised via `bf_lock_default()`.
+ * @param bpffs_path Filesystem path to the bpffs mountpoint.
  * @param mode Lock mode for the pin directory.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode);
+int bf_lock_init(struct bf_lock *lock, const char *bpffs_path,
+                 enum bf_lock_mode mode);
 
 /**
  * @brief Open and lock the pin directory and a chain directory.
@@ -217,7 +219,7 @@ int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode);
  * `bf_lock_acquire_chain()` instead.
  *
  * @pre
- *  - The runtime context has been initialized.
+ *  - `bpffs_path` is not NULL.
  *  - `lock` is not NULL, and contains sane defaults (see `bf_lock_default()`).
  *  - `name` is not NULL.
  *  - `create == true` implies `pindir_mode == BF_LOCK_WRITE` and
@@ -229,6 +231,7 @@ int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode);
  *  - On failure: `lock` is unchanged.
  *
  * @param lock Lock object to initialize.
+ * @param bpffs_path Filesystem path to the bpffs mountpoint.
  * @param name Name of the chain to lock.
  * @param pindir_mode Lock mode for the pin directory.
  * @param chain_mode Lock mode for the chain directory.
@@ -237,8 +240,8 @@ int bf_lock_init(struct bf_lock *lock, enum bf_lock_mode mode);
  *        `chain_mode == BF_LOCK_WRITE`.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_lock_init_for_chain(struct bf_lock *lock, const char *name,
-                           enum bf_lock_mode pindir_mode,
+int bf_lock_init_for_chain(struct bf_lock *lock, const char *bpffs_path,
+                           const char *name, enum bf_lock_mode pindir_mode,
                            enum bf_lock_mode chain_mode, bool create);
 
 /**

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -213,6 +213,11 @@ void bf_ctx_free(struct bf_ctx **ctx)
     freep((void *)ctx);
 }
 
+struct bf_ctx *_bf_ctx_global(void)
+{
+    return _bf_global_ctx;
+}
+
 /**
  * See @ref bf_ctx_dump for details.
  */
@@ -273,7 +278,7 @@ int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen)
     if (!_bf_global_ctx)
         return bf_err_r(-EINVAL, "context is not initialized");
 
-    r = bf_cgen_new_from_dir_fd(&_cgen, lock);
+    r = bf_cgen_new_from_dir_fd(&_cgen, _bf_global_ctx, lock);
     if (r)
         return bf_err_r(r, "failed to load chain '%s' from bpffs",
                         lock->chain_name ? lock->chain_name : "(unknown)");
@@ -344,7 +349,7 @@ int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens)
             continue;
         }
 
-        r = bf_cgen_new_from_dir_fd(&cgen, lock);
+        r = bf_cgen_new_from_dir_fd(&cgen, _bf_global_ctx, lock);
         if (r) {
             bf_warn_r(r, "failed to restore chain '%s', skipping",
                       entry->d_name);

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -38,7 +38,6 @@ static struct bf_ctx *_bf_global_ctx = NULL;
         .stubs = {0},                                                          \
         .with_bpf_token = false,                                               \
         .bpffs_path = NULL,                                                    \
-        .verbose = 0,                                                          \
     })
 
 static void _bf_ctx_cleanup(struct bf_ctx *ctx);
@@ -86,7 +85,8 @@ static int _bf_ctx_gen_token(const char *bpffs_path)
  * @param ctx Pre-allocated context to populate.
  * @param with_bpf_token If true, create a BPF token from bpffs.
  * @param bpffs_path Path to the bpffs mountpoint.
- * @param verbose Bitmask of verbose flags.
+ * @param verbose Bitmask of verbose flags. Applied to the process-wide
+ *        logger configuration via `bf_logger_set_verbose()`.
  * @return 0 on success, or a negative errno value on failure.
  */
 static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
@@ -98,8 +98,9 @@ static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
     assert(ctx);
     assert(bpffs_path);
 
+    bf_logger_set_verbose(verbose);
+
     _ctx.with_bpf_token = with_bpf_token;
-    _ctx.verbose = verbose;
 
     _ctx.bpffs_path = strdup(bpffs_path);
     if (!_ctx.bpffs_path)
@@ -380,14 +381,6 @@ const struct bf_elfstub *bf_ctx_get_elfstub(enum bf_elfstub_id id)
         return NULL;
 
     return _bf_global_ctx->stubs[id];
-}
-
-bool bf_ctx_is_verbose(enum bf_verbose opt)
-{
-    if (!_bf_global_ctx)
-        return false;
-
-    return _bf_global_ctx->verbose & BF_FLAG(opt);
 }
 
 const char *bf_ctx_get_bpffs_path(void)

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -11,7 +11,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/file.h>
 #include <unistd.h>
 
 #include <bpfilter/bpf.h>
@@ -238,74 +237,6 @@ static void _bf_free_dir(DIR **dir)
 
 #define _free_dir_ __attribute__((__cleanup__(_bf_free_dir)))
 
-/**
- * @brief Sweep leftover staging directories from a previous run.
- *
- * `core/lock.c` creates uniquely-named `.staging.*` directories while
- * publishing new chain dirs via `renameat2(RENAME_NOREPLACE)`. If a
- * process crashes between the `mkdirat` and the `renameat2`, the staging
- * dir is orphaned.
- *
- * This function walks the pindir under `BF_LOCK_WRITE` and removes any
- * `.staging.*` entry whose `flock(LOCK_EX | LOCK_NB)` succeeds (meaning
- * nobody currently owns it). Live staging dirs are left alone.
- *
- * Runs once from `bf_ctx_setup()`. Non-fatal: a failure to sweep only
- * leaves garbage behind, it does not compromise correctness.
- */
-static void _bf_ctx_sweep_staging(void)
-{
-    _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
-    _free_dir_ DIR *dir = NULL;
-    struct dirent *entry;
-    int iter_fd;
-    int r;
-
-    r = bf_lock_init(&lock, BF_LOCK_WRITE);
-    if (r) {
-        bf_warn_r(r, "failed to lock pindir for staging sweep, skipping");
-        return;
-    }
-
-    iter_fd = dup(lock.pindir_fd);
-    if (iter_fd < 0) {
-        bf_warn_r(-errno, "failed to dup pindir fd for staging sweep");
-        return;
-    }
-
-    dir = fdopendir(iter_fd);
-    if (!dir) {
-        close(iter_fd);
-        bf_warn_r(-errno, "failed to fdopendir pindir for staging sweep");
-        return;
-    }
-
-    while ((entry = readdir(dir))) {
-        _cleanup_close_ int stage_fd = -1;
-
-        if (!bf_strneq(entry->d_name, BF_LOCK_STAGING_PREFIX,
-                       sizeof(BF_LOCK_STAGING_PREFIX) - 1))
-            continue;
-
-        if (entry->d_type != DT_DIR && entry->d_type != DT_UNKNOWN)
-            continue;
-
-        stage_fd = openat(lock.pindir_fd, entry->d_name, O_DIRECTORY);
-        if (stage_fd < 0)
-            continue;
-
-        /* LOCK_NB: if the staging dir is still live, skip it. */
-        if (flock(stage_fd, LOCK_EX | LOCK_NB) < 0)
-            continue;
-
-        if (bf_rmdir_at(lock.pindir_fd, entry->d_name, true)) {
-            bf_warn("failed to sweep orphan staging dir '%s'", entry->d_name);
-        } else {
-            bf_dbg("removed left-over staging directory '%s'", entry->d_name);
-        }
-    }
-}
-
 int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
 {
     int r;
@@ -313,9 +244,6 @@ int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
     r = bf_ctx_new(&_bf_global_ctx, with_bpf_token, bpffs_path, verbose);
     if (r)
         return bf_err_r(r, "failed to create new context");
-
-    /* Reclaim any orphan staging directory left by a previous crash. */
-    _bf_ctx_sweep_staging();
 
     return 0;
 }

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -3,11 +3,14 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include "core/ctx.h"
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/file.h>
 #include <unistd.h>
 
@@ -27,35 +30,21 @@
 #include "cgen/cgen.h"
 #include "core/lock.h"
 
-#define _free_bf_ctx_ __attribute__((cleanup(_bf_ctx_free)))
-
-/**
- * @struct bf_ctx
- *
- * bpfilter working context. Only one context is used during the library's
- * lifetime.
- */
-struct bf_ctx
-{
-    /// BPF token file descriptor
-    int token_fd;
-
-    struct bf_elfstub *stubs[_BF_ELFSTUB_MAX];
-
-    /// Pass a token to BPF system calls, obtained from bpffs.
-    bool with_bpf_token;
-
-    /// Path to the bpffs to pin the BPF objects into.
-    const char *bpffs_path;
-
-    /// Verbose flags.
-    uint16_t verbose;
-};
-
-static void _bf_ctx_free(struct bf_ctx **ctx);
-
-/// Global runtime context. Hidden in this translation unit.
+/// Global runtime context. Populated by `bf_ctx_setup`; hidden in this TU.
 static struct bf_ctx *_bf_global_ctx = NULL;
+
+#define bf_ctx_default()                                                       \
+    ((struct bf_ctx) {                                                         \
+        .token_fd = -1,                                                        \
+        .stubs = {0},                                                          \
+        .with_bpf_token = false,                                               \
+        .bpffs_path = NULL,                                                    \
+        .verbose = 0,                                                          \
+    })
+
+static void _bf_ctx_cleanup(struct bf_ctx *ctx);
+
+#define _clean_bf_ctx_ __attribute__((cleanup(_bf_ctx_cleanup)))
 
 static int _bf_ctx_gen_token(const char *bpffs_path)
 {
@@ -81,18 +70,102 @@ static int _bf_ctx_gen_token(const char *bpffs_path)
 }
 
 /**
- * Create and initialize a new context.
+ * @brief Populate an empty context with the requested configuration.
  *
- * On failure, @p ctx is left unchanged.
+ * Performs the actual work (BTF load, BPF token creation, ELF stubs) on a
+ * locally-owned stack `bf_ctx`, then atomically swaps the populated state
+ * into `ctx` on success.
  *
- * @param ctx New context to create. Can't be NULL.
+ * @pre
+ *  - `ctx` is not NULL and is in the `bf_ctx_default` state.
+ *  - `bpffs_path` is not NULL.
+ * @post
+ *  - On success: `ctx` owns the BPF token (if requested), the ELF stubs,
+ *    a heap copy of `bpffs_path`, and a vmlinux BTF reference.
+ *  - On failure: `ctx` is unchanged.
+ *
+ * @param ctx Pre-allocated context to populate.
  * @param with_bpf_token If true, create a BPF token from bpffs.
- * @param bpffs_path Path to the bpffs mountpoint. Can't be NULL.
+ * @param bpffs_path Path to the bpffs mountpoint.
  * @param verbose Bitmask of verbose flags.
- * @return 0 on success, negative errno value on failure.
+ * @return 0 on success, or a negative errno value on failure.
  */
-static int _bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
-                       const char *bpffs_path, uint16_t verbose)
+static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
+                        const char *bpffs_path, uint16_t verbose)
+{
+    _clean_bf_ctx_ struct bf_ctx _ctx = bf_ctx_default();
+    int r;
+
+    assert(ctx);
+    assert(bpffs_path);
+
+    _ctx.with_bpf_token = with_bpf_token;
+    _ctx.verbose = verbose;
+
+    _ctx.bpffs_path = strdup(bpffs_path);
+    if (!_ctx.bpffs_path)
+        return -ENOMEM;
+
+    if (_ctx.with_bpf_token) {
+        _cleanup_close_ int token_fd = -1;
+
+        r = bf_btf_kernel_has_token();
+        if (r == -ENOENT) {
+            return bf_err_r(
+                r,
+                "--with-bpf-token requested, but this kernel doesn't support BPF token");
+        }
+        if (r)
+            return bf_err_r(r, "failed to check for BPF token support");
+
+        token_fd = _bf_ctx_gen_token(_ctx.bpffs_path);
+        if (token_fd < 0)
+            return bf_err_r(token_fd, "failed to generate a BPF token");
+
+        _ctx.token_fd = TAKE_FD(token_fd);
+    }
+
+    for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id) {
+        r = bf_elfstub_new(&_ctx.stubs[id], id);
+        if (r)
+            return bf_err_r(r, "failed to create ELF stub ID %u", id);
+    }
+
+    bf_swap(*ctx, _ctx);
+
+    return 0;
+}
+
+/**
+ * @brief Release the resources owned by a context in place.
+ *
+ * Does not free the container. After the call, `ctx` is back to the
+ * `bf_ctx_default()` state and may be safely re-initialised or cleaned-up again
+ * (idempotent).
+ *
+ * @pre
+ *  - `ctx` is not NULL.
+ * @post
+ *  - `ctx` is in the `bf_ctx_default` state.
+ *
+ * @param ctx Context to clean up.
+ */
+static void _bf_ctx_cleanup(struct bf_ctx *ctx)
+{
+    assert(ctx);
+
+    closep(&ctx->token_fd);
+
+    for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id)
+        bf_elfstub_free(&ctx->stubs[id]);
+
+    freep((void *)&ctx->bpffs_path);
+
+    *ctx = bf_ctx_default();
+}
+
+int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
+               uint16_t verbose)
 {
     _free_bf_ctx_ struct bf_ctx *_ctx = NULL;
     int r;
@@ -100,42 +173,27 @@ static int _bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
     assert(ctx);
     assert(bpffs_path);
 
-    _ctx = calloc(1, sizeof(*_ctx));
-    if (!_ctx)
-        return -ENOMEM;
-
+    /* vmlinux BTF is a process-wide resource (single static in btf.c) but
+     * its lifetime is currently coupled to the context. Pair setup/teardown
+     * with the heap-owning constructor/destructor so the swap-style
+     * _bf_ctx_init can run a cleanup on its local without tearing down the
+     * BTF the live context will rely on. */
     r = bf_btf_setup();
     if (r)
         return bf_err_r(r, "failed to load vmlinux BTF");
 
-    _ctx->with_bpf_token = with_bpf_token;
-    _ctx->bpffs_path = bpffs_path;
-    _ctx->verbose = verbose;
-
-    _ctx->token_fd = -1;
-    if (_ctx->with_bpf_token) {
-        _cleanup_close_ int token_fd = -1;
-
-        r = bf_btf_kernel_has_token();
-        if (r == -ENOENT) {
-            bf_err(
-                "--with-bpf-token requested, but this kernel doesn't support BPF token");
-            return r;
-        }
-        if (r)
-            return bf_err_r(r, "failed to check for BPF token support");
-
-        token_fd = _bf_ctx_gen_token(_ctx->bpffs_path);
-        if (token_fd < 0)
-            return bf_err_r(token_fd, "failed to generate a BPF token");
-
-        _ctx->token_fd = TAKE_FD(token_fd);
+    _ctx = malloc(sizeof(*_ctx));
+    if (!_ctx) {
+        bf_btf_teardown();
+        return -ENOMEM;
     }
 
-    for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id) {
-        r = bf_elfstub_new(&_ctx->stubs[id], id);
-        if (r)
-            return bf_err_r(r, "failed to create ELF stub ID %u", id);
+    *_ctx = bf_ctx_default();
+
+    r = _bf_ctx_init(_ctx, with_bpf_token, bpffs_path, verbose);
+    if (r) {
+        bf_btf_teardown();
+        return r;
     }
 
     *ctx = TAKE_PTR(_ctx);
@@ -143,28 +201,15 @@ static int _bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
     return 0;
 }
 
-/**
- * Free a context.
- *
- * If @p ctx points to a NULL pointer, this function does nothing. Once
- * the function returns, @p ctx points to a NULL pointer.
- *
- * @param ctx Context to free. Can't be NULL.
- */
-static void _bf_ctx_free(struct bf_ctx **ctx)
+void bf_ctx_free(struct bf_ctx **ctx)
 {
     assert(ctx);
 
     if (!*ctx)
         return;
 
-    closep(&(*ctx)->token_fd);
-
-    for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id)
-        bf_elfstub_free(&(*ctx)->stubs[id]);
-
+    _bf_ctx_cleanup(*ctx);
     bf_btf_teardown();
-
     freep((void *)ctx);
 }
 
@@ -265,7 +310,7 @@ int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
 {
     int r;
 
-    r = _bf_ctx_new(&_bf_global_ctx, with_bpf_token, bpffs_path, verbose);
+    r = bf_ctx_new(&_bf_global_ctx, with_bpf_token, bpffs_path, verbose);
     if (r)
         return bf_err_r(r, "failed to create new context");
 
@@ -277,7 +322,7 @@ int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
 
 void bf_ctx_teardown(void)
 {
-    _bf_ctx_free(&_bf_global_ctx);
+    bf_ctx_free(&_bf_global_ctx);
 }
 
 void bf_ctx_dump(prefix_t *prefix)

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -30,9 +30,6 @@
 #include "cgen/cgen.h"
 #include "core/lock.h"
 
-/// Global runtime context. Populated by `bf_ctx_setup`; hidden in this TU.
-static struct bf_ctx *_bf_global_ctx = NULL;
-
 #define bf_ctx_default()                                                       \
     ((struct bf_ctx) {                                                         \
         .token_fd = -1,                                                        \
@@ -87,20 +84,16 @@ static int _bf_ctx_gen_token(const char *bpffs_path)
  * @param ctx Pre-allocated context to populate.
  * @param with_bpf_token If true, create a BPF token from bpffs.
  * @param bpffs_path Path to the bpffs mountpoint.
- * @param verbose Bitmask of verbose flags. Applied to the process-wide
- *        logger configuration via `bf_logger_set_verbose()`.
  * @return 0 on success, or a negative errno value on failure.
  */
 static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
-                        const char *bpffs_path, uint16_t verbose)
+                        const char *bpffs_path)
 {
     _clean_bf_ctx_ struct bf_ctx _ctx = bf_ctx_default();
     int r;
 
     assert(ctx);
     assert(bpffs_path);
-
-    bf_logger_set_verbose(verbose);
 
     _ctx.with_bpf_token = with_bpf_token;
 
@@ -173,8 +166,7 @@ static void _bf_ctx_cleanup(struct bf_ctx *ctx)
     *ctx = bf_ctx_default();
 }
 
-int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
-               uint16_t verbose)
+int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path)
 {
     _free_bf_ctx_ struct bf_ctx *_ctx = NULL;
     int r;
@@ -188,7 +180,7 @@ int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
 
     *_ctx = bf_ctx_default();
 
-    r = _bf_ctx_init(_ctx, with_bpf_token, bpffs_path, verbose);
+    r = _bf_ctx_init(_ctx, with_bpf_token, bpffs_path);
     if (r)
         return r;
 
@@ -208,16 +200,10 @@ void bf_ctx_free(struct bf_ctx **ctx)
     freep((void *)ctx);
 }
 
-struct bf_ctx *_bf_ctx_global(void)
+void bf_ctx_dump(const struct bf_ctx *ctx, prefix_t *prefix)
 {
-    return _bf_global_ctx;
-}
+    assert(ctx);
 
-/**
- * See @ref bf_ctx_dump for details.
- */
-static void _bf_ctx_dump(const struct bf_ctx *ctx, prefix_t *prefix)
-{
     DUMP(prefix, "struct bf_ctx at %p", ctx);
 
     bf_dump_prefix_push(prefix);
@@ -238,42 +224,17 @@ static void _bf_free_dir(DIR **dir)
 
 #define _free_dir_ __attribute__((__cleanup__(_bf_free_dir)))
 
-int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
-{
-    int r;
-
-    r = bf_ctx_new(&_bf_global_ctx, with_bpf_token, bpffs_path, verbose);
-    if (r)
-        return bf_err_r(r, "failed to create new context");
-
-    return 0;
-}
-
-void bf_ctx_teardown(void)
-{
-    bf_ctx_free(&_bf_global_ctx);
-}
-
-void bf_ctx_dump(prefix_t *prefix)
-{
-    if (!_bf_global_ctx)
-        return;
-
-    _bf_ctx_dump(_bf_global_ctx, prefix);
-}
-
-int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen)
+int bf_ctx_get_cgen(const struct bf_ctx *ctx, struct bf_lock *lock,
+                    struct bf_cgen **cgen)
 {
     _free_bf_cgen_ struct bf_cgen *_cgen = NULL;
     int r;
 
+    assert(ctx);
     assert(lock);
     assert(cgen);
 
-    if (!_bf_global_ctx)
-        return bf_err_r(-EINVAL, "context is not initialized");
-
-    r = bf_cgen_new_from_dir_fd(&_cgen, _bf_global_ctx, lock);
+    r = bf_cgen_new_from_dir_fd(&_cgen, ctx, lock);
     if (r)
         return bf_err_r(r, "failed to load chain '%s' from bpffs",
                         lock->chain_name ? lock->chain_name : "(unknown)");
@@ -283,7 +244,8 @@ int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen)
     return 0;
 }
 
-int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens)
+int bf_ctx_get_cgens(const struct bf_ctx *ctx, struct bf_lock *lock,
+                     bf_list **cgens)
 {
     _free_bf_list_ bf_list *_cgens = NULL;
     _free_dir_ DIR *dir = NULL;
@@ -291,11 +253,9 @@ int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens)
     int iter_fd;
     int r;
 
+    assert(ctx);
     assert(lock);
     assert(cgens);
-
-    if (!_bf_global_ctx)
-        return bf_err_r(-EINVAL, "context is not initialized");
 
     r = bf_list_new(&_cgens, &bf_list_ops_default(bf_cgen_free, bf_cgen_pack));
     if (r)
@@ -344,7 +304,7 @@ int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens)
             continue;
         }
 
-        r = bf_cgen_new_from_dir_fd(&cgen, _bf_global_ctx, lock);
+        r = bf_cgen_new_from_dir_fd(&cgen, ctx, lock);
         if (r) {
             bf_warn_r(r, "failed to restore chain '%s', skipping",
                       entry->d_name);
@@ -365,28 +325,4 @@ int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens)
     *cgens = TAKE_PTR(_cgens);
 
     return 0;
-}
-
-int bf_ctx_token(void)
-{
-    if (!_bf_global_ctx)
-        return -1;
-
-    return _bf_global_ctx->token_fd;
-}
-
-const struct bf_elfstub *bf_ctx_get_elfstub(enum bf_elfstub_id id)
-{
-    if (!_bf_global_ctx)
-        return NULL;
-
-    return _bf_global_ctx->stubs[id];
-}
-
-const char *bf_ctx_get_bpffs_path(void)
-{
-    if (!_bf_global_ctx)
-        return NULL;
-
-    return _bf_global_ctx->bpffs_path;
 }

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -5,6 +5,7 @@
 
 #include "core/ctx.h"
 
+#include <bpf/btf.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -38,6 +39,7 @@ static struct bf_ctx *_bf_global_ctx = NULL;
         .stubs = {0},                                                          \
         .with_bpf_token = false,                                               \
         .bpffs_path = NULL,                                                    \
+        .btf = NULL,                                                           \
     })
 
 static void _bf_ctx_cleanup(struct bf_ctx *ctx);
@@ -106,10 +108,14 @@ static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
     if (!_ctx.bpffs_path)
         return -ENOMEM;
 
+    _ctx.btf = btf__load_vmlinux_btf();
+    if (!_ctx.btf)
+        return bf_err_r(-errno, "failed to load vmlinux BTF");
+
     if (_ctx.with_bpf_token) {
         _cleanup_close_ int token_fd = -1;
 
-        r = bf_btf_kernel_has_token();
+        r = bf_btf_kernel_has_token(_ctx.btf);
         if (r == -ENOENT) {
             return bf_err_r(
                 r,
@@ -126,7 +132,7 @@ static int _bf_ctx_init(struct bf_ctx *ctx, bool with_bpf_token,
     }
 
     for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id) {
-        r = bf_elfstub_new(&_ctx.stubs[id], id);
+        r = bf_elfstub_new(&_ctx.stubs[id], _ctx.btf, id);
         if (r)
             return bf_err_r(r, "failed to create ELF stub ID %u", id);
     }
@@ -161,6 +167,9 @@ static void _bf_ctx_cleanup(struct bf_ctx *ctx)
 
     freep((void *)&ctx->bpffs_path);
 
+    btf__free(ctx->btf);
+    ctx->btf = NULL;
+
     *ctx = bf_ctx_default();
 }
 
@@ -173,28 +182,15 @@ int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
     assert(ctx);
     assert(bpffs_path);
 
-    /* vmlinux BTF is a process-wide resource (single static in btf.c) but
-     * its lifetime is currently coupled to the context. Pair setup/teardown
-     * with the heap-owning constructor/destructor so the swap-style
-     * _bf_ctx_init can run a cleanup on its local without tearing down the
-     * BTF the live context will rely on. */
-    r = bf_btf_setup();
-    if (r)
-        return bf_err_r(r, "failed to load vmlinux BTF");
-
     _ctx = malloc(sizeof(*_ctx));
-    if (!_ctx) {
-        bf_btf_teardown();
+    if (!_ctx)
         return -ENOMEM;
-    }
 
     *_ctx = bf_ctx_default();
 
     r = _bf_ctx_init(_ctx, with_bpf_token, bpffs_path, verbose);
-    if (r) {
-        bf_btf_teardown();
+    if (r)
         return r;
-    }
 
     *ctx = TAKE_PTR(_ctx);
 
@@ -209,7 +205,6 @@ void bf_ctx_free(struct bf_ctx **ctx)
         return;
 
     _bf_ctx_cleanup(*ctx);
-    bf_btf_teardown();
     freep((void *)ctx);
 }
 

--- a/src/libbpfilter/include/bpfilter/bpfilter.h
+++ b/src/libbpfilter/include/bpfilter/bpfilter.h
@@ -22,32 +22,35 @@ struct bf_hookopts;
  *
  * **Lifecycle**
  *
- * Every caller must initialise the library before using any other function,
- * and tear it down when done:
+ * Every caller obtains a runtime context with `bf_ctx_new()` and releases
+ * it with `bf_ctx_free()` (or the `_free_bf_ctx_` cleanup attribute):
  *
  * @code{.c}
- * int r = bf_ctx_setup(false, "/sys/fs/bpf", 0);
+ * _free_bf_ctx_ struct bf_ctx *ctx = NULL;
+ *
+ * int r = bf_ctx_new(&ctx, false, "/sys/fs/bpf");
  * if (r < 0)
  *     // handle error
  *
- * // use bf_ruleset_*, bf_chain_*, ...
- *
- * bf_ctx_teardown();
+ * // use bf_ruleset_*, bf_chain_*, ... passing `ctx` as first argument
  * @endcode
  *
- * `bf_ctx_setup` and `bf_ctx_teardown` are declared in `<bpfilter/ctx.h>`,
- * which is included by this header. Calling any API function before
- * `bf_ctx_setup` succeeds returns `-EINVAL`.
+ * `bf_ctx_new()` / `bf_ctx_free()` are declared in `<bpfilter/ctx.h>`, which is
+ * included by this header. Multiple contexts may coexist within a single
+ * process; each carries its own bpffs path, BPF token state, ELF stubs,
+ * and vmlinux BTF.
  */
 
 /**
  * @brief Get the current ruleset.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param chains List of `bf_chain` to be filled.
  * @param hookopts List of hook options objects.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_ruleset_get(bf_list *chains, bf_list *hookopts);
+int bf_ruleset_get(const struct bf_ctx *ctx, bf_list *chains,
+                   bf_list *hookopts);
 
 /**
  * @brief Load a ruleset.
@@ -59,19 +62,22 @@ int bf_ruleset_get(bf_list *chains, bf_list *hookopts);
  * mapped 1 to 1. If a chain shouldn't be attached, the corresponding entry
  * in `hookopts` should be NULL.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param chains List of chains to define. Can't be NULL.
  * @param hookopts List of hook options to attach the chains in `chain`. Can't
  *        be NULL.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_ruleset_set(bf_list *chains, bf_list *hookopts);
+int bf_ruleset_set(const struct bf_ctx *ctx, bf_list *chains,
+                   bf_list *hookopts);
 
 /**
  * @brief Remove the current ruleset.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @return 0 on success, or a negative error value on failure.
  */
-int bf_ruleset_flush(void);
+int bf_ruleset_flush(const struct bf_ctx *ctx);
 
 /**
  * @brief Set a chain.
@@ -79,16 +85,19 @@ int bf_ruleset_flush(void);
  * If a chain with the same name already exists, it is detached and unloaded.
  * The new chain is loaded, and attached if hook options are defined.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param chain Chain to set. Can't be NULL.
  * @param hookopts Hook options to attach the chain. If NULL, the chain is not
  *        attached.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts);
+int bf_chain_set(const struct bf_ctx *ctx, struct bf_chain *chain,
+                 struct bf_hookopts *hookopts);
 
 /**
  * @brief Get a chain.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param name Name of the chain to look for. Can't be NULL.
  * @param chain On success, contains a pointer to the chain. The caller is
  *        responsible for freeing it. Can't be NULL.
@@ -98,8 +107,8 @@ int bf_chain_set(struct bf_chain *chain, struct bf_hookopts *hookopts);
  * @return 0 on success, or a negative errno value on failure, including:
  * - `-ENOENT`: no chain found for this name.
  */
-int bf_chain_get(const char *name, struct bf_chain **chain,
-                 struct bf_hookopts **hookopts);
+int bf_chain_get(const struct bf_ctx *ctx, const char *name,
+                 struct bf_chain **chain, struct bf_hookopts **hookopts);
 
 /**
  * @brief Get the file descriptor of a chain's program.
@@ -111,61 +120,69 @@ int bf_chain_get(const char *name, struct bf_chain **chain,
  * API will be disabled for non-tests use cases.
  *
  * @pre
+ * - `ctx` is not NULL.
  * - `name` is a non-NULL pointer to a C-string.
  *
+ * @param ctx Runtime context.
  * @param name Name of the chain to get the program from.
  * @return File descriptor of the chain's program, or a negative error value
  *         on failure. The caller owns the file descriptor and must close it.
  */
-int bf_chain_prog_fd(const char *name);
+int bf_chain_prog_fd(const struct bf_ctx *ctx, const char *name);
 
 /**
  * @brief Get the file descriptor of a chain's logs buffer.
  *
  * @pre
+ * - `ctx` is not NULL.
  * - `name` is a non-NULL pointer to a C-string.
  *
+ * @param ctx Runtime context.
  * @param name Name of the chain to get the log buffer from.
  * @return File descriptor of the chain's logs buffer, or a negative error
  *         value on failure. The caller owns the file descriptor and must
  *         close it.
  */
-int bf_chain_logs_fd(const char *name);
+int bf_chain_logs_fd(const struct bf_ctx *ctx, const char *name);
 
 /**
  * @brief Load a chain.
  *
  * If a chain with the same name already exists, `-EEXIST` is returned.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param chain Chain to load. Can't be NULL.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_chain_load(struct bf_chain *chain);
+int bf_chain_load(const struct bf_ctx *ctx, struct bf_chain *chain);
 
 /**
  * @brief Attach a chain.
  *
  * If the chain doesn't exist, `-ENOENT` is returned.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param name Name of the chain to attach. Can't be NULL.
  * @param hookopts Hook options to attach the chain. Can't be NULL.
  * @return 0 on success, or a negative errno value on failure, including:
  * - `-ENOENT`: no chain found for this name.
  * - `-EBUSY`: chain is already attached.
  */
-int bf_chain_attach(const char *name, const struct bf_hookopts *hookopts);
+int bf_chain_attach(const struct bf_ctx *ctx, const char *name,
+                    const struct bf_hookopts *hookopts);
 
 /**
  * @brief Update an attached chain.
  *
  * The chain to update must exist and be attached to a hook.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param chain Chain to update. Can't be NULL.
  * @return 0 on success, or a negative errno value on failure, including:
  * - `-ENOENT`: no chain found for this name.
  * - `-ENOLINK`: the chain to update is not attached.
  */
-int bf_chain_update(const struct bf_chain *chain);
+int bf_chain_update(const struct bf_ctx *ctx, const struct bf_chain *chain);
 
 /**
  * @brief Update a named set in an existing chain using delta operations.
@@ -176,6 +193,7 @@ int bf_chain_update(const struct bf_chain *chain);
  * `to_remove` has elements that already aren't present in the program,
  * these elements are ignored.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param name Name of the chain containing the set. Can't be NULL.
  * @param to_add Set containing elements to add. The set name and key format
  *        must match the existing set in the chain. Can't be NULL.
@@ -185,14 +203,16 @@ int bf_chain_update(const struct bf_chain *chain);
  * - `-ENOENT`: no chain found for this name or set not found in chain.
  * - `-EINVAL`: set key format doesn't match existing set.
  */
-int bf_chain_update_set(const char *name, const struct bf_set *to_add,
+int bf_chain_update_set(const struct bf_ctx *ctx, const char *name,
+                        const struct bf_set *to_add,
                         const struct bf_set *to_remove);
 
 /**
  * @brief Remove a chain.
  *
+ * @param ctx Runtime context. Can't be NULL.
  * @param name Name of the chain to flush. Can't be NULL.
  * @return 0 on success, or a negative errno value on failure, including:
  * - `-ENOENT`: no chain found for this name.
  */
-int bf_chain_flush(const char *name);
+int bf_chain_flush(const struct bf_ctx *ctx, const char *name);

--- a/src/libbpfilter/include/bpfilter/btf.h
+++ b/src/libbpfilter/include/bpfilter/btf.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+struct btf;
+
 struct bf_btf
 {
     struct btf *btf;
@@ -16,64 +18,63 @@ struct bf_btf
 };
 
 /**
- * Load current kernel's BTF data.
+ * @brief Get BTF ID of a kernel function.
  *
- * This function has to be called early, so BPF program generation can access
- * kernel's BTF data and use the kfunc's BTF ID.
+ * @pre
+ *  - `btf` is not NULL.
+ *  - `name` is not NULL.
  *
- * @return 0 on success, or negative errno value on failure.
- */
-int bf_btf_setup(void);
-
-/**
- * Free current kernel's BTF data.
- */
-void bf_btf_teardown(void);
-
-/**
- * Get BTF ID of a kernel function.
- *
- * Linux' BTF data must be loaded with @ref bf_btf_setup before calling this
- * function.
- *
+ * @param btf Loaded kernel BTF object.
  * @param name Name of the kernel function.
  * @return BTF ID on success, or negative errno value on failure.
  */
-int bf_btf_get_id(const char *name);
+int bf_btf_get_id(const struct btf *btf, const char *name);
 
 /**
- * Get a type name from a BTF ID from the kernel BTF data.
+ * @brief Get a type name from a BTF ID from the kernel BTF data.
  *
- * Linux BTF data must be loaded with @ref bf_btf_setup before calling this
- * function. If @c id is invalid, or not part of the kernel's BTF data, @c NULL
- * is returned.
+ * @pre
+ *  - `btf` is not NULL.
  *
+ * @param btf Loaded kernel BTF object.
  * @param id Type ID to look for.
- * @return Name of the type represented by @c id or @c NULL .
+ * @return Name of the type represented by @p id, or NULL if @p id is
+ *         invalid or not part of @p btf.
  */
-const char *bf_btf_get_name(int id);
+const char *bf_btf_get_name(const struct btf *btf, int id);
 
 /**
- * Check if BPF token is supported by the current system.
+ * @brief Check if BPF token is supported by the current system.
  *
- * Read the kernel's BTF data to check if `prog_token_fd` is a valid field, if
- * so it is assume BPF token is supported by the current kernel.
+ * Read the kernel's BTF data to check if `prog_token_fd` is a valid field;
+ * if so, BPF token is assumed to be supported by the current kernel.
  *
+ * @pre
+ *  - `btf` is not NULL.
+ *
+ * @param btf Loaded kernel BTF object.
  * @return 0 on success, or a negative errno value on failure, including:
- * - `-ENOENT`: `prog_token_fd` can't be found, meaning BPF token is likely
- *   unsupported.
+ *         `-ENOENT` if `prog_token_fd` can't be found (BPF token likely
+ *         unsupported).
  */
-int bf_btf_kernel_has_token(void);
+int bf_btf_kernel_has_token(const struct btf *btf);
 
 /**
- * Get the offset of a field in a kernel structure.
+ * @brief Get the offset of a field in a kernel structure.
  *
- * Use Linux' BTF data to find the offset of a specific field in a structure.
- * This function will fail if the offset of a bitfield is requested.
+ * Use the kernel BTF data to find the offset of a specific field in a
+ * structure. Fails if the offset of a bitfield is requested.
  *
- * @param struct_name Name of the structure to find the offset in. Can't be
- *        NULL.
- * @param field_name Name of the field to get the offset of. Can't be NULL.
- * @return Offset of @p field_name if found, negative error value on failure.
+ * @pre
+ *  - `btf` is not NULL.
+ *  - `struct_name` is not NULL.
+ *  - `field_name` is not NULL.
+ *
+ * @param btf Loaded kernel BTF object.
+ * @param struct_name Name of the structure to find the offset in.
+ * @param field_name Name of the field to get the offset of.
+ * @return Offset of @p field_name (in bytes) if found, or a negative errno
+ *         value on failure.
  */
-int bf_btf_get_field_off(const char *struct_name, const char *field_name);
+int bf_btf_get_field_off(const struct btf *btf, const char *struct_name,
+                         const char *field_name);

--- a/src/libbpfilter/include/bpfilter/ctx.h
+++ b/src/libbpfilter/include/bpfilter/ctx.h
@@ -6,11 +6,9 @@
 #pragma once
 
 #include <stdbool.h>
-#include <stdint.h>
 
 #include <bpfilter/core/list.h>
 #include <bpfilter/dump.h>
-#include <bpfilter/elfstub.h>
 
 /**
  * @file ctx.h
@@ -19,8 +17,8 @@
  *
  * `struct bf_ctx` is an opaque, user-managed object obtained via
  * `bf_ctx_new()` and released via `bf_ctx_free()`. Each context carries
- * its own bpffs path, BPF token state and verbose-flag mask, so multiple
- * contexts may coexist within a single process.
+ * its own bpffs path, BPF token state, ELF stubs and vmlinux BTF, so
+ * multiple contexts may coexist within a single process.
  *
  * Chain state is persisted in per-chain bpffs context maps and loaded on
  * demand by `bf_ctx_get_cgen()` and `bf_ctx_get_cgens()`; the context does
@@ -50,11 +48,10 @@ struct bf_lock;
  * @param ctx Output pointer to the new context.
  * @param with_bpf_token If true, create a BPF token from bpffs.
  * @param bpffs_path Path to the bpffs mountpoint.
- * @param verbose Bitmask of verbose flags.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
-               uint16_t verbose);
+int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
+               const char *bpffs_path);
 
 /**
  * @brief Free a runtime context.
@@ -73,26 +70,12 @@ void bf_ctx_free(struct bf_ctx **ctx);
 #define _free_bf_ctx_ __attribute__((cleanup(bf_ctx_free)))
 
 /**
- * Initialise the global context.
+ * @brief Dump the runtime context.
  *
- * @param with_bpf_token If true, create a BPF token from bpffs.
- * @param bpffs_path Path to the bpffs mountpoint. Can't be NULL.
- * @param verbose Bitmask of verbose flags.
- * @return 0 on success, or a negative errno value on failure.
- */
-int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose);
-
-/**
- * Teardown the global context.
- */
-void bf_ctx_teardown(void);
-
-/**
- * Dump the global context.
- *
+ * @param ctx Runtime context. Can't be NULL.
  * @param prefix Prefix to use for the dump.
  */
-void bf_ctx_dump(prefix_t *prefix);
+void bf_ctx_dump(const struct bf_ctx *ctx, prefix_t *prefix);
 
 /**
  * @brief Load a codegen from a chain pinned in bpffs.
@@ -102,13 +85,16 @@ void bf_ctx_dump(prefix_t *prefix);
  * the chain via `bf_lock_acquire_chain`). On success `*cgen` is set to
  * a newly-allocated codegen owned by the caller (use `_free_bf_cgen_`).
  *
+ * @param ctx Runtime context the new codegen will hold a borrowed pointer
+ *        to. Can't be NULL.
  * @param lock Lock providing the chain directory file descriptor. Must
  *        hold a valid `chain_fd`. Can't be NULL.
  * @param cgen Output pointer to the loaded codegen. Can't be NULL. Left
  *        unchanged on failure.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen);
+int bf_ctx_get_cgen(const struct bf_ctx *ctx, struct bf_lock *lock,
+                    struct bf_cgen **cgen);
 
 /**
  * @brief Discover and load all codegens persisted under `{bpffs}/bpfilter/`.
@@ -121,6 +107,8 @@ int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen);
  * then releases it before moving to the next chain. Per-entry failures
  * are logged and the offending chain is skipped.
  *
+ * @param ctx Runtime context the new codegens will hold a borrowed pointer
+ *        to. Can't be NULL.
  * @param lock Lock that must already hold the pin directory locked
  *        (e.g. via `bf_lock_init(BF_LOCK_READ)` or `BF_LOCK_WRITE`).
  *        Must not currently hold a chain lock. Can't be NULL.
@@ -130,24 +118,5 @@ int bf_ctx_get_cgen(struct bf_lock *lock, struct bf_cgen **cgen);
  * @return 0 on success, or a negative errno value on setup failure
  *         (cannot open pin directory, allocation failure).
  */
-int bf_ctx_get_cgens(struct bf_lock *lock, bf_list **cgens);
-
-/**
- * Get the BPF token file descriptor.
- *
- * @return The BPF token file descriptor, or -1 if no token is used.
- */
-int bf_ctx_token(void);
-
-/**
- * @brief Get a ELF stub from its ID.
- *
- * @param id ID of the ELF stub to retrieve.
- * @return The requested ELF stub.
- */
-const struct bf_elfstub *bf_ctx_get_elfstub(enum bf_elfstub_id id);
-
-/**
- * @return Path to the configured BPF filesystem.
- */
-const char *bf_ctx_get_bpffs_path(void);
+int bf_ctx_get_cgens(const struct bf_ctx *ctx, struct bf_lock *lock,
+                     bf_list **cgens);

--- a/src/libbpfilter/include/bpfilter/ctx.h
+++ b/src/libbpfilter/include/bpfilter/ctx.h
@@ -31,14 +31,6 @@ struct bf_cgen;
 struct bf_ctx;
 struct bf_lock;
 
-enum bf_verbose
-{
-    BF_VERBOSE_DEBUG,
-    BF_VERBOSE_BPF,
-    BF_VERBOSE_BYTECODE,
-    _BF_VERBOSE_MAX,
-};
-
 /**
  * @brief Allocate and initialise a new runtime context.
  *
@@ -154,11 +146,6 @@ int bf_ctx_token(void);
  * @return The requested ELF stub.
  */
 const struct bf_elfstub *bf_ctx_get_elfstub(enum bf_elfstub_id id);
-
-/**
- * @return true if the given verbose flag is set.
- */
-bool bf_ctx_is_verbose(enum bf_verbose opt);
 
 /**
  * @return Path to the configured BPF filesystem.

--- a/src/libbpfilter/include/bpfilter/ctx.h
+++ b/src/libbpfilter/include/bpfilter/ctx.h
@@ -15,18 +15,20 @@
 /**
  * @file ctx.h
  *
- * Global runtime context for `bpfilter`.
+ * Runtime context for `bpfilter`.
  *
- * This file contains the definition of the `bf_ctx` structure, which is
- * the main structure used to store the runtime context.
+ * `struct bf_ctx` is an opaque, user-managed object obtained via
+ * `bf_ctx_new()` and released via `bf_ctx_free()`. Each context carries
+ * its own bpffs path, BPF token state and verbose-flag mask, so multiple
+ * contexts may coexist within a single process.
  *
- * All the public `bf_ctx_*` functions manipulate a private global context.
  * Chain state is persisted in per-chain bpffs context maps and loaded on
- * demand by `bf_ctx_get_cgen()` and `bf_ctx_get_cgens()`; the global
- * context does not cache them.
+ * demand by `bf_ctx_get_cgen()` and `bf_ctx_get_cgens()`; the context does
+ * not cache them.
  */
 
 struct bf_cgen;
+struct bf_ctx;
 struct bf_lock;
 
 enum bf_verbose
@@ -36,6 +38,47 @@ enum bf_verbose
     BF_VERBOSE_BYTECODE,
     _BF_VERBOSE_MAX,
 };
+
+/**
+ * @brief Allocate and initialise a new runtime context.
+ *
+ * On success, `*ctx` points to a freshly allocated context. The caller owns
+ * the pointer and must release it with `bf_ctx_free()` (or via the
+ * `_free_bf_ctx_` cleanup attribute). The context owns a heap copy of
+ * `bpffs_path`; the caller may free or modify the input string after the
+ * call returns.
+ *
+ * @pre
+ *  - `ctx` is not NULL.
+ *  - `bpffs_path` is not NULL.
+ * @post
+ *  - On success: `*ctx` points to a fully-initialised context.
+ *  - On failure: `*ctx` is unchanged.
+ *
+ * @param ctx Output pointer to the new context.
+ * @param with_bpf_token If true, create a BPF token from bpffs.
+ * @param bpffs_path Path to the bpffs mountpoint.
+ * @param verbose Bitmask of verbose flags.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token, const char *bpffs_path,
+               uint16_t verbose);
+
+/**
+ * @brief Free a runtime context.
+ *
+ * If `*ctx` is NULL, the call is a no-op.
+ *
+ * @pre
+ *  - `ctx` is not NULL.
+ * @post
+ *  - `*ctx == NULL`.
+ *
+ * @param ctx Context to free.
+ */
+void bf_ctx_free(struct bf_ctx **ctx);
+
+#define _free_bf_ctx_ __attribute__((cleanup(bf_ctx_free)))
 
 /**
  * Initialise the global context.

--- a/src/libbpfilter/include/bpfilter/elfstub.h
+++ b/src/libbpfilter/include/bpfilter/elfstub.h
@@ -70,6 +70,7 @@
  */
 
 struct bpf_insn;
+struct btf;
 
 /**
  * @brief Identifiers for the ELF stubs.
@@ -197,13 +198,15 @@ struct bf_elfstub
  *
  * The corresponding raw ELF stub will be read, its text section will be copied
  * into the final ELF, and the calls to kfuncs will be relocated according to
- * the host's kernel.
+ * the host's kernel BTF.
  *
  * @param stub ELF stub to allocate and initialize. Can't be NULL.
+ * @param btf Kernel BTF used to resolve kfunc call IDs. Can't be NULL.
  * @param id Identifier of the raw ELF stub to initialize.
  * @return 0 on success, or negative errno value on failure.
  */
-int bf_elfstub_new(struct bf_elfstub **stub, enum bf_elfstub_id id);
+int bf_elfstub_new(struct bf_elfstub **stub, const struct btf *btf,
+                   enum bf_elfstub_id id);
 
 /**
  * Deinitialise and deallocate an ELF stub.

--- a/src/libbpfilter/include/bpfilter/logger.h
+++ b/src/libbpfilter/include/bpfilter/logger.h
@@ -5,9 +5,28 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h> // NOLINT: fprintf is used
 
 #include <bpfilter/helper.h>
+
+/**
+ * @brief Verbose flags controlling optional debug output emitted by the
+ * library.
+ *
+ * The mask is process-wide configuration (see `bf_logger_set_verbose()`)
+ * rather than per-context state, since the same code paths consult these
+ * flags from many call sites that would otherwise have to thread the
+ * runtime context.
+ */
+enum bf_verbose
+{
+    BF_VERBOSE_DEBUG,
+    BF_VERBOSE_BPF,
+    BF_VERBOSE_BYTECODE,
+    _BF_VERBOSE_MAX,
+};
 
 enum bf_color
 {
@@ -219,3 +238,23 @@ const char *bf_log_level_to_str(enum bf_log_level level);
  *         otherwise.
  */
 enum bf_log_level bf_log_level_from_str(const char *str);
+
+/**
+ * @brief Set the process-wide verbose flag bitmask.
+ *
+ * @param mask Bitmask of `BF_FLAG(BF_VERBOSE_*)` values.
+ */
+void bf_logger_set_verbose(uint16_t mask);
+
+/**
+ * @brief Return the current process-wide verbose flag bitmask.
+ */
+uint16_t bf_logger_get_verbose(void);
+
+/**
+ * @brief Test whether a verbose flag is set in the process-wide mask.
+ *
+ * @param opt Flag to test.
+ * @return `true` if the flag is set, `false` otherwise.
+ */
+bool bf_logger_is_verbose(enum bf_verbose opt);

--- a/src/libbpfilter/logger.c
+++ b/src/libbpfilter/logger.c
@@ -16,6 +16,9 @@ static bool _bf_can_print_color = false;
  * be ignored (not printed). */
 static enum bf_log_level _bf_log_level = BF_LOG_INFO;
 
+/** Process-wide verbose flag bitmask. */
+static uint16_t _bf_verbose;
+
 void bf_logger_setup(void)
 {
     _bf_can_print_color = isatty(fileno(stdout)) && isatty(fileno(stderr));
@@ -98,4 +101,19 @@ enum bf_log_level bf_log_level_from_str(const char *str)
     }
 
     return -EINVAL;
+}
+
+void bf_logger_set_verbose(uint16_t mask)
+{
+    _bf_verbose = mask;
+}
+
+uint16_t bf_logger_get_verbose(void)
+{
+    return _bf_verbose;
+}
+
+bool bf_logger_is_verbose(enum bf_verbose opt)
+{
+    return (_bf_verbose & BF_FLAG(opt)) != 0;
 }

--- a/tests/e2e/verdicts/next.cpp
+++ b/tests/e2e/verdicts/next.cpp
@@ -41,7 +41,7 @@ static void next_rule_verdict(void **state)
     (void)state;
 
     for (auto hook: kTestableHooks) {
-        assert_int_equal(0, bf_ruleset_flush());
+        assert_int_equal(0, bf_ruleset_flush(bft_matcher_ctx));
 
         // IPPROTO_TCP = 6
         BFT_CHAIN_SET(
@@ -72,7 +72,7 @@ static void next_policy(void **state)
     (void)state;
 
     for (auto hook: kTestableHooks) {
-        assert_int_equal(0, bf_ruleset_flush());
+        assert_int_equal(0, bf_ruleset_flush(bft_matcher_ctx));
 
         // IPPROTO_TCP = 6
         BFT_CHAIN_SET(
@@ -120,11 +120,13 @@ static void next_is_terminal(void **state)
 
 int main()
 {
-    int r = bf_ctx_setup(false, "/sys/fs/bpf", 0);
+    _free_bf_ctx_ struct bf_ctx *ctx = nullptr;
+    int r = bf_ctx_new(&ctx, false, "/sys/fs/bpf");
     if (r != 0) {
         bf_err("failed to setup bpfilter context: %s", strerror(-r));
         return 1;
     }
+    bft_matcher_ctx = ctx;
 
     const std::vector<CMUnitTest> tests = {
         cmocka_unit_test_setup_teardown(next_rule_verdict,
@@ -139,6 +141,6 @@ int main()
 
     r = _cmocka_run_group_tests("NEXT verdict", tests.data(), tests.size(),
                                 nullptr, nullptr);
-    bf_ctx_teardown();
+    bft_matcher_ctx = nullptr;
     return r;
 }

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -20,6 +20,8 @@
 
 #include "bpfilter/core/list.h"
 
+const struct bf_ctx *bft_matcher_ctx = NULL;
+
 void bft_assert_counter_eq(const char *chain_name, size_t rule_idx,
                            uint64_t packets, int64_t bytes)
 {
@@ -27,9 +29,10 @@ void bft_assert_counter_eq(const char *chain_name, size_t rule_idx,
     _free_bf_hookopts_ struct bf_hookopts *hopts = NULL;
     struct bf_rule *rule;
 
+    assert_non_null(bft_matcher_ctx);
     assert_non_null(chain_name);
 
-    assert_ok(bf_chain_get(chain_name, &chain, &hopts));
+    assert_ok(bf_chain_get(bft_matcher_ctx, chain_name, &chain, &hopts));
 
     rule = bf_list_get_at(&chain->rules, rule_idx);
     assert_non_null(rule);
@@ -314,30 +317,45 @@ bool bft_matcher_equal(const struct bf_matcher *matcher0,
                        bf_matcher_payload_len(matcher0));
 }
 
-int bft_setup_ctx(void **state)
+int bft_setup_ctx_state(void **state)
 {
     _free_bft_tmpdir_ struct bft_tmpdir *tmpdir = NULL;
+    _free_bf_ctx_ struct bf_ctx *ctx = NULL;
+    struct bft_ctx_state *_state;
     int r;
 
     r = bft_tmpdir_new(&tmpdir);
     if (r)
         return r;
 
-    r = bf_ctx_setup(false, tmpdir->dir_path, BF_FLAG(BF_VERBOSE_DEBUG));
+    bf_logger_set_verbose(BF_FLAG(BF_VERBOSE_DEBUG));
+
+    r = bf_ctx_new(&ctx, false, tmpdir->dir_path);
     if (r)
         return r;
 
-    *state = TAKE_PTR(tmpdir);
+    _state = malloc(sizeof(*_state));
+    if (!_state)
+        return -ENOMEM;
+
+    _state->tmpdir = TAKE_PTR(tmpdir);
+    _state->ctx = TAKE_PTR(ctx);
+
+    *state = _state;
 
     return 0;
 }
 
-int bft_teardown_ctx(void **state)
+int bft_teardown_ctx_state(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_ctx_state *_state = *state;
 
-    bf_ctx_teardown();
-    bft_tmpdir_free(&tmpdir);
+    if (!_state)
+        return 0;
+
+    bf_ctx_free(&_state->ctx);
+    bft_tmpdir_free(&_state->tmpdir);
+    free(_state);
 
     *state = NULL;
 

--- a/tests/harness/test.cpp
+++ b/tests/harness/test.cpp
@@ -39,7 +39,7 @@ void bft_assert_prog_run(const char *chain_name, enum bf_hook hook,
 
     static_assert(sizeof(nf_hook_state_ctx) == 48);
 
-    fd = bf_chain_prog_fd(chain_name);
+    fd = bf_chain_prog_fd(bft_matcher_ctx, chain_name);
     assert_true(fd >= 0);
 
     if (bf_hook_to_flavor(hook) == BF_FLAVOR_NF) {
@@ -126,7 +126,7 @@ int bft_matcher_test_setup(void **state)
 {
     (void)state;
 
-    int r = bf_ruleset_flush();
+    int r = bf_ruleset_flush(bft_matcher_ctx);
     if (r != 0)
         return bf_err_r(r, "failed to flush ruleset in test setup");
 
@@ -137,7 +137,7 @@ int bft_matcher_test_teardown(void **state)
 {
     (void)state;
 
-    int r = bf_ruleset_flush();
+    int r = bf_ruleset_flush(bft_matcher_ctx);
     if (r != 0)
         return bf_err_r(r, "failed to flush ruleset in test teardown");
 

--- a/tests/harness/test.h
+++ b/tests/harness/test.h
@@ -24,8 +24,19 @@
 
 #include "fake.h"
 
+struct bf_ctx;
 struct bf_set;
 struct bf_counter;
+
+/**
+ * @brief Module-level borrowed context used by the test harness helpers.
+ *
+ * Defined in `test.c`. Test entry points (e.g. `MatcherTestsSuite::run` or
+ * a `main()` that constructs a `bf_ctx` for a suite) assign this so that
+ * `bft_assert_counter_eq` and `bft_assert_prog_run` can resolve chains
+ * without each caller threading the context manually.
+ */
+extern const struct bf_ctx *bft_matcher_ctx;
 
 #define assert_ok(expr) assert_true((expr) == 0)
 #define assert_err(expr) assert_true((expr) < 0)
@@ -216,30 +227,60 @@ int bft_hook_drop(enum bf_hook hook);
 int bft_hook_next(enum bf_hook hook);
 
 /**
- * @brief Initialize the global test `bf_ctx`.
+ * @brief Pair of a temporary bpffs directory and the `bf_ctx` constructed
+ * over it. Stored as the cmocka test state by `bft_setup_ctx_state`.
+ */
+struct bft_ctx_state
+{
+    struct bft_tmpdir *tmpdir;
+    struct bf_ctx *ctx;
+};
+
+/**
+ * @brief Initialize a test `bf_ctx` over a fresh temporary directory.
  *
  * @pre
  * - `state` is not NULL.
  * @post
- * - On success: `*state` is a pointer to a valid heap-allocated `bft_tmpdir`
- *   object, and the global `bf_ctx` has been initalized with the temporary
- *   directory.
+ * - On success: `*state` is a pointer to a freshly allocated
+ *   `struct bft_ctx_state` containing the constructed context and the
+ *   backing temporary directory.
  * - On failure: `*state` is unchanged.
  *
  * @param state Pointer to a custom object, provided by CMocka.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bft_setup_ctx(void **state);
+int bft_setup_ctx_state(void **state);
 
 /**
- * @brief Cleanup the global test `bf_ctx`.
+ * @brief Cleanup the test `bf_ctx` and its temporary directory.
  *
  * @pre
- * - `state` is not NULL, `*state` points to a valid `bft_tmpdir`.
+ * - `state` is not NULL, `*state` points to a valid `bft_ctx_state`.
  * @post
- * - The `bft_tmpdir` has been deallocated, `*state` is NULL.
+ * - The state has been deallocated, `*state` is NULL.
  *
  * @param state Pointer to a custom test object, provided by CMocka.
  * @return 0 on success, or a negative errno value on failure.
  */
-int bft_teardown_ctx(void **state);
+int bft_teardown_ctx_state(void **state);
+
+/**
+ * @brief Return the `bf_ctx` from a `bft_ctx_state` cmocka state.
+ *
+ * @param state Pointer captured by cmocka; must point to a valid
+ *        `bft_ctx_state`.
+ * @return The borrowed `bf_ctx` pointer.
+ */
+static inline const struct bf_ctx *bft_state_ctx(void *state)
+{
+    return ((const struct bft_ctx_state *)state)->ctx;
+}
+
+/**
+ * @brief Return the temporary directory from a `bft_ctx_state` cmocka state.
+ */
+static inline struct bft_tmpdir *bft_state_tmpdir(void *state)
+{
+    return ((struct bft_ctx_state *)state)->tmpdir;
+}

--- a/tests/harness/test.hpp
+++ b/tests/harness/test.hpp
@@ -59,7 +59,8 @@ int bft_matcher_test_teardown(void **state);
 #define BFT_CHAIN_SET(chain_expr)                                              \
     do {                                                                       \
         auto _bft_chain = (chain_expr).get();                                  \
-        assert_int_equal(0, bf_chain_set(_bft_chain.get(), nullptr));          \
+        assert_int_equal(                                                      \
+            0, bf_chain_set(bft_matcher_ctx, _bft_chain.get(), nullptr));      \
     } while (0)
 
 /**
@@ -353,11 +354,13 @@ public:
 
     int run()
     {
-        int r = bf_ctx_setup(false, "/sys/fs/bpf", 0);
+        _free_bf_ctx_ struct bf_ctx *ctx = nullptr;
+        int r = bf_ctx_new(&ctx, false, "/sys/fs/bpf");
         if (r != 0) {
             bf_err("failed to setup bpfilter context: %s", strerror(-r));
             return 1;
         }
+        bft_matcher_ctx = ctx;
 
         std::vector<CMUnitTest> tests;
         tests.reserve(_tests.size() + 1);
@@ -380,7 +383,7 @@ public:
 
         r = _cmocka_run_group_tests(bf_matcher_type_to_str(_type), tests.data(),
                                     tests.size(), nullptr, nullptr);
-        bf_ctx_teardown();
+        bft_matcher_ctx = nullptr;
         return r;
     }
 };

--- a/tests/unit/libbpfilter/btf.c
+++ b/tests/unit/libbpfilter/btf.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include <bpf/btf.h>
 #include <limits.h>
 
 #include <bpfilter/btf.h>
@@ -10,87 +11,89 @@
 #include "mock.h"
 #include "test.h"
 
-static void init_and_clean(void **state)
+static void load_failure(void **state)
 {
+    _clean_bft_mock_ bft_mock _ = bft_mock_get(btf__load_vmlinux_btf);
+
     (void)state;
 
-    {
-        _clean_bft_mock_ bft_mock _ = bft_mock_get(btf__load_vmlinux_btf);
-
-        assert_err(bf_btf_setup());
-    }
-
-    assert_ok(bf_btf_setup());
-    bf_btf_teardown();
-    assert_ok(bf_btf_setup());
-    bf_btf_teardown();
+    assert_null(btf__load_vmlinux_btf());
 }
 
 static void get_id_and_name(void **state)
 {
+    struct btf *btf;
     int id;
 
     (void)state;
 
-    assert_ok(bf_btf_setup());
+    btf = btf__load_vmlinux_btf();
+    assert_non_null(btf);
 
     // Unknown type
-    assert_err(bf_btf_get_id("les carottes sont cuites"));
+    assert_err(bf_btf_get_id(btf, "les carottes sont cuites"));
 
-    id = bf_btf_get_id("sk_buff");
+    id = bf_btf_get_id(btf, "sk_buff");
     assert_int_gte(id, 0);
 
-    assert_string_equal(bf_btf_get_name(id), "sk_buff");
+    assert_string_equal(bf_btf_get_name(btf, id), "sk_buff");
 
-    assert_null(bf_btf_get_name(-1));
-    assert_null(bf_btf_get_name(INT_MAX));
+    assert_null(bf_btf_get_name(btf, -1));
+    assert_null(bf_btf_get_name(btf, INT_MAX));
 
-    bf_btf_teardown();
+    btf__free(btf);
 }
 
 static void check_token(void **state)
 {
+    struct btf *btf;
+
     (void)state;
 
-    assert_ok(bf_btf_setup());
+    btf = btf__load_vmlinux_btf();
+    assert_non_null(btf);
 
-    /* Ignore the return value, has the expected result depends on the current
-     * kernel version, but trigger the code path anyway. */
-    bf_btf_kernel_has_token();
+    /* Ignore the return value, as the expected result depends on the
+     * current kernel version, but trigger the code path anyway. */
+    bf_btf_kernel_has_token(btf);
 
-    bf_btf_teardown();
+    btf__free(btf);
 }
 
 static void get_field_offset(void **state)
 {
+    struct btf *btf;
+
     (void)state;
 
-    assert_ok(bf_btf_setup());
+    btf = btf__load_vmlinux_btf();
+    assert_non_null(btf);
 
-    assert_int_gte(bf_btf_get_field_off("sk_buff", "sk"), 0);
+    assert_int_gte(bf_btf_get_field_off(btf, "sk_buff", "sk"), 0);
 
     // Nested in anonymous union/structs
-    assert_int_equal(bf_btf_get_field_off("sk_buff", "next"), 0);
-    assert_int_equal(bf_btf_get_field_off("sk_buff", "prev"), sizeof(void *));
-    assert_int_equal(bf_btf_get_field_off("sk_buff", "dev"),
+    assert_int_equal(bf_btf_get_field_off(btf, "sk_buff", "next"), 0);
+    assert_int_equal(bf_btf_get_field_off(btf, "sk_buff", "prev"),
+                     sizeof(void *));
+    assert_int_equal(bf_btf_get_field_off(btf, "sk_buff", "dev"),
                      2 * sizeof(void *));
 
     // Invalid compound type
-    assert_err(bf_btf_get_field_off("les carottes", "sont cuites"));
+    assert_err(bf_btf_get_field_off(btf, "les carottes", "sont cuites"));
 
     // Invalid field
-    assert_err(bf_btf_get_field_off("sk_buff", "sont cuites"));
+    assert_err(bf_btf_get_field_off(btf, "sk_buff", "sont cuites"));
 
     // Bitfield are not supported
-    assert_err(bf_btf_get_field_off("tcphdr", "syn"));
+    assert_err(bf_btf_get_field_off(btf, "tcphdr", "syn"));
 
-    bf_btf_teardown();
+    btf__free(btf);
 }
 
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(init_and_clean),
+        cmocka_unit_test(load_failure),
         cmocka_unit_test(get_id_and_name),
         cmocka_unit_test(check_token),
         cmocka_unit_test(get_field_offset),

--- a/tests/unit/libbpfilter/cli.c
+++ b/tests/unit/libbpfilter/cli.c
@@ -29,14 +29,14 @@ static void ruleset_get(void **state)
         _clean_bf_list_ bf_list chains = bf_list_default(NULL, NULL);
         _clean_bf_list_ bf_list hookopts = bf_list_default(NULL, NULL);
 
-        assert_ok(bf_ruleset_get(&chains, &hookopts));
+        assert_ok(bf_ruleset_get(bft_state_ctx(*state), &chains, &hookopts));
         assert_int_equal(bf_list_size(&chains), 0);
         assert_int_equal(bf_list_size(&hookopts), 0);
     }
 
     {
         // Skip corrupt chains
-        struct bft_tmpdir *tmpdir = *state;
+        struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
         _clean_bf_list_ bf_list chains = bf_list_default(NULL, NULL);
         _clean_bf_list_ bf_list hookopts = bf_list_default(NULL, NULL);
         char path[PATH_MAX];
@@ -51,7 +51,7 @@ static void ruleset_get(void **state)
                        tmpdir->dir_path);
         assert_ok(mkdir(path, 0755));
 
-        assert_ok(bf_ruleset_get(&chains, &hookopts));
+        assert_ok(bf_ruleset_get(bft_state_ctx(*state), &chains, &hookopts));
         assert_int_equal(bf_list_size(&chains), 0);
         assert_int_equal(bf_list_size(&hookopts), 0);
     }
@@ -68,7 +68,7 @@ static void ruleset_set(void **state)
 
     // Mismatched list sizes should fail
     assert_ok(bf_list_add_tail(&chains, bft_chain_dummy(false)));
-    assert_err(bf_ruleset_set(&chains, &hookopts));
+    assert_err(bf_ruleset_set(bft_state_ctx(*state), &chains, &hookopts));
 }
 
 static void ruleset_flush(void **state)
@@ -76,7 +76,7 @@ static void ruleset_flush(void **state)
     (void)state;
 
     // Empty ruleset
-    assert_ok(bf_ruleset_flush());
+    assert_ok(bf_ruleset_flush(bft_state_ctx(*state)));
 }
 
 static void chain_set(void **state)
@@ -85,7 +85,7 @@ static void chain_set(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_set(chain, NULL));
+    assert_err(bf_chain_set(bft_state_ctx(*state), chain, NULL));
 }
 
 static void chain_get(void **state)
@@ -95,21 +95,22 @@ static void chain_get(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_get("invalid_chain", &chain, &hookopts));
+    assert_err(
+        bf_chain_get(bft_state_ctx(*state), "invalid_chain", &chain, &hookopts));
 }
 
 static void chain_prog_fd(void **state)
 {
     (void)state;
 
-    assert_err(bf_chain_prog_fd("invalid_chain"));
+    assert_err(bf_chain_prog_fd(bft_state_ctx(*state), "invalid_chain"));
 }
 
 static void chain_logs_fd(void **state)
 {
     (void)state;
 
-    assert_err(bf_chain_logs_fd("invalid_chain"));
+    assert_err(bf_chain_logs_fd(bft_state_ctx(*state), "invalid_chain"));
 }
 
 static void chain_load(void **state)
@@ -118,7 +119,7 @@ static void chain_load(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_load(chain));
+    assert_err(bf_chain_load(bft_state_ctx(*state), chain));
 }
 
 static void chain_attach(void **state)
@@ -127,7 +128,8 @@ static void chain_attach(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_attach("invalid_chain", &hookopts));
+    assert_err(
+        bf_chain_attach(bft_state_ctx(*state), "invalid_chain", &hookopts));
 }
 
 static void chain_update(void **state)
@@ -136,7 +138,7 @@ static void chain_update(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_update(chain));
+    assert_err(bf_chain_update(bft_state_ctx(*state), chain));
 }
 
 static void chain_update_set(void **state)
@@ -146,43 +148,44 @@ static void chain_update_set(void **state)
 
     (void)state;
 
-    assert_err(bf_chain_update_set("invalid_name", set0, set1));
+    assert_err(
+        bf_chain_update_set(bft_state_ctx(*state), "invalid_name", set0, set1));
 }
 
 static void chain_flush(void **state)
 {
     (void)state;
 
-    assert_err(bf_chain_flush("invalid_chain"));
+    assert_err(bf_chain_flush(bft_state_ctx(*state), "invalid_chain"));
 }
 
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test_setup_teardown(ruleset_get, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(ruleset_set, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(ruleset_flush, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_set, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_get, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_prog_fd, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_logs_fd, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_load, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_attach, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_update, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_update_set, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(chain_flush, bft_setup_ctx,
-                                        bft_teardown_ctx),
+        cmocka_unit_test_setup_teardown(ruleset_get, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(ruleset_set, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(ruleset_flush, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_set, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_get, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_prog_fd, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_logs_fd, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_load, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_attach, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_update, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_update_set, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(chain_flush, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/libbpfilter/core/lock.c
+++ b/tests/unit/libbpfilter/core/lock.c
@@ -49,10 +49,11 @@ static void default_values(void **state)
 /* Success post: bpffs_fd and pindir_fd are valid, pindir_lock == mode. */
 static void init_success_post_state(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
     assert_fd(lock.bpffs_fd);
     assert_fd(lock.pindir_fd);
     assert_int_equal(lock.pindir_lock, BF_LOCK_READ);
@@ -73,9 +74,11 @@ static void init_failure_preserves_lock(void **state)
     (void)state;
 
     /* Hold WRITE on the pindir so a second WRITE init will fail. */
-    assert_ok(bf_lock_init(&holder, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&holder, bft_state_tmpdir(*state)->dir_path,
+                           BF_LOCK_WRITE));
 
-    assert_err(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_err(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
 
     /* lock is unchanged (still in default state). */
     assert_int_equal(lock.bpffs_fd, -1);
@@ -96,11 +99,14 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock1 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
-        assert_err(
-            bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
-        assert_err(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
-        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
+        assert_err(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                                BF_LOCK_WRITE));
+        assert_err(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                                BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_NONE));
     }
 
     {
@@ -108,11 +114,14 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock1 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
-        assert_err(
-            bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
-        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
-        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_READ));
+        assert_err(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                                BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_NONE));
     }
 
     {
@@ -121,12 +130,15 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock3 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_NONE));
 
-        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
         bf_lock_cleanup(&lock2);
 
-        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_READ));
         bf_lock_cleanup(&lock2);
     }
 }
@@ -135,12 +147,13 @@ static void pindir_lock_matrix(void **state)
  * the library). Multiple init/cleanup cycles never remove the pindir. */
 static void pindir_survives_repeated_cycles(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
 
     for (int i = 0; i < 5; ++i) {
         struct bf_lock lock = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_READ));
         bf_lock_cleanup(&lock);
         assert_dir_exists(tmpdir, "bpfilter");
     }
@@ -153,7 +166,7 @@ static void pindir_survives_repeated_cycles(void **state)
 /* Invalid lock (default state) => -EBADFD; lock unchanged. */
 static void acquire_chain_uninitialized_rejects(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     struct bf_lock lock = bf_lock_default();
 
     // Pindir not locked, can't acquire a chain
@@ -168,9 +181,10 @@ static void acquire_chain_uninitialized_rejects(void **state)
 static void acquire_chain_double_rejects(void **state)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "first", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/first");
 
@@ -186,9 +200,10 @@ static void acquire_chain_double_rejects(void **state)
 static void acquire_chain_create(void **state)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
 
     // Acquire with READ and create=true fails
     assert_err(bf_lock_acquire_chain(&lock, "c", BF_LOCK_READ, true));
@@ -210,9 +225,10 @@ static void acquire_chain_create(void **state)
 static void acquire_chain_missing_fails(void **state)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
     assert_err(bf_lock_acquire_chain(&lock, "absent", BF_LOCK_READ, false));
     assert_dir_not_exists(tmpdir, "bpfilter/absent");
 }
@@ -231,15 +247,18 @@ static void chain_read_compatible_read(void **state)
 
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "shared", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock1, bf_ctx_get_bpffs_path(), "shared",
-                                     BF_LOCK_READ, BF_LOCK_READ, false));
-    assert_ok(bf_lock_init_for_chain(&lock2, bf_ctx_get_bpffs_path(), "shared",
-                                     BF_LOCK_READ, BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock1, bft_state_tmpdir(*state)->dir_path,
+                                     "shared", BF_LOCK_READ, BF_LOCK_READ,
+                                     false));
+    assert_ok(bf_lock_init_for_chain(&lock2, bft_state_tmpdir(*state)->dir_path,
+                                     "shared", BF_LOCK_READ, BF_LOCK_READ,
+                                     false));
 }
 
 /* Two locks on DIFFERENT chains are compatible, even when both hold WRITE.
@@ -256,7 +275,8 @@ static void chain_lock_isolates_per_chain(void **state)
     /* Materialise both chains so they can be opened with create=false. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "alpha", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
 
@@ -265,14 +285,16 @@ static void chain_lock_isolates_per_chain(void **state)
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock_a, bf_ctx_get_bpffs_path(), "alpha",
-                                     BF_LOCK_READ, BF_LOCK_WRITE, false));
+    assert_ok(
+        bf_lock_init_for_chain(&lock_a, bft_state_tmpdir(*state)->dir_path,
+                               "alpha", BF_LOCK_READ, BF_LOCK_WRITE, false));
     assert_string_equal(lock_a.chain_name, "alpha");
     assert_int_equal(lock_a.chain_lock, BF_LOCK_WRITE);
 
     /* Independent chain: WRITE on "beta" must not contend with WRITE on
      * "alpha". */
-    assert_ok(bf_lock_init_for_chain(&lock_b, bf_ctx_get_bpffs_path(), "beta",
+    assert_ok(bf_lock_init_for_chain(&lock_b,
+                                     bft_state_tmpdir(*state)->dir_path, "beta",
                                      BF_LOCK_READ, BF_LOCK_WRITE, false));
     assert_string_equal(lock_b.chain_name, "beta");
     assert_int_equal(lock_b.chain_lock, BF_LOCK_WRITE);
@@ -300,7 +322,8 @@ static void release_chain_idempotent(void **state)
     assert_int_equal(lock.chain_lock, BF_LOCK_NONE);
 
     /* Initialised lock with no chain held: still a no-op, twice. */
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
     bf_lock_release_chain(&lock);
     bf_lock_release_chain(&lock);
     assert_fd(lock.pindir_fd);
@@ -327,7 +350,8 @@ static void release_then_reacquire(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
 
     assert_ok(bf_lock_acquire_chain(&lock, "first", BF_LOCK_WRITE, true));
     assert_string_equal(lock.chain_name, "first");
@@ -356,19 +380,21 @@ static void release_then_reacquire(void **state)
  * removal gate is `chain_lock == BF_LOCK_WRITE`). */
 static void chain_lock_none_acquire_and_release(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
     /* Pre-create the chain dir; we'll open it with chain mode == NONE. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
         assert_ok(
             bf_lock_acquire_chain(&prep, "none_chain", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
     assert_ok(bf_lock_acquire_chain(&lock, "none_chain", BF_LOCK_NONE, false));
 
     /* Because chain_lock != WRITE, release must NOT remove the chain dir,
@@ -384,7 +410,8 @@ static void release_no_chain_is_noop(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
     bf_lock_release_chain(&lock);
 
     /* Pindir state untouched. */
@@ -398,10 +425,11 @@ static void release_no_chain_is_noop(void **state)
 /* WRITE release removes an empty chain dir; the chain fields are reset. */
 static void release_write_removes_empty_chain(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "empty", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/empty");
 
@@ -421,10 +449,11 @@ static void release_write_removes_empty_chain(void **state)
 /* WRITE release does NOT remove a non-empty chain dir. */
 static void release_write_keeps_nonempty_chain(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "populated", BF_LOCK_WRITE, true));
     /* Populate so rmdir returns ENOTEMPTY and no-ops. */
     (void)mknodat(lock.chain_fd, "inside", S_IFREG | 0644, 0);
@@ -437,7 +466,7 @@ static void release_write_keeps_nonempty_chain(void **state)
 /* READ release does NOT remove the chain dir (I2). */
 static void release_read_keeps_chain(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
     (void)state;
@@ -447,13 +476,15 @@ static void release_read_keeps_chain(void **state)
      * observe via the "chain stays" invariant. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bft_state_tmpdir(*state)->dir_path,
+                               BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "reader", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "reader",
-                                     BF_LOCK_READ, BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path,
+                                     "reader", BF_LOCK_READ, BF_LOCK_READ,
+                                     false));
 
     bf_lock_release_chain(&lock);
     assert_dir_exists(tmpdir, "bpfilter/reader");
@@ -475,7 +506,8 @@ static void cleanup_idempotent(void **state)
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
     bf_lock_cleanup(&lock);
     bf_lock_cleanup(&lock);
 
@@ -496,20 +528,23 @@ static void cleanup_releases_pindir_lock(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock1, bft_state_tmpdir(*state)->dir_path,
+                           BF_LOCK_WRITE));
     bf_lock_cleanup(&lock1);
 
-    assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock2, bft_state_tmpdir(*state)->dir_path,
+                           BF_LOCK_WRITE));
 }
 
 /* Cleanup on a lock holding a chain WRITE lock releases both locks and
  * removes the empty chain dir; the pindir itself is kept (I1). */
 static void cleanup_with_chain_lock(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "c", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/c");
 
@@ -534,9 +569,10 @@ static void init_for_chain_create_needs_write_pindir(void **state)
 
     (void)state;
 
-    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "c",
-                                            BF_LOCK_READ, BF_LOCK_WRITE, true),
-                     -EINVAL);
+    assert_int_equal(
+        bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path, "c",
+                               BF_LOCK_READ, BF_LOCK_WRITE, true),
+        -EINVAL);
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
     assert_int_equal(lock.chain_fd, -1);
@@ -550,9 +586,10 @@ static void init_for_chain_create_needs_write_chain(void **state)
 
     (void)state;
 
-    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "c",
-                                            BF_LOCK_WRITE, BF_LOCK_READ, true),
-                     -EINVAL);
+    assert_int_equal(
+        bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path, "c",
+                               BF_LOCK_WRITE, BF_LOCK_READ, true),
+        -EINVAL);
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
 }
@@ -564,8 +601,9 @@ static void init_for_chain_success(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "both",
-                                     BF_LOCK_WRITE, BF_LOCK_WRITE, true));
+    assert_ok(bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path,
+                                     "both", BF_LOCK_WRITE, BF_LOCK_WRITE,
+                                     true));
     assert_fd(lock.bpffs_fd);
     assert_fd(lock.pindir_fd);
     assert_int_equal(lock.pindir_lock, BF_LOCK_WRITE);
@@ -582,10 +620,10 @@ static void init_for_chain_failure_preserves_lock(void **state)
     (void)state;
 
     /* Missing chain, create=false. */
-    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(),
-                                            "absent", BF_LOCK_READ,
-                                            BF_LOCK_READ, false),
-                     -ENOENT);
+    assert_int_equal(
+        bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path,
+                               "absent", BF_LOCK_READ, BF_LOCK_READ, false),
+        -ENOENT);
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
     assert_int_equal(lock.chain_fd, -1);
@@ -597,55 +635,75 @@ int main(void)
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(default_values),
 
-        cmocka_unit_test_setup_teardown(init_success_post_state, bft_setup_ctx,
-                                        bft_teardown_ctx),
+        cmocka_unit_test_setup_teardown(init_success_post_state,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(init_failure_preserves_lock,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(pindir_lock_matrix, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(pindir_lock_matrix, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(pindir_survives_repeated_cycles,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(acquire_chain_uninitialized_rejects,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(acquire_chain_double_rejects,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(chain_read_compatible_read,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(chain_lock_isolates_per_chain,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(chain_lock_none_acquire_and_release,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(release_chain_idempotent, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(release_then_reacquire, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(release_no_chain_is_noop, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(release_chain_idempotent,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(release_then_reacquire,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(release_no_chain_is_noop,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(release_write_removes_empty_chain,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(release_write_keeps_nonempty_chain,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(release_read_keeps_chain, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(cleanup_idempotent, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(release_read_keeps_chain,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(cleanup_idempotent, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(cleanup_releases_pindir_lock,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(cleanup_with_chain_lock, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(cleanup_with_chain_lock,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(
-            init_for_chain_create_needs_write_pindir, bft_setup_ctx,
-            bft_teardown_ctx),
+            init_for_chain_create_needs_write_pindir, bft_setup_ctx_state,
+            bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(init_for_chain_create_needs_write_chain,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(init_for_chain_success, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(init_for_chain_success,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(init_for_chain_failure_preserves_lock,
-                                        bft_setup_ctx, bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(acquire_chain_missing_fails,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(acquire_chain_create, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(
+            acquire_chain_create, bft_setup_ctx_state, bft_teardown_ctx_state),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/libbpfilter/core/lock.c
+++ b/tests/unit/libbpfilter/core/lock.c
@@ -52,7 +52,7 @@ static void init_success_post_state(void **state)
     struct bft_tmpdir *tmpdir = *state;
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     assert_fd(lock.bpffs_fd);
     assert_fd(lock.pindir_fd);
     assert_int_equal(lock.pindir_lock, BF_LOCK_READ);
@@ -73,9 +73,9 @@ static void init_failure_preserves_lock(void **state)
     (void)state;
 
     /* Hold WRITE on the pindir so a second WRITE init will fail. */
-    assert_ok(bf_lock_init(&holder, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&holder, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
 
-    assert_err(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_err(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
 
     /* lock is unchanged (still in default state). */
     assert_int_equal(lock.bpffs_fd, -1);
@@ -96,10 +96,11 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock1 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, BF_LOCK_WRITE));
-        assert_err(bf_lock_init(&lock2, BF_LOCK_WRITE));
-        assert_err(bf_lock_init(&lock2, BF_LOCK_READ));
-        assert_ok(bf_lock_init(&lock2, BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_err(
+            bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_err(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
     }
 
     {
@@ -107,10 +108,11 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock1 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, BF_LOCK_READ));
-        assert_err(bf_lock_init(&lock2, BF_LOCK_WRITE));
-        assert_ok(bf_lock_init(&lock2, BF_LOCK_READ));
-        assert_ok(bf_lock_init(&lock2, BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+        assert_err(
+            bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
     }
 
     {
@@ -119,12 +121,12 @@ static void pindir_lock_matrix(void **state)
         _clean_bf_lock_ struct bf_lock lock2 = bf_lock_default();
         _clean_bf_lock_ struct bf_lock lock3 = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock1, BF_LOCK_NONE));
+        assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_NONE));
 
-        assert_ok(bf_lock_init(&lock2, BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
         bf_lock_cleanup(&lock2);
 
-        assert_ok(bf_lock_init(&lock2, BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
         bf_lock_cleanup(&lock2);
     }
 }
@@ -138,7 +140,7 @@ static void pindir_survives_repeated_cycles(void **state)
     for (int i = 0; i < 5; ++i) {
         struct bf_lock lock = bf_lock_default();
 
-        assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+        assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
         bf_lock_cleanup(&lock);
         assert_dir_exists(tmpdir, "bpfilter");
     }
@@ -168,7 +170,7 @@ static void acquire_chain_double_rejects(void **state)
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     struct bft_tmpdir *tmpdir = *state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "first", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/first");
 
@@ -186,7 +188,7 @@ static void acquire_chain_create(void **state)
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     struct bft_tmpdir *tmpdir = *state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
 
     // Acquire with READ and create=true fails
     assert_err(bf_lock_acquire_chain(&lock, "c", BF_LOCK_READ, true));
@@ -210,7 +212,7 @@ static void acquire_chain_missing_fails(void **state)
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     struct bft_tmpdir *tmpdir = *state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     assert_err(bf_lock_acquire_chain(&lock, "absent", BF_LOCK_READ, false));
     assert_dir_not_exists(tmpdir, "bpfilter/absent");
 }
@@ -229,15 +231,15 @@ static void chain_read_compatible_read(void **state)
 
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "shared", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock1, "shared", BF_LOCK_READ,
-                                     BF_LOCK_READ, false));
-    assert_ok(bf_lock_init_for_chain(&lock2, "shared", BF_LOCK_READ,
-                                     BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock1, bf_ctx_get_bpffs_path(), "shared",
+                                     BF_LOCK_READ, BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock2, bf_ctx_get_bpffs_path(), "shared",
+                                     BF_LOCK_READ, BF_LOCK_READ, false));
 }
 
 /* Two locks on DIFFERENT chains are compatible, even when both hold WRITE.
@@ -254,7 +256,7 @@ static void chain_lock_isolates_per_chain(void **state)
     /* Materialise both chains so they can be opened with create=false. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "alpha", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
 
@@ -263,15 +265,15 @@ static void chain_lock_isolates_per_chain(void **state)
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock_a, "alpha", BF_LOCK_READ,
-                                     BF_LOCK_WRITE, false));
+    assert_ok(bf_lock_init_for_chain(&lock_a, bf_ctx_get_bpffs_path(), "alpha",
+                                     BF_LOCK_READ, BF_LOCK_WRITE, false));
     assert_string_equal(lock_a.chain_name, "alpha");
     assert_int_equal(lock_a.chain_lock, BF_LOCK_WRITE);
 
     /* Independent chain: WRITE on "beta" must not contend with WRITE on
      * "alpha". */
-    assert_ok(bf_lock_init_for_chain(&lock_b, "beta", BF_LOCK_READ,
-                                     BF_LOCK_WRITE, false));
+    assert_ok(bf_lock_init_for_chain(&lock_b, bf_ctx_get_bpffs_path(), "beta",
+                                     BF_LOCK_READ, BF_LOCK_WRITE, false));
     assert_string_equal(lock_b.chain_name, "beta");
     assert_int_equal(lock_b.chain_lock, BF_LOCK_WRITE);
 }
@@ -298,7 +300,7 @@ static void release_chain_idempotent(void **state)
     assert_int_equal(lock.chain_lock, BF_LOCK_NONE);
 
     /* Initialised lock with no chain held: still a no-op, twice. */
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     bf_lock_release_chain(&lock);
     bf_lock_release_chain(&lock);
     assert_fd(lock.pindir_fd);
@@ -325,7 +327,7 @@ static void release_then_reacquire(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
 
     assert_ok(bf_lock_acquire_chain(&lock, "first", BF_LOCK_WRITE, true));
     assert_string_equal(lock.chain_name, "first");
@@ -360,13 +362,13 @@ static void chain_lock_none_acquire_and_release(void **state)
     /* Pre-create the chain dir; we'll open it with chain mode == NONE. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
         assert_ok(
             bf_lock_acquire_chain(&prep, "none_chain", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     assert_ok(bf_lock_acquire_chain(&lock, "none_chain", BF_LOCK_NONE, false));
 
     /* Because chain_lock != WRITE, release must NOT remove the chain dir,
@@ -382,7 +384,7 @@ static void release_no_chain_is_noop(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     bf_lock_release_chain(&lock);
 
     /* Pindir state untouched. */
@@ -399,7 +401,7 @@ static void release_write_removes_empty_chain(void **state)
     struct bft_tmpdir *tmpdir = *state;
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "empty", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/empty");
 
@@ -422,7 +424,7 @@ static void release_write_keeps_nonempty_chain(void **state)
     struct bft_tmpdir *tmpdir = *state;
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "populated", BF_LOCK_WRITE, true));
     /* Populate so rmdir returns ENOTEMPTY and no-ops. */
     (void)mknodat(lock.chain_fd, "inside", S_IFREG | 0644, 0);
@@ -445,13 +447,13 @@ static void release_read_keeps_chain(void **state)
      * observe via the "chain stays" invariant. */
     {
         _clean_bf_lock_ struct bf_lock prep = bf_lock_default();
-        assert_ok(bf_lock_init(&prep, BF_LOCK_WRITE));
+        assert_ok(bf_lock_init(&prep, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
         assert_ok(bf_lock_acquire_chain(&prep, "reader", BF_LOCK_WRITE, true));
         (void)mknodat(prep.chain_fd, "keepalive", S_IFREG | 0644, 0);
     }
 
-    assert_ok(bf_lock_init_for_chain(&lock, "reader", BF_LOCK_READ,
-                                     BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "reader",
+                                     BF_LOCK_READ, BF_LOCK_READ, false));
 
     bf_lock_release_chain(&lock);
     assert_dir_exists(tmpdir, "bpfilter/reader");
@@ -473,7 +475,7 @@ static void cleanup_idempotent(void **state)
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     bf_lock_cleanup(&lock);
     bf_lock_cleanup(&lock);
 
@@ -494,10 +496,10 @@ static void cleanup_releases_pindir_lock(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock1, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock1, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     bf_lock_cleanup(&lock1);
 
-    assert_ok(bf_lock_init(&lock2, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock2, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
 }
 
 /* Cleanup on a lock holding a chain WRITE lock releases both locks and
@@ -507,7 +509,7 @@ static void cleanup_with_chain_lock(void **state)
     struct bft_tmpdir *tmpdir = *state;
     struct bf_lock lock = bf_lock_default();
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_WRITE));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_WRITE));
     assert_ok(bf_lock_acquire_chain(&lock, "c", BF_LOCK_WRITE, true));
     assert_dir_exists(tmpdir, "bpfilter/c");
 
@@ -532,9 +534,9 @@ static void init_for_chain_create_needs_write_pindir(void **state)
 
     (void)state;
 
-    assert_int_equal(
-        bf_lock_init_for_chain(&lock, "c", BF_LOCK_READ, BF_LOCK_WRITE, true),
-        -EINVAL);
+    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "c",
+                                            BF_LOCK_READ, BF_LOCK_WRITE, true),
+                     -EINVAL);
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
     assert_int_equal(lock.chain_fd, -1);
@@ -548,9 +550,9 @@ static void init_for_chain_create_needs_write_chain(void **state)
 
     (void)state;
 
-    assert_int_equal(
-        bf_lock_init_for_chain(&lock, "c", BF_LOCK_WRITE, BF_LOCK_READ, true),
-        -EINVAL);
+    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "c",
+                                            BF_LOCK_WRITE, BF_LOCK_READ, true),
+                     -EINVAL);
     assert_int_equal(lock.bpffs_fd, -1);
     assert_int_equal(lock.pindir_fd, -1);
 }
@@ -562,8 +564,8 @@ static void init_for_chain_success(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init_for_chain(&lock, "both", BF_LOCK_WRITE,
-                                     BF_LOCK_WRITE, true));
+    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "both",
+                                     BF_LOCK_WRITE, BF_LOCK_WRITE, true));
     assert_fd(lock.bpffs_fd);
     assert_fd(lock.pindir_fd);
     assert_int_equal(lock.pindir_lock, BF_LOCK_WRITE);
@@ -580,7 +582,8 @@ static void init_for_chain_failure_preserves_lock(void **state)
     (void)state;
 
     /* Missing chain, create=false. */
-    assert_int_equal(bf_lock_init_for_chain(&lock, "absent", BF_LOCK_READ,
+    assert_int_equal(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(),
+                                            "absent", BF_LOCK_READ,
                                             BF_LOCK_READ, false),
                      -ENOENT);
     assert_int_equal(lock.bpffs_fd, -1);

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -13,36 +13,27 @@
 
 #include <bpfilter/core/list.h>
 #include <bpfilter/ctx.h>
+#include <bpfilter/logger.h>
 
 #include "core/lock.h"
 #include "test.h"
-
-static void no_setup(void **state)
-{
-    (void)state;
-
-    /* The legacy global-form accessors return safe defaults when no
-     * context has been registered via `bf_ctx_setup`. */
-    assert_int_equal(bf_ctx_token(), -1);
-    assert_null(bf_ctx_get_elfstub(0));
-}
 
 static void get_cgens_empty(void **state)
 {
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_list_ bf_list *cgens = NULL;
+    const struct bf_ctx *ctx = bft_state_ctx(*state);
 
-    (void)state;
-
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
-    assert_ok(bf_ctx_get_cgens(&lock, &cgens));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
+    assert_ok(bf_ctx_get_cgens(ctx, &lock, &cgens));
     assert_non_null(cgens);
     assert_int_equal(bf_list_size(cgens), 0);
 }
 
 static void get_cgens_skips_corrupt(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     _free_bf_list_ bf_list *cgens = NULL;
     char pindir_path[PATH_MAX];
@@ -69,15 +60,16 @@ static void get_cgens_skips_corrupt(void **state)
                    tmpdir->dir_path);
     assert_fd(fd = open(file_path, O_CREAT | O_WRONLY, 0644));
 
-    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
-    assert_ok(bf_ctx_get_cgens(&lock, &cgens));
+    assert_ok(
+        bf_lock_init(&lock, bft_state_tmpdir(*state)->dir_path, BF_LOCK_READ));
+    assert_ok(bf_ctx_get_cgens(bft_state_ctx(*state), &lock, &cgens));
     assert_non_null(cgens);
     assert_int_equal(bf_list_size(cgens), 0);
 }
 
 static void get_cgen_corrupt_returns_error(void **state)
 {
-    struct bft_tmpdir *tmpdir = *state;
+    struct bft_tmpdir *tmpdir = bft_state_tmpdir(*state);
     _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
     struct bf_cgen *cgen = NULL;
     char pindir_path[PATH_MAX];
@@ -93,9 +85,10 @@ static void get_cgen_corrupt_returns_error(void **state)
 
     /* Chain dir exists but the `bf_ctx` map is missing: bf_cgen_new_from_dir_fd
      * fails, and the error must be propagated (not swallowed as -ENOENT). */
-    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "broken",
-                                     BF_LOCK_READ, BF_LOCK_READ, false));
-    assert_err(bf_ctx_get_cgen(&lock, &cgen));
+    assert_ok(bf_lock_init_for_chain(&lock, bft_state_tmpdir(*state)->dir_path,
+                                     "broken", BF_LOCK_READ, BF_LOCK_READ,
+                                     false));
+    assert_err(bf_ctx_get_cgen(bft_state_ctx(*state), &lock, &cgen));
     assert_null(cgen);
 }
 
@@ -103,7 +96,7 @@ static void verbose_flags(void **state)
 {
     (void)state;
 
-    /* `bft_setup_ctx()` configures BF_VERBOSE_DEBUG through the
+    /* `bft_setup_ctx_state()` configures BF_VERBOSE_DEBUG through the
      * process-wide logger; verify the other flags are off. */
     assert_true(bf_logger_is_verbose(BF_VERBOSE_DEBUG));
     assert_false(bf_logger_is_verbose(BF_VERBOSE_BPF));
@@ -118,7 +111,7 @@ static void new_and_free_roundtrip(void **state)
     (void)state;
 
     assert_ok(bft_tmpdir_new(&tmpdir));
-    assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path, 0));
+    assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path));
     assert_non_null(ctx);
 
     bf_ctx_free(&ctx);
@@ -140,7 +133,7 @@ static void free_cleanup_attribute(void **state)
     /* _free_bf_ctx_ runs bf_ctx_free at scope exit; no leaks expected. */
     {
         _free_bf_ctx_ struct bf_ctx *ctx = NULL;
-        assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path, 0));
+        assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path));
         assert_non_null(ctx);
     }
 }
@@ -148,15 +141,16 @@ static void free_cleanup_attribute(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(no_setup),
-        cmocka_unit_test_setup_teardown(get_cgens_empty, bft_setup_ctx,
-                                        bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(get_cgens_skips_corrupt, bft_setup_ctx,
-                                        bft_teardown_ctx),
+        cmocka_unit_test_setup_teardown(get_cgens_empty, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(get_cgens_skips_corrupt,
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test_setup_teardown(get_cgen_corrupt_returns_error,
-                                        bft_setup_ctx, bft_teardown_ctx),
-        cmocka_unit_test_setup_teardown(verbose_flags, bft_setup_ctx,
-                                        bft_teardown_ctx),
+                                        bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
+        cmocka_unit_test_setup_teardown(verbose_flags, bft_setup_ctx_state,
+                                        bft_teardown_ctx_state),
         cmocka_unit_test(new_and_free_roundtrip),
         cmocka_unit_test(free_cleanup_attribute),
     };

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -27,7 +27,6 @@ static void no_setup(void **state)
     assert_int_equal(bf_lock_init(&lock, BF_LOCK_READ), -EINVAL);
     assert_int_equal(bf_ctx_token(), -1);
     assert_null(bf_ctx_get_elfstub(0));
-    assert_false(bf_ctx_is_verbose(BF_VERBOSE_DEBUG));
 }
 
 static void get_cgens_empty(void **state)
@@ -106,9 +105,11 @@ static void verbose_flags(void **state)
 {
     (void)state;
 
-    assert_true(bf_ctx_is_verbose(BF_VERBOSE_DEBUG));
-    assert_false(bf_ctx_is_verbose(BF_VERBOSE_BPF));
-    assert_false(bf_ctx_is_verbose(BF_VERBOSE_BYTECODE));
+    /* `bft_setup_ctx()` configures BF_VERBOSE_DEBUG through the
+     * process-wide logger; verify the other flags are off. */
+    assert_true(bf_logger_is_verbose(BF_VERBOSE_DEBUG));
+    assert_false(bf_logger_is_verbose(BF_VERBOSE_BPF));
+    assert_false(bf_logger_is_verbose(BF_VERBOSE_BYTECODE));
 }
 
 static void new_and_free_roundtrip(void **state)

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -19,12 +19,10 @@
 
 static void no_setup(void **state)
 {
-    _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
-
     (void)state;
 
-    /* All ctx accessors must reject calls made before bf_ctx_setup. */
-    assert_int_equal(bf_lock_init(&lock, BF_LOCK_READ), -EINVAL);
+    /* The legacy global-form accessors return safe defaults when no
+     * context has been registered via `bf_ctx_setup`. */
     assert_int_equal(bf_ctx_token(), -1);
     assert_null(bf_ctx_get_elfstub(0));
 }
@@ -36,7 +34,7 @@ static void get_cgens_empty(void **state)
 
     (void)state;
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     assert_ok(bf_ctx_get_cgens(&lock, &cgens));
     assert_non_null(cgens);
     assert_int_equal(bf_list_size(cgens), 0);
@@ -71,7 +69,7 @@ static void get_cgens_skips_corrupt(void **state)
                    tmpdir->dir_path);
     assert_fd(fd = open(file_path, O_CREAT | O_WRONLY, 0644));
 
-    assert_ok(bf_lock_init(&lock, BF_LOCK_READ));
+    assert_ok(bf_lock_init(&lock, bf_ctx_get_bpffs_path(), BF_LOCK_READ));
     assert_ok(bf_ctx_get_cgens(&lock, &cgens));
     assert_non_null(cgens);
     assert_int_equal(bf_list_size(cgens), 0);
@@ -95,8 +93,8 @@ static void get_cgen_corrupt_returns_error(void **state)
 
     /* Chain dir exists but the `bf_ctx` map is missing: bf_cgen_new_from_dir_fd
      * fails, and the error must be propagated (not swallowed as -ENOENT). */
-    assert_ok(bf_lock_init_for_chain(&lock, "broken", BF_LOCK_READ,
-                                     BF_LOCK_READ, false));
+    assert_ok(bf_lock_init_for_chain(&lock, bf_ctx_get_bpffs_path(), "broken",
+                                     BF_LOCK_READ, BF_LOCK_READ, false));
     assert_err(bf_ctx_get_cgen(&lock, &cgen));
     assert_null(cgen);
 }

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -111,6 +111,41 @@ static void verbose_flags(void **state)
     assert_false(bf_ctx_is_verbose(BF_VERBOSE_BYTECODE));
 }
 
+static void new_and_free_roundtrip(void **state)
+{
+    _free_bft_tmpdir_ struct bft_tmpdir *tmpdir = NULL;
+    struct bf_ctx *ctx = NULL;
+
+    (void)state;
+
+    assert_ok(bft_tmpdir_new(&tmpdir));
+    assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path, 0));
+    assert_non_null(ctx);
+
+    bf_ctx_free(&ctx);
+    assert_null(ctx);
+
+    /* bf_ctx_free is a no-op on a NULL pointer. */
+    bf_ctx_free(&ctx);
+    assert_null(ctx);
+}
+
+static void free_cleanup_attribute(void **state)
+{
+    _free_bft_tmpdir_ struct bft_tmpdir *tmpdir = NULL;
+
+    (void)state;
+
+    assert_ok(bft_tmpdir_new(&tmpdir));
+
+    /* _free_bf_ctx_ runs bf_ctx_free at scope exit; no leaks expected. */
+    {
+        _free_bf_ctx_ struct bf_ctx *ctx = NULL;
+        assert_ok(bf_ctx_new(&ctx, false, tmpdir->dir_path, 0));
+        assert_non_null(ctx);
+    }
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -123,6 +158,8 @@ int main(void)
                                         bft_setup_ctx, bft_teardown_ctx),
         cmocka_unit_test_setup_teardown(verbose_flags, bft_setup_ctx,
                                         bft_teardown_ctx),
+        cmocka_unit_test(new_and_free_roundtrip),
+        cmocka_unit_test(free_cleanup_attribute),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
With bpfilter getting rid of the daemon, there is no reason any more for the library to only allow a single `bf_ctx` object. Instead, `bf_ctx` should be initialized by the library's client with proper settings, this allows multiple `bf_ctx` to be used (with different bpffs path).

This PR introduces:
- No cleanup of the left-over staging directories in `$BPFFS/bpfilter` on context init
- Verbosity flags are now defined at the process level
- `bf_btf` is now owned by `bf_ctx` instead of being global
- `bf_ctx` is threaded through the public API when required