### PR TITLE
doc: add memory and resource management reference (+ fixes)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,8 @@
 # - bugprone-easily-swappable-parameters
 #   Too many false positives, especially when swapable arguments are of different
 #   types (which will be flagged by the compiler).
+# - bugprone-multi-level-implicit-pointer-conversion
+#   Multi-level pointer conversion is used for BF_FREEP
 # - cert-dcl03-c
 #   We use assert(0) for impossible default in switch...case.
 # - cert-dcl37-c
@@ -66,6 +68,7 @@ Checks: >
   bugprone-*,
     -bugprone-assignment-in-if-condition,
     -bugprone-easily-swappable-parameters,
+    -bugprone-multi-level-implicit-pointer-conversion,
   cert-*,
     -cert-dcl03-c,
     -cert-dcl37-c,

--- a/.claude/agents/memory-auditor.md
+++ b/.claude/agents/memory-auditor.md
@@ -1,0 +1,92 @@
+---
+name: memory-auditor
+description: Use proactively when reviewing C changes under src/ for memory and resource safety — leaks, double-frees, use-after-free, fd leaks, lock leaks, broken cleanup-function contracts, missing TAKE_PTR/TAKE_FD ownership transfers, and misuse of the project's _free_/_clean_/_cleanup_close_/_cleanup_free_ attribute macros. Pass the target as a PR number, a git ref or range, a path under src/, or omit it to audit the working-tree diff.
+tools: Bash, Read, Glob, Grep, Task
+---
+
+You are a memory-safety auditor for the bpfilter codebase.
+
+## Authoritative rules
+
+All memory and resource conventions you must enforce are documented in `doc/developers/memory.rst`. **Read that file in full before doing anything else** — it is the single source of truth shared between human reviewers and this agent. Specifically, it covers:
+
+- How per-function contracts in Doxygen override the generic rules
+- Cleanup attribute families (`_cleanup_free_`, `_cleanup_close_`, `_free_bf_<type>_`, `_clean_bf_<type>_`)
+- The cleanup-function contract (double pointer, NULL-safe, sets `*ptr = NULL`)
+- Ownership transfer with `TAKE_PTR` / `TAKE_FD` / `TAKE_STRUCT`
+- File-descriptor handling (`-1` sentinel, `_cleanup_close_` rules)
+- The output-parameter contract (leave `*out` unchanged on failure)
+- Memory-helper contracts (`bf_memdup`, `bf_memcpy`, `bf_realloc`, `bf_read_file`)
+- Container destructors (`bf_list`, `bf_vector`, `bf_hashset`)
+- The "common pitfalls" bug classes you will categorise findings under
+- The sanitizer build recipe for dynamic verification
+
+If `doc/developers/memory.rst` and this prompt ever disagree, the doc wins. Report the discrepancy in your final message.
+
+## Scope
+
+Focus exclusively on memory and resource safety. Do **not** report style, performance, logic, or BPF-codegen issues unless they directly cause a leak, use-after-free, double-free, or fd/lock leak. Other subagents cover those areas.
+
+Do **not** flag Doxygen-vs-code drift as a memory-safety finding. Doxygen is treated as input (the authoritative call-site contract) — drift findings belong to the `documentation-reviewer` subagent.
+
+## Determining the audit target
+
+The invoker passes the target in the prompt. Interpret it as follows:
+
+- **PR number** (a bare integer, e.g. `123`):
+  1. `git fetch origin pull/<n>/head:pr-<n>` (fall back to `upstream` if `origin` fails)
+  2. `git worktree add /tmp/bpfilter-pr-<n> pr-<n>`
+  3. Audit the diff against `main`
+  4. Remove the worktree and delete the `pr-<n>` branch when done
+- **Git ref or range** (e.g. `HEAD`, `HEAD~3..HEAD`, `origin/main..my-branch`): diff that revspec in place
+- **Path** (anything starting with `src/`, `tests/`, or another tracked directory): audit the file/directory as-is, no diffing
+- **Empty / unspecified**: audit the unstaged + staged working-tree diff against `HEAD`
+
+If the target is ambiguous, ask the invoker once, then proceed.
+
+## Audit procedure
+
+1. Read `doc/developers/memory.rst` end to end.
+2. Compute the file list and diff for the target.
+3. For each touched function or new function:
+   - Map out every owning resource: heap pointers, fds, list/vector/hashset values, locks, BPF maps/links, `bf_jmpctx` / `bf_swich` scopes.
+   - For each resource, confirm: initialisation, cleanup attribute (or manual free on every exit path), ownership transfer on escape.
+4. For each new `bf_<type>_free` / `bf_<type>_clean`, verify the contract from the doc (double pointer, NULL-safe, sets to NULL / re-defaults the value).
+5. Cross-check every header that adds a `bf_<type>_free` defines the matching `_free_bf_<type>_` macro (and `_clean_bf_<type>_` when relevant).
+6. Walk all error paths (`if (r) return ...;`, `if (r) goto ...;`) and confirm no resource leaks, no double-frees, no use of a moved-from pointer.
+7. Check that every assignment from an owning local into an output parameter or struct field goes through `TAKE_PTR` / `TAKE_FD`.
+8. Check that every lock is properly initialized with ``bf_lock_default`` 
+9. Check that fd-typed fields and locals are initialised to `-1` before any path on which `_cleanup_close_` might fire.
+10. Before flagging a bug at a call site, read the callee's Doxygen header and confirm the suspected behaviour matches what the callee actually promises. If the callee's contract differs from the generic rules, the Doxygen is authoritative.
+
+## Optional dynamic checks
+
+When a static finding is plausible but not certain, confirm it by running the unit tests under sanitizers using the recipe in `doc/developers/memory.rst` (Dynamic verification section).
+
+Mention in the final report whether sanitizers were run and what they reported. Skip this step entirely if the static review found nothing worth confirming.
+
+## Final report
+
+Return a single message structured as:
+
+1. **Scope** — one paragraph: what was audited (file list / commit range), and whether sanitizers were run.
+2. **Findings** — grouped by severity, each item formatted as:
+   > **[Severity] [Bug class]** — `function_name` in `path/to/file.c:LINE`
+   > One- or two-sentence explanation, with a minimal code excerpt (≤6 lines) if it clarifies the issue. End with a one-line suggested fix.
+
+   Use the bug-class labels from the Common pitfalls section of `doc/developers/memory.rst`.
+
+   Severities:
+   - **Must fix** — definite leak, double-free, UAF, or contract violation
+   - **Likely bug** — the code path is reachable and the failure is plausible, but not fully proven
+   - **Suggestion** — defensible today but fragile (e.g. relies on an invariant that future edits could break)
+3. **Sanitizer results** — pass/fail per suite, with the relevant excerpt for any failure. Omit the section if no sanitizer run was performed.
+4. **Overall status** — `PASS`, `PASS (conditional)`, or `FAIL`.
+
+Rules for the report:
+
+- Reference symbols with backticks and always give `file:line`.
+- Quote no more than ~6 lines of context per finding.
+- Do not flag the same root cause more than once; collapse duplicates.
+- Only report what you have high confidence in. When unsure, file under **Suggestion** with an explicit "needs confirmation" note.
+- If the change set has no memory-safety issues, say so plainly and return `PASS` — do not invent findings.

--- a/.claude/commands/memory-audit.md
+++ b/.claude/commands/memory-audit.md
@@ -1,0 +1,11 @@
+---
+allowed-tools: Task
+argument-hint: <target> (PR number, commit/range, path, or empty for working tree)
+description: Run the memory-auditor subagent on a change set
+---
+
+Delegate to the `memory-auditor` subagent with target: `$ARGUMENTS`.
+
+If `$ARGUMENTS` is empty, ask the subagent to audit the working-tree diff against `HEAD`.
+
+Pass the target verbatim — the subagent knows how to interpret PR numbers, git revspecs, paths, and empty input. Return its report unchanged.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -84,12 +84,14 @@ set(doc_srcs
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/build.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/contributing.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/generation.rst
+	${CMAKE_CURRENT_SOURCE_DIR}/developers/memory.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/packets_processing.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/style.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/tests.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/core/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/core/locking.rst
+	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/helpers.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/developers/modules/libbpfilter/libbpfilter.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/external/benchmarks/index.rst
 	${CMAKE_CURRENT_SOURCE_DIR}/external/coverage/index.rst

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -30,7 +30,7 @@ WARN_AS_ERROR           = FAIL_ON_WARNINGS_PRINT
 #---------------------------------------------------------------------------
 INPUT                   = "@CMAKE_SOURCE_DIR@/src" "@CMAKE_SOURCE_DIR@/tests/harness"
 EXCLUDE                 = "@CMAKE_SOURCE_DIR@/src/external"
-EXCLUDE_SYMBOLS         = bf_test_mock_declare
+EXCLUDE_SYMBOLS         = bf_test_mock_declare bf_aligned
 FILE_PATTERNS           = *.c \
                           *.h
 RECURSIVE               = YES

--- a/doc/developers/memory.rst
+++ b/doc/developers/memory.rst
@@ -1,0 +1,334 @@
+Memory and resource management
+==============================
+
+This document is the authoritative reference for memory and resource safety conventions in ``bpfilter``. It is the single source of truth for code review and can be used by AI agents.
+
+``bpfilter`` relies heavily on GCC's and Clang's ``__attribute__((cleanup))`` together with a small set of conventions for ownership transfer and file-descriptor handling. The rules below describe what correct code looks like and how to verify it during review. Following these conventions eliminates entire classes of leaks, double-frees, and use-after-free bugs by making resource lifetimes explicit and locally verifiable.
+
+This page is the deep reference. The Memory management section of :doc:`style` is a short pointer back here for contributors browsing the style guide.
+
+
+
+Local verifiability
+-------------------
+
+The conventions in this document exist so that a reader can examine a single function and convince themselves it does not leak, double-free, or use freed memory, **without reading any of its callees**.
+
+Cleanup attributes turn resource lifetime into a syntactic property: every owning local is visibly tagged with the destructor that will run when it goes out of scope. Ownership-transfer macros (``TAKE_PTR``, ``TAKE_FD``) make every escape from a local explicit. The output-parameter contract guarantees that a function returning an error never leaves the caller's locals in an indeterminate state.
+
+If a function's correctness requires reading another function's body, one of these conventions has been broken. Most findings raised against this document can be characterised as "this code is not locally verifiable because ...".
+
+
+
+Per-function contracts live in Doxygen
+--------------------------------------
+
+The generic conventions in this document are the **fallback**. The authoritative contract for any specific function lives in its Doxygen header (above the declaration in the public header, or above the definition for internal functions). While the Doxygen documentation is authoritative for a specific function, you should try to stick to the conventions defined in this document unless you have a good reason not to, in which case you should document it. When judging whether a call site is correct, read the callee's Doxygen for:
+
+- **Ownership**: who owns the resources before the function call? After? The owner is responsible for the resources lifetime.
+- **NULL-safety**: can pointer arguments be NULL?
+- **Allocation**: are resources allocated? Who will own them?
+- **Output-parameter semantics**: should caller-allocated resources be freed on error? Does the function changes the resources ownership on success?
+- **Locking**: what are preconditions on held locks (read/write/none)?
+
+If a callee's Doxygen contradicts the generic rules below, the Doxygen wins. The reason behind this drift in behaviour must be documented. Real examples from the codebase where the per-function contract overrides the defaults:
+
+- ``bf_hashset_add(set, &data)`` transfers ownership of ``*data`` to the hashset on success (and sets ``*data`` to ``NULL``), but **not** on ``-EEXIST``: the caller retains ownership when the element was already present. Both naive assumptions ("inputs are borrowed" and "inputs are always taken") are wrong; only the per-return-code contract is correct, and getting it wrong produces either a leak (on success) or a double-free (on ``-EEXIST``).
+- ``bf_set_add(dest, &to_add)`` and ``bf_set_remove(dest, &to_remove)`` consume their second argument on success: the function frees ``*to_add`` / ``*to_remove`` and sets the caller's pointer to ``NULL``. The generic rule "callers retain ownership of inputs" is reversed.
+- ``bf_cgen_new(&cgen, hook, chain)`` takes ownership of ``chain`` on success: after the call returns, the new codegen owns the chain and the caller must not free it. Same reversal as above, but for a constructor.
+- ``bf_vector_take(vec)`` is the inverse of the usual container contract: it transfers ownership of the vector's **backing buffer** out to the caller, leaving ``vec`` empty but reusable. The caller must ``free()`` the returned pointer.
+
+Each of these is a place where reading the Doxygen carefully is the only way to write correct calling code — applying the generic rules below would produce either leaks or double-frees.
+
+For struct fields, inline ``///`` comments often encode the element type or ownership (e.g. ``/// List of struct bf_rule``). Use those to validate container destructors and field cleanup.
+
+If a function has no Doxygen, fall back on the conventions below.
+
+
+Cleanup attributes
+------------------
+
+Use ``__attribute__((cleanup))`` to release owned resources at scope exit. Four macro families exist, with strict naming conventions.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Macro
+     - Used for
+   * - :c:macro:`_cleanup_free_`
+     - Raw heap pointers freed via ``free()`` (the destructor is :c:func:`freep`)
+   * - :c:macro:`_cleanup_close_`
+     - File descriptors closed via ``close()`` (the destructor is :c:func:`closep`)
+   * - ``_free_bf_<type>_``
+     - Heap-allocated ``bf_<type>`` objects
+   * - ``_clean_bf_<type>_``
+     - Stack-allocated ``bf_<type>`` values (lock, list, vector, hashset, ...)
+
+Per-type macros live next to their ``bf_<type>_free`` / ``bf_<type>_clean`` declaration in the corresponding header. See e.g. ``chain.h``.
+
+A pointer carrying a cleanup attribute **must be initialised** (typically to ``NULL``), otherwise the destructor runs on garbage when the scope exits early.
+
+.. code:: c
+
+    _free_bf_chain_ struct bf_chain *chain = NULL;  // Correct: initialised
+
+
+Cleanup function contract
+-------------------------
+
+Every ``bf_<type>_free(struct bf_<type> **p)`` must:
+
+- Return ``void``
+- Take a **double pointer**
+- Be a no-op when ``*p == NULL``
+- Call :c:func:`freep` (or the right destructor chain) to free the heap-allocated object and set the pointer to NULL
+
+.. code:: c
+
+    void bf_chain_free(struct bf_chain **chain)
+    {
+        if (!*chain)
+            return;
+
+        // ... release nested resources ...
+
+        freep((void *)*chain);
+    }
+
+The ``bf_<type>_clean(struct bf_<type> *p)`` variant (used by ``_clean_*``) tears down the fields of an automatic-storage object and must leave it in a state where calling it again is a no-op.
+
+
+Ownership transfer
+------------------
+
+Two macros transfer ownership out of a local variable:
+
+- :c:macro:`TAKE_PTR` (``p``) — returns ``p``, sets ``p = NULL``
+- :c:macro:`TAKE_FD` (``fd``) — returns ``fd``, sets ``fd = -1``
+
+These exist precisely so the cleanup attribute on the source variable becomes a no-op after the value escapes. Whenever a local with ``_free_*``, :c:macro:`_cleanup_free_`, or :c:macro:`_cleanup_close_` is assigned into an output parameter or struct field, the assignment **must** go through the appropriate ``TAKE_*``:
+
+.. code:: c
+
+    *out = TAKE_PTR(local);  // local becomes NULL, *out takes ownership
+
+Assigning without ``TAKE_*`` leads to a double-free: the cleanup attribute on ``local`` will fire **and** the caller will free ``*out``.
+
+
+File descriptors
+----------------
+
+- ``-1`` is the sentinel for "not open"
+- New fd variables should be initialised to ``-1``
+- Owned fds should carry :c:macro:`_cleanup_close_` or live in a struct whose cleanup function closes them
+- Transfer ownership with :c:macro:`TAKE_FD`
+- :c:func:`closep` ignores negative fds, so :c:macro:`_cleanup_close_` on an uninitialised variable is undefined behaviour, but :c:func:`closep` on a negative errno value is valid. Always initialise to ``-1``
+
+
+Locking
+-------
+
+The :c:struct:`bf_lock` object (see :doc:`modules/core/locking`) bundles file descriptors and ``flock(2)`` locks on bpffs directories that protect the ruleset and individual chains. It has its own lifecycle that mirrors the cleanup-attribute discipline:
+
+.. code:: c
+
+    _clean_bf_lock_ struct bf_lock lock = bf_lock_default();
+    int r;
+
+    r = bf_lock_init(&lock, BF_LOCK_READ);
+    if (r)
+        return r;
+
+    // ... use lock.pindir_fd / lock.chain_fd ...
+
+    // On scope exit, bf_lock_cleanup() releases every fd and every flock.
+
+Rules:
+
+- A :c:struct:`bf_lock` local **must** be declared with :c:macro:`_clean_bf_lock_` and initialised with :c:macro:`bf_lock_default`. :c:func:`bf_lock_cleanup` is idempotent on a defaulted, initialised, or already-cleaned lock, so the cleanup attribute is always safe to run.
+- :c:func:`bf_lock_init` and :c:func:`bf_lock_init_for_chain` leave the lock unchanged on failure, so the cleanup attribute on an as-yet-uninitialised lock is a no-op.
+- :c:struct:`bf_lock` values must never escape their scope. There is no ``TAKE_LOCK``: locks are stack-only and their ownership is non-transferable.
+- For chain-level locking on an already-initialised lock, use :c:func:`bf_lock_acquire_chain` / :c:func:`bf_lock_release_chain`. The matching cleanup is still :c:func:`bf_lock_cleanup`; explicit release is only needed if the chain lock should be dropped before scope exit.
+
+See the locking matrix and invariants in :doc:`modules/core/locking` for the policy that determines which mode each operation requires.
+
+
+Output-parameter contract
+-------------------------
+
+Functions of the form ``int bf_x_new(struct bf_x **out, ...)`` follow a strict contract:
+
+- Return ``0`` on success, negative errno on failure
+- On failure, ``*out`` is **left unchanged**
+- On success, ownership of ``*out`` transfers to the caller
+
+A failure path that mutates ``*out`` is a bug: the caller may already have applied ``_free_bf_x_`` to its local, leading to a double-free or a free on a partially-constructed object. Trace every error return and confirm ``*out`` was not touched before it.
+
+
+Memory helpers
+--------------
+
+These helpers in :doc:`modules/helpers` have non-obvious contracts worth memorising:
+
+- :c:func:`bf_memdup` returns ``NULL`` if ``src == NULL``; caller frees the returned buffer
+- :c:func:`bf_memcpy` tolerates ``src == NULL`` only when ``len == 0``
+- :c:func:`bf_realloc` leaves ``p`` untouched on failure (unlike ``realloc``), so ``p`` is still owned by the caller and must be freed
+- :c:func:`bf_read_file` allocates ``*buf``; caller frees. ``*buf`` is unchanged on failure
+
+
+Lists, vectors, and hashsets
+----------------------------
+
+``bf_list``, ``bf_vector``, and ``bf_hashset`` each carry an element destructor. Verify on every use:
+
+- The destructor matches the element type (``bf_rule_free`` for a list of rules, etc.)
+- For nested containers, the inner free function is registered
+- ``_free_`` is used when the container itself is heap-allocated, ``_clean_`` when it is on the stack
+
+
+Kernel-side resources
+---------------------
+
+Some ``bpfilter`` objects wrap resources whose real owner is the kernel: ``bf_map`` (BPF maps), ``bf_link`` (BPF links), ``bf_program`` (BPF programs). Each follows the standard heap-object discipline (``_free_bf_map_``, ``_free_bf_link_``, ``_free_bf_program_``) and its ``bf_<type>_free`` closes the embedded fd as part of cleanup.
+
+What makes these objects unusual is that closing the fd does **not** necessarily destroy the kernel resource. A BPF map, link, or program persists as long as any of the following holds a reference:
+
+- An open fd anywhere in the system.
+- A pin in bpffs.
+
+Two consequences for reviewers:
+
+- Forgetting ``_free_bf_link_`` on a local leaks the userspace struct *and* potentially detaches the BPF program from its hook when the kernel link's last reference goes away. Cleanup correctness has user-visible side effects beyond memory.
+- Conversely, a pinned object survives the death of every userspace handle. ``bf_link_unpin`` removes the bpffs entry; until that runs, freeing the ``bf_link`` doesn't actually detach anything. See ``bf_link_free`` for the explicit warning.
+
+Reviewing a change that allocates, transfers, or releases a ``bf_map`` / ``bf_link`` / ``bf_program`` requires checking both the userspace lifetime (cleanup attribute, ``TAKE_PTR``) **and** the kernel-side lifetime (pinning / unpinning).
+
+
+A worked example
+----------------
+
+The following constructor exercises every rule in this document. Each annotation calls out the invariant being relied on.
+
+.. code:: c
+
+    struct bf_widget
+    {
+        char *name;
+        int fd;
+    };
+
+    #define _free_bf_widget_ __attribute__((cleanup(bf_widget_free)))
+
+    int bf_widget_new(struct bf_widget **out, const char *name)
+    {
+        _free_bf_widget_ struct bf_widget *w = NULL;  // heap obj; cleanup runs unless TAKE_PTR
+        _cleanup_free_ char *name_copy = NULL;        // raw heap; cleanup is free()
+        _cleanup_close_ int fd = -1;                  // owned fd; -1 = closep no-op
+
+        assert(out);
+        assert(name);
+
+        w = calloc(1, sizeof(*w));
+        if (!w)
+            return -ENOMEM;
+        w->fd = -1;                                   // sentinel before any failure
+
+        name_copy = strdup(name);
+        if (!name_copy)
+            return -ENOMEM;
+
+        fd = open("/some/resource", O_RDWR);
+        if (fd < 0)
+            return -errno;
+
+        w->name = TAKE_PTR(name_copy);                // now owned by *w
+        w->fd = TAKE_FD(fd);                          // now owned by *w
+
+        *out = TAKE_PTR(w);                           // ownership escapes to caller
+        *
+        return 0;
+    }
+
+Trace each return statement against the rules:
+
+- First ``return -ENOMEM``: nothing has been initialised; ``w``, ``name_copy``, and ``fd`` are at their sentinel values, so all three cleanup attributes are no-ops.
+- Second ``return -ENOMEM``: ``w`` is allocated with ``w->fd == -1`` and ``w->name == NULL``. ``bf_widget_free`` must therefore be NULL-safe on every field it touches, just like the cleanup-function contract requires.
+- ``return -errno`` after ``open``: ``name_copy`` is non-NULL; ``_cleanup_free_`` will free it. ``w`` is freed by ``_free_bf_widget_``. ``fd`` is negative, so ``_cleanup_close_`` is a no-op.
+- The success ``return 0``: every owning local has been transferred via ``TAKE_*``, so each cleanup attribute sees the sentinel value and runs as a no-op. Ownership of the widget is now in the caller's hands.
+
+The caller side mirrors the contract:
+
+.. code:: c
+
+    int caller(void)
+    {
+        _free_bf_widget_ struct bf_widget *w = NULL;  // unchanged if call fails
+        int r;
+
+        r = bf_widget_new(&w, "thingy");
+        if (r)
+            return r;                                 // *out is unchanged; w stays NULL
+
+        // ... use w ...
+
+        return 0;                                     // bf_widget_free(&w) runs here
+    }
+
+Verifying both functions required reading exactly one body each: nowhere did the argument depend on inspecting the implementation of ``bf_widget_free``, ``calloc``, ``strdup``, ``open``, or any other callee. That is the local-verifiability principle in practice.
+
+
+Common pitfalls
+---------------
+
+The bug classes below are recurring failure modes.
+
+**Leak**
+    Allocation, fd, or lock not released on some return path.
+
+**Double-free**
+    Manual ``free()`` plus a cleanup attribute on the same object; or ``TAKE_*`` missing on ownership transfer; or two cleanup attributes covering the same object.
+
+**Use-after-free / use-after-move**
+    Pointer dereferenced after ``TAKE_PTR``, or after the cleanup attribute already ran.
+
+**Uninitialised cleanup**
+    ``_free_*`` or ``_cleanup_*`` variable not given a value before a path that returns. For pointers this means missing ``= NULL``; for fds it means missing ``= -1``.
+
+**Broken cleanup contract**
+    ``bf_<type>_free`` that isn't NULL-safe, doesn't null out ``*ptr``, takes a single pointer, returns non-void, or has a mismatched ``_free_`` macro.
+
+**Output-parameter mutation on failure**
+    Function writes ``*out`` then returns an error, breaking the "unchanged on failure" guarantee.
+
+**Container destructor mismatch**
+    ``bf_list``/``bf_vector``/``bf_hashset`` registered with the wrong free function, or ``NULL`` when the element owns resources.
+
+**Fd sentinel violation**
+    Fd not initialised to ``-1``, or an explicit ``close(fd)`` on a path that also has ``_cleanup_close_``.
+
+**Lock leak**
+    ``bf_lock_init`` succeeded but ``_clean_bf_lock_`` is missing on the local, or the lock escapes its scope.
+
+
+Dynamic verification
+--------------------
+
+When static review leaves a finding uncertain, confirm it by running the unit tests under sanitizers (see :doc:`tests` for the full test layout). With ``-DCMAKE_BUILD_TYPE=debug``, the address and undefined sanitizers are enabled by default:
+
+.. code:: bash
+
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=debug
+    make -C build
+
+To narrow on a specific test:
+
+.. code:: bash
+
+    ctest --test-dir build --output-on-failure -R <pattern>
+
+
+Automated review
+----------------
+
+The ``memory-auditor`` subagent applies the rules on this page to a change set (PR, git ref/range, path, or working-tree diff). Invoke it via the ``/memory-audit`` slash command, or let the main agent delegate to it automatically when it sees risky C changes.

--- a/doc/developers/memory.rst
+++ b/doc/developers/memory.rst
@@ -57,7 +57,7 @@ Use ``__attribute__((cleanup))`` to release owned resources at scope exit. Four 
    * - Macro
      - Used for
    * - :c:macro:`_cleanup_free_`
-     - Raw heap pointers freed via ``free()`` (the destructor is :c:func:`freep`)
+     - Raw heap pointers freed via ``free()`` (the destructor is :c:func:`bf_freep`)
    * - :c:macro:`_cleanup_close_`
      - File descriptors closed via ``close()`` (the destructor is :c:func:`closep`)
    * - ``_free_bf_<type>_``
@@ -82,7 +82,7 @@ Every ``bf_<type>_free(struct bf_<type> **p)`` must:
 - Return ``void``
 - Take a **double pointer**
 - Be a no-op when ``*p == NULL``
-- Call :c:func:`freep` (or the right destructor chain) to free the heap-allocated object and set the pointer to NULL
+- Call :c:macro:`BF_FREEP` (or the right destructor chain) to free the heap-allocated object and set the pointer to NULL
 
 .. code:: c
 
@@ -93,7 +93,7 @@ Every ``bf_<type>_free(struct bf_<type> **p)`` must:
 
         // ... release nested resources ...
 
-        freep((void *)*chain);
+        BF_FREEP(*chain);
     }
 
 The ``bf_<type>_clean(struct bf_<type> *p)`` variant (used by ``_clean_*``) tears down the fields of an automatic-storage object and must leave it in a state where calling it again is a no-op.

--- a/doc/developers/modules/helpers.rst
+++ b/doc/developers/modules/helpers.rst
@@ -1,0 +1,8 @@
+Helpers
+=======
+
+Macros and utility functions shared across ``bpfilter``: the cleanup-attribute machinery, ownership-transfer helpers (``TAKE_PTR``, ``TAKE_FD``), and common memory and string helpers.
+
+See :doc:`../memory` for the philosophy and the rules these helpers enforce.
+
+.. doxygenfile:: bpfilter/helper.h

--- a/doc/developers/modules/index.rst
+++ b/doc/developers/modules/index.rst
@@ -7,10 +7,12 @@ Modules
 
    libbpfilter/libbpfilter
    core/index
+   helpers
 
 ``bpfilter`` is composed of multiple modules depending on each other. Splitting the project in different modules allows for the source code to be efficiently reused:
 
 - ``core``: core definitions used by ``bfcli`` and ``libbpfilter``.
 - ``libbpfilter``: core library containing all filtering logic, BPF code generation, and program lifecycle management.
 - ``bfcli``: CLI tool for defining and managing filtering rules via ``libbpfilter``.
+- ``helpers``: shared macros and utility functions (cleanup attributes, ownership transfer, memory and string helpers).
 - ``external``: non-``bpfilter`` code, imported into the project to provide consistent external definitions.

--- a/doc/developers/style.rst
+++ b/doc/developers/style.rst
@@ -144,55 +144,15 @@ Only use ``assert()`` for pointer values. For other validation, use ``if ()`` wi
 Memory management
 -----------------
 
-Cleanup attributes
-^^^^^^^^^^^^^^^^^^
+See :doc:`memory` for the full reference on memory and resource management conventions: cleanup attributes (``_free_*``, ``_clean_*``, ``_cleanup_free_``, ``_cleanup_close_``), the cleanup-function contract, ownership transfer with ``TAKE_PTR`` / ``TAKE_FD`` / ``TAKE_STRUCT``, the file-descriptor sentinel, the output-parameter contract, memory-helper semantics, container destructors, and common pitfalls.
 
-Use ``__attribute__((cleanup))`` extensively. Two naming conventions:
+In short:
 
-- ``_free_*``: cleanup dynamically allocated objects
-- ``_clean_*``: cleanup objects with automatic storage duration
+- Use ``__attribute__((cleanup))`` extensively. ``_free_*`` for heap-allocated objects, ``_clean_*`` for stack-allocated values with non-trivial teardown.
+- Cleanup functions take a double pointer, are a no-op when ``*ptr == NULL``, and set ``*ptr`` to ``NULL`` after freeing.
+- Use ``TAKE_PTR`` / ``TAKE_FD`` / ``TAKE_STRUCT`` whenever an owning local escapes (into an output parameter or a struct field).
+- ``int bf_x_new(struct bf_x **out, ...)`` returns ``0`` or negative errno, and leaves ``*out`` unchanged on failure.
 
-.. code:: c
-
-    #define _free_bf_chain_ __attribute__((cleanup(_bf_chain_free)))
-
-    void example(void)
-    {
-        _free_bf_chain_ struct bf_chain *chain = NULL;
-
-        r = bf_chain_new(&chain);
-        if (r)
-            return r;
-
-        // chain is automatically freed when function returns
-    }
-
-Cleanup functions
-^^^^^^^^^^^^^^^^^
-
-Cleanup functions take double pointers, are no-op if ``*ptr`` is ``NULL`` (already freed), and set ``*ptr`` to ``NULL`` after freeing:
-
-.. code:: c
-
-    static void _bf_chain_free(struct bf_chain **chain)
-    {
-        if (!*chain)
-            return;
-
-        free(*chain);
-        *chain = NULL;
-    }
-
-Ownership transfer
-^^^^^^^^^^^^^^^^^^
-
-Use ``TAKE_PTR()`` to transfer ownership:
-
-.. code:: c
-
-    *out = TAKE_PTR(local);  // local becomes NULL, *out takes ownership
-
-Use ``TAKE_FD()`` for file descriptors, ``TAKE_STRUCT()`` for struct values.
 
 
 Error handling and logging
@@ -259,7 +219,8 @@ Not every function needs documentation. Skip documentation for trivial getters/s
 For documented functions:
 
 - First line is a brief description with ``@brief`` tag
-- Use ``@param`` for parameters, ``@return`` for return values
+- Use ``@param`` for parameters, ``@return`` for return values. To reference a parameter in a comment, do not use ``@p``, use backticks instead.
+- For pre-requirements to a function or a parameter, use ``@pre``, keep ``@param`` to describe what a parameter is, not what's required from it. Use ``@post`` for post requirements: what the caller can expect once the function succeeds, or fails.
 - Use backticks to reference function, variable, and parameter names
 - Use ``@code{.c}`` for examples
 
@@ -352,4 +313,3 @@ Examples:
     build: create targets to run tests suites individually
 
 Use the commit description to explain why the change is necessary. The "what" is taken care of by the code changes. Details about a specific algorithm or complex changes should be documented in the code.
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@
    developers/build
    developers/contributing
    developers/style
+   developers/memory
    developers/modules/index
    developers/packets_processing
    developers/generation

--- a/src/bfcli/helper.c
+++ b/src/bfcli/helper.c
@@ -57,6 +57,8 @@ int bfc_parse_file(const char *file, struct bfc_ruleset *ruleset)
     else if (r == 2)
         r = bf_err_r(-ENOMEM, "failed to parse rules, not enough memory");
 
+    (void)fclose(rules);
+
     return r;
 }
 

--- a/src/bfcli/parser.y
+++ b/src/bfcli/parser.y
@@ -113,7 +113,7 @@
 %token <sval> REDIRECT_DIR
 
 // Grammar types
-%destructor { freep(&$$); } <sval>
+%destructor { BF_FREEP(&$$); } <sval>
 
 %type <hook> hook
 %type <hookopts> hookopts

--- a/src/libbpfilter/cgen/elfstub.c
+++ b/src/libbpfilter/cgen/elfstub.c
@@ -40,7 +40,7 @@ static void _bf_printk_str_free(struct bf_printk_str **pstr)
     if (!*pstr)
         return;
 
-    freep((void *)pstr);
+    BF_FREEP(pstr);
 }
 
 static int _bf_elfstub_prepare(struct bf_elfstub *stub,
@@ -213,6 +213,6 @@ void bf_elfstub_free(struct bf_elfstub **stub)
         return;
 
     bf_list_clean(&(*stub)->strs);
-    freep((void *)&(*stub)->insns);
-    freep((void *)stub);
+    BF_FREEP(&(*stub)->insns);
+    BF_FREEP(stub);
 }

--- a/src/libbpfilter/cgen/fixup.c
+++ b/src/libbpfilter/cgen/fixup.c
@@ -37,7 +37,7 @@ void bf_fixup_free(struct bf_fixup **fixup)
     if (!*fixup)
         return;
 
-    freep((void *)fixup);
+    BF_FREEP(fixup);
 }
 
 static const char *_bf_fixup_type_to_str(enum bf_fixup_type type)

--- a/src/libbpfilter/cgen/prog/link.c
+++ b/src/libbpfilter/cgen/prog/link.c
@@ -174,7 +174,7 @@ void bf_link_free(struct bf_link **link)
     bf_hookopts_free(&(*link)->hookopts);
     closep(&(*link)->fd);
     closep(&(*link)->fd_extra);
-    freep((void *)link);
+    BF_FREEP(link);
 }
 
 int bf_link_pack(const struct bf_link *link, bf_wpack_t *pack)

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -239,6 +239,8 @@ int bf_map_new_from_pack(struct bf_map **map, int dir_fd, bf_rpack_node_t node)
     if (!_map)
         return -ENOMEM;
 
+    _map->fd = -1;
+
     r = bf_rpack_kv_str(node, "name", &name);
     if (r)
         return bf_rpack_key_err(r, "bf_map.name");
@@ -286,7 +288,7 @@ void bf_map_free(struct bf_map **map)
         return;
 
     closep(&(*map)->fd);
-    freep((void *)map);
+    freep(map);
 }
 
 int bf_map_pack(const struct bf_map *map, bf_wpack_t *pack)

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -57,7 +57,7 @@ static void _bf_btf_free(struct bf_btf **btf)
 
     btf__free((*btf)->btf);
     closep(&(*btf)->fd);
-    freep((void *)btf);
+    BF_FREEP(btf);
 }
 
 static int _bf_btf_load(struct bf_btf *btf)
@@ -288,7 +288,7 @@ void bf_map_free(struct bf_map **map)
         return;
 
     closep(&(*map)->fd);
-    freep(map);
+    BF_FREEP(map);
 }
 
 int bf_map_pack(const struct bf_map *map, bf_wpack_t *pack)

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -289,6 +289,8 @@ int bf_program_new(struct bf_program **program, const struct bf_chain *chain,
 
 void bf_program_free(struct bf_program **program)
 {
+    assert(program);
+
     if (!*program)
         return;
 

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -115,7 +115,7 @@ static void _bf_set_group_free(struct bf_set_group **group)
         return;
 
     bf_list_clean(&(*group)->sets);
-    freep((void *)group);
+    BF_FREEP(group);
 }
 
 static int _bf_set_group_new(struct bf_set_group **group)

--- a/src/libbpfilter/cgen/swich.c
+++ b/src/libbpfilter/cgen/swich.c
@@ -118,7 +118,6 @@ void bf_swich_cleanup(struct bf_swich *swich)
 
     bf_list_clean(&swich->options);
     _bf_swich_option_free(&swich->default_opt);
-    free(swich->default_opt);
 }
 
 int bf_swich_add_option(struct bf_swich *swich, uint32_t imm,

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -355,8 +355,8 @@ void bf_chain_free(struct bf_chain **chain)
 
     bf_list_clean(&(*chain)->sets);
     bf_list_clean(&(*chain)->rules);
-    freep((void *)&(*chain)->name);
-    freep((void *)chain);
+    BF_FREEP(&(*chain)->name);
+    BF_FREEP(chain);
 }
 
 int bf_chain_pack(const struct bf_chain *chain, bf_wpack_t *pack)

--- a/src/libbpfilter/core/hashset.c
+++ b/src/libbpfilter/core/hashset.c
@@ -75,7 +75,7 @@ static int _bf_hashset_resize(bf_hashset *set, size_t new_cap)
         new_slots[idx] = elem;
     }
 
-    freep((void *)&set->slots);
+    BF_FREEP(&set->slots);
     set->slots = new_slots;
     set->cap = new_cap;
     set->slots_in_use = set->len;
@@ -188,7 +188,7 @@ void bf_hashset_free(bf_hashset **set)
         return;
 
     bf_hashset_clean(*set);
-    freep((void *)set);
+    BF_FREEP(set);
 }
 
 void bf_hashset_init(bf_hashset *set, const bf_hashset_ops *ops, void *ctx)
@@ -208,10 +208,10 @@ void bf_hashset_clean(bf_hashset *set)
     bf_hashset_foreach (set, elem) {
         if (set->ops.free)
             set->ops.free(&elem->data, set->ctx);
-        freep((void *)&elem);
+        BF_FREEP(&elem);
     }
 
-    freep((void *)&set->slots);
+    BF_FREEP(&set->slots);
     set->cap = 0;
     set->len = 0;
     set->slots_in_use = 0;
@@ -328,7 +328,7 @@ static void _bf_hashset_unlink(bf_hashset *set, size_t found_idx)
         set->tail = elem->prev;
 
     set->slots[found_idx] = _BF_HASHSET_TOMBSTONE;
-    freep((void *)&elem);
+    BF_FREEP(&elem);
     --set->len;
 }
 

--- a/src/libbpfilter/core/list.c
+++ b/src/libbpfilter/core/list.c
@@ -48,7 +48,7 @@ static void bf_list_node_free(bf_list_node **node,
 
     if (free_data)
         free_data(&(*node)->data);
-    freep((void *)node);
+    BF_FREEP(node);
 }
 
 int bf_list_new(bf_list **list, const bf_list_ops *ops)

--- a/src/libbpfilter/core/lock.c
+++ b/src/libbpfilter/core/lock.c
@@ -417,6 +417,6 @@ void bf_lock_release_chain(struct bf_lock *lock)
 
     closep(&lock->chain_fd);
 
-    freep((void *)&lock->chain_name);
+    BF_FREEP(&lock->chain_name);
     lock->chain_lock = BF_LOCK_NONE;
 }

--- a/src/libbpfilter/core/vector.c
+++ b/src/libbpfilter/core/vector.c
@@ -61,14 +61,14 @@ void bf_vector_free(bf_vector **vec)
         return;
 
     bf_vector_clean(*vec);
-    freep((void *)vec);
+    BF_FREEP(vec);
 }
 
 void bf_vector_clean(bf_vector *vec)
 {
     assert(vec);
 
-    freep((void *)&vec->data);
+    BF_FREEP(&vec->data);
     vec->size = 0;
     vec->cap = 0;
 }

--- a/src/libbpfilter/counter.c
+++ b/src/libbpfilter/counter.c
@@ -60,7 +60,7 @@ void bf_counter_free(struct bf_counter **counter)
     if (!*counter)
         return;
 
-    freep((void *)counter);
+    BF_FREEP(counter);
 }
 
 int bf_counter_pack(const struct bf_counter *counter, bf_wpack_t *pack)

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -163,14 +163,14 @@ static void _bf_ctx_free(struct bf_ctx **ctx)
         return;
 
     closep(&(*ctx)->token_fd);
-    freep((void *)&(*ctx)->bpffs_path);
+    BF_FREEP(&(*ctx)->bpffs_path);
 
     for (enum bf_elfstub_id id = 0; id < _BF_ELFSTUB_MAX; ++id)
         bf_elfstub_free(&(*ctx)->stubs[id]);
 
     bf_btf_teardown();
 
-    freep((void *)ctx);
+    BF_FREEP(ctx);
 }
 
 /**

--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -104,6 +104,8 @@ static int _bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
     if (!_ctx)
         return -ENOMEM;
 
+    _ctx->token_fd = -1;
+
     r = bf_btf_setup();
     if (r)
         return bf_err_r(r, "failed to load vmlinux BTF");
@@ -115,7 +117,6 @@ static int _bf_ctx_new(struct bf_ctx **ctx, bool with_bpf_token,
     if (!_ctx->bpffs_path)
         return -ENOMEM;
 
-    _ctx->token_fd = -1;
     if (_ctx->with_bpf_token) {
         _cleanup_close_ int token_fd = -1;
 

--- a/src/libbpfilter/helper.c
+++ b/src/libbpfilter/helper.c
@@ -56,7 +56,7 @@ int bf_strncpy(char *dst, size_t len, const char *src)
 
 int bf_realloc(void **ptr, size_t size)
 {
-    _cleanup_free_ void *_ptr;
+    _cleanup_free_ void *_ptr = NULL;
 
     assert(ptr);
 

--- a/src/libbpfilter/hook.c
+++ b/src/libbpfilter/hook.c
@@ -506,7 +506,7 @@ int bf_hookopts_new_from_pack(struct bf_hookopts **hookopts,
 
 void bf_hookopts_clean(struct bf_hookopts *hookopts)
 {
-    freep((void *)&hookopts->cgpath);
+    BF_FREEP(&hookopts->cgpath);
 }
 
 void bf_hookopts_free(struct bf_hookopts **hookopts)
@@ -517,7 +517,7 @@ void bf_hookopts_free(struct bf_hookopts **hookopts)
         return;
 
     bf_hookopts_clean(*hookopts);
-    freep((void *)hookopts);
+    BF_FREEP(hookopts);
 }
 
 int bf_hookopts_pack(const struct bf_hookopts *hookopts, bf_wpack_t *pack)

--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -145,7 +145,6 @@ extern const char *strerrordesc_np(int errnum);
  */
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
-#define _cleanup_free_ __attribute__((__cleanup__(freep)))
 #define _cleanup_close_ __attribute__((__cleanup__(closep)))
 
 /**
@@ -214,15 +213,56 @@ char *bf_rtrim(char *str);
 char *bf_trim(char *str);
 
 /**
- * Free a pointer and set it to NULL.
+ * @brief Free a pointer and set it to NULL.
  *
- * @param ptr Pointer to free.
+ * Frees `*ptr` with `free()` and sets `*ptr` to NULL. If `*ptr` is already
+ * NULL, the call is a no-op (per `free()`).
+ *
+ * This is the function form of the free-and-null helper. It is used:
+ *
+ * - As the cleanup callback bound to the `_cleanup_free_` attribute.
+ * - As a function pointer where a `void (*)(void *)` callback is expected
+ *   (e.g. `bf_list_ops_default(bf_freep, ...)`).
+ *
+ * For direct manual frees in source code, prefer the `BF_FREEP()` macro:
+ * it accepts any `T **` argument without the explicit `(void *)` cast that
+ * Clang would otherwise require for the multilevel pointer conversion.
+ *
+ * @pre `ptr` is not NULL.
+ *
+ * @param ptr Address of the pointer to free, typed as `void *` so the
+ *        cleanup-attribute machinery and other callback consumers can pass
+ *        any `T **` to it.
  */
-static inline void freep(void *ptr)
+static inline void bf_freep(void *ptr)
 {
     free(*(void **)ptr);
     *(void **)ptr = NULL;
 }
+
+#define _cleanup_free_ __attribute__((__cleanup__(bf_freep)))
+
+/**
+ * @brief Free a pointer and set it to NULL, type-safe.
+ *
+ * Manual counterpart of `_cleanup_free_` and `bf_freep`. Calls `free(*p)`
+ * then assigns NULL to `*p`. `*p` may be NULL, in which case the call is
+ * a no-op.
+ *
+ * Implemented as a macro so it accepts any `T **` argument without the
+ * `(void *)` cast that `bf_freep(void *)` would otherwise require at the
+ * call site. Use this for direct manual frees; use `bf_freep` when a
+ * function pointer is needed.
+ *
+ * @pre `p` is not NULL.
+ *
+ * @param p Address of the pointer to free.
+ */
+#define BF_FREEP(p)                                                            \
+    do {                                                                       \
+        free(*(p));                                                            \
+        *(p) = NULL;                                                           \
+    } while (0)
 
 /**
  * @brief Close a file descriptor and set it to -1.

--- a/src/libbpfilter/io.c
+++ b/src/libbpfilter/io.c
@@ -97,6 +97,7 @@ int bf_rmdir_at(int parent_fd, const char *dir_name, bool recursive)
         _cleanup_close_ int child_fd = -1;
         _free_dir_ DIR *dir = NULL;
         struct dirent *entry;
+        int dir_fd;
 
         child_fd = openat(parent_fd, dir_name, O_DIRECTORY);
         if (child_fd < 0) {
@@ -107,6 +108,13 @@ int bf_rmdir_at(int parent_fd, const char *dir_name, bool recursive)
         dir = fdopendir(child_fd);
         if (!dir)
             return bf_err_r(errno, "failed to open DIR from file descriptor");
+        /* fdopendir takes ownership of the FD, let's prevent double-close in
+         * case of multithreading and FD reuse */
+        TAKE_FD(child_fd);
+
+        dir_fd = dirfd(dir);
+        if (dir_fd < 0)
+            return bf_err_r(errno, "failed to retrieve FD after fdopendir");
 
         while ((entry = readdir(dir))) {
             struct stat stat;
@@ -114,16 +122,16 @@ int bf_rmdir_at(int parent_fd, const char *dir_name, bool recursive)
             if (bf_streq(entry->d_name, ".") || bf_streq(entry->d_name, ".."))
                 continue;
 
-            if (fstatat(child_fd, entry->d_name, &stat, 0) < 0) {
+            if (fstatat(dir_fd, entry->d_name, &stat, 0) < 0) {
                 return bf_err_r(errno,
                                 "failed to fstatat() file '%s' for removal",
                                 entry->d_name);
             }
 
             if (S_ISDIR(stat.st_mode))
-                r = bf_rmdir_at(child_fd, entry->d_name, true);
+                r = bf_rmdir_at(dir_fd, entry->d_name, true);
             else
-                r = unlinkat(child_fd, entry->d_name, 0) == 0 ? 0 : -errno;
+                r = unlinkat(dir_fd, entry->d_name, 0) == 0 ? 0 : -errno;
             if (r)
                 return bf_err_r(r, "failed to remove '%s'", entry->d_name);
         }

--- a/src/libbpfilter/pack.c
+++ b/src/libbpfilter/pack.c
@@ -83,8 +83,8 @@ void bf_wpack_free(bf_wpack_t **pack)
 
     mpack_writer_destroy(&_pack->writer);
 
-    freep((void *)&_pack->data);
-    freep((void *)pack);
+    BF_FREEP(&_pack->data);
+    BF_FREEP(pack);
 }
 
 bool bf_wpack_is_valid(bf_wpack_t *pack)
@@ -275,7 +275,7 @@ void bf_rpack_free(bf_rpack_t **pack)
         return;
 
     mpack_tree_destroy(&_pack->tree);
-    freep((void *)pack);
+    BF_FREEP(pack);
 }
 
 #define MP_NODE(node) (*(mpack_node_t *)&(node))

--- a/src/libbpfilter/rule.c
+++ b/src/libbpfilter/rule.c
@@ -50,7 +50,7 @@ int bf_log_opt_from_str(const char *str, enum bf_log_opt *hdr)
 
 int bf_rule_new(struct bf_rule **rule)
 {
-    struct bf_rule *_rule;
+    _free_bf_rule_ struct bf_rule *_rule = NULL;
 
     assert(rule);
 
@@ -60,7 +60,7 @@ int bf_rule_new(struct bf_rule **rule)
 
     _rule->matchers = bf_list_default(bf_matcher_free, bf_matcher_pack);
 
-    *rule = _rule;
+    *rule = TAKE_PTR(_rule);
 
     return 0;
 }

--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -35,7 +35,7 @@ static bool _bf_set_elem_equal(const void *lhs, const void *rhs, void *ctx)
 static void _bf_set_elem_free(void **data, void *ctx)
 {
     (void)ctx;
-    freep((void *)data);
+    BF_FREEP(data);
 }
 
 static const bf_hashset_ops _bf_set_elem_ops = {
@@ -349,8 +349,8 @@ void bf_set_free(struct bf_set **set)
         return;
 
     bf_hashset_clean(&(*set)->elems);
-    freep((void *)&(*set)->name);
-    freep((void *)set);
+    BF_FREEP(&(*set)->name);
+    BF_FREEP(set);
 }
 
 int bf_set_pack(const struct bf_set *set, bf_wpack_t *pack)

--- a/tests/harness/fake.c
+++ b/tests/harness/fake.c
@@ -34,7 +34,7 @@ static int _bft_list_dummy_pack(const void *data, bf_wpack_t *pack)
 bf_list *bft_list_dummy(size_t len, bft_list_dummy_inserter inserter)
 {
     _free_bf_list_ bf_list *list = NULL;
-    bf_list_ops ops = bf_list_ops_default(freep, _bft_list_dummy_pack);
+    bf_list_ops ops = bf_list_ops_default(bf_freep, _bft_list_dummy_pack);
     int r;
 
     r = bf_list_new(&list, &ops);

--- a/tests/harness/test.c
+++ b/tests/harness/test.c
@@ -109,9 +109,9 @@ void bft_stream_free(struct bft_streams **streams)
     (void)fclose(_streams->new_stdout);
     (void)fclose(_streams->new_stderr);
 
-    freep((void *)&_streams->stdout_buf);
-    freep((void *)&_streams->stderr_buf);
-    freep((void *)streams);
+    BF_FREEP(&_streams->stdout_buf);
+    BF_FREEP(&_streams->stderr_buf);
+    BF_FREEP(streams);
 }
 
 int btf_setup_create_sockets(void **state)
@@ -165,7 +165,7 @@ void bft_sockets_free(struct bft_sockets **sockets)
 
     closep(&_sockets->client_fd);
     closep(&_sockets->server_fd);
-    freep((void *)sockets);
+    BF_FREEP(sockets);
 }
 
 int btf_setup_create_tmpdir(void **state)
@@ -223,7 +223,7 @@ void bft_tmpdir_free(struct bft_tmpdir **tmpdir)
         return;
 
     nftw(_tmpdir->dir_path, _bft_unlink_cb, 64, FTW_DEPTH | FTW_PHYS);
-    freep((void *)tmpdir);
+    BF_FREEP(tmpdir);
 }
 
 bool bft_list_eq(const bf_list *lhs, const bf_list *rhs, bft_list_eq_cb cb)

--- a/tests/unit/libbpfilter/core/hashset.c
+++ b/tests/unit/libbpfilter/core/hashset.c
@@ -23,7 +23,7 @@ static bool _bf_uint32_equal(const void *lhs, const void *rhs, void *ctx)
 static void _bf_uint32_free(void **data, void *ctx)
 {
     (void)ctx;
-    freep((void *)data);
+    BF_FREEP(data);
 }
 
 static const bf_hashset_ops _bf_uint32_ops = {

--- a/tests/unit/libbpfilter/core/list.c
+++ b/tests/unit/libbpfilter/core/list.c
@@ -26,7 +26,7 @@ static void new_and_free(void **state)
         // Allocate and free, custom operators, empty
 
         bf_list *list;
-        bf_list_ops free_ops = bf_list_ops_default(freep, NULL);
+        bf_list_ops free_ops = bf_list_ops_default(bf_freep, NULL);
 
         assert_int_equal(0, bf_list_new(&list, &free_ops));
         bf_list_free(&list);

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -74,7 +74,7 @@ static void bpffs_path_is_owned_copy(void **state)
 
     /* Tear down before the tmpdir cleanup so the ctx releases its copy while
      * the bpffs path is still on disk. ASan/leak detectors would flag a
-     * missing free here, exercising the matching freep() in _bf_ctx_free. */
+     * missing free here, exercising the matching BF_FREEP() in _bf_ctx_free. */
     bf_ctx_teardown();
 }
 

--- a/tests/unit/libbpfilter/hook.c
+++ b/tests/unit/libbpfilter/hook.c
@@ -687,7 +687,7 @@ static void hookopts_parse_opts_list(void **state)
 {
     _free_bf_hookopts_ struct bf_hookopts *hookopts = NULL;
     _free_bf_list_ bf_list *opts = NULL;
-    bf_list_ops free_ops = bf_list_ops_default(freep, NULL);
+    bf_list_ops free_ops = bf_list_ops_default(bf_freep, NULL);
     char *opt1 = strdup("ifindex=42");
     char *opt2 = strdup("family=inet4");
     char *opt3 = strdup("priorities=100-200");


### PR DESCRIPTION
Codify bpfilter's memory and resource safety conventions in a single deep reference (`doc/developers/memory.rst`), and apply them in two follow-ups. The doc leads with a **local verifiability** principle: every other rule (cleanup attributes, ownership transfer, output-parameter contract, fd sentinels, locking, kernel-side BPF resources) exists so that a single function can be reviewed without tracing its callees.

### Commits

1. **`doc: developers: add memory and resource management reference`**: the doc itself, a new Breathe-rendered `modules/helpers.rst` so it can cross-link `TAKE_PTR`, `freep`, etc. as live symbols, a trimmed `style.rst` Memory section pointing here, and a Doxyfile fix for a pre-existing duplicate `bf_aligned` definition.

2. **`lib,cli: fix various memory and fd safety issues`**: eight small defects uncovered while writing the doc (`FILE*` leak in `bfc_parse_file`, double-close after `fdopendir` in `bf_rmdir_at`, uninitialised `_cleanup_free_` in `bf_realloc`, missing fd sentinels, missing `TAKE_PTR` in `bf_rule_new`, etc.).

3. **`lib,tests,doc: helper: split freep into cleanup callback and macro`**: the old `freep(void *)` required `freep((void *)x)` at every call site (Clang refuses the implicit `T**` → `void*`). Split into a `_bf_freep_cb` callback and a type-safe `freep` macro; sweeps 19 files.

### Note

Also adds a `memory-auditor` Claude subagent and `/memory-audit` slash command that apply `memory.rst`'s rules to a diff.