### PR TITLE
Fix `clang-tidy` errors in Fedora 44

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,6 +58,10 @@
 # - readability-function-cognitive-complexity
 #   Functions generating BPF bytecode will trigger this rule anytime, but they're
 #   not that complex due to heavy use of macros.
+# - readability-implicit-bool-conversion
+#   Implicit bool<->int conversions are idiomatic C (e.g. returning int from
+#   `cond ? 0 : -EINVAL` where `cond` is bool). The check has no option to
+#   suppress just the bool->int direction, which produces most of the noise.
 # - readability-isolate-declaration
 #   Rely on manual check: it's uncommon in bpfilter for multiple variable to be
 #   defined on a single line, but it's sometimes for the better.
@@ -97,6 +101,7 @@ Checks: >
   readability-*,
     -readability-enum-initial-value,
     -readability-function-cognitive-complexity,
+    -readability-implicit-bool-conversion,
     -readability-isolate-declaration,
     -readability-suspicious-call-argument,
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ target_compile_options(bf_global_flags
         $<$<CONFIG:release>:-O2>
 )
 target_include_directories(bf_global_flags
-    INTERFACE
+    SYSTEM INTERFACE
         ${CMAKE_SOURCE_DIR}/src/external
 )
 target_link_options(bf_global_flags

--- a/src/bfcli/helper.c
+++ b/src/bfcli/helper.c
@@ -15,7 +15,9 @@
 #include "lexer.h"
 #include "parser.h"
 
-// To speed up parsing very large rulesets, we can increase YY_READ_BUF_SIZE
+/* To speed up parsing very large rulesets, we can increase YY_READ_BUF_SIZE.
+ * Referenced by the generated lexer; cannot be static. */
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 int yy_read_buf_size;
 
 #define _BF_LEX_MIN_BUF_POW 14

--- a/src/bfcli/main.c
+++ b/src/bfcli/main.c
@@ -60,6 +60,8 @@ int main(int argc, char *argv[])
     return r;
 }
 
+/* Called by the generated parser; cannot be static. */
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void yyerror(struct bfc_ruleset *ruleset, const char *fmt, ...)
 {
     va_list args;

--- a/src/bfcli/opts.c
+++ b/src/bfcli/opts.c
@@ -61,7 +61,7 @@ static const char *bfc_object_to_str(enum bfc_object object)
     return _bfc_object_strs[object];
 }
 
-enum bfc_object bfc_object_from_str(const char *str)
+static enum bfc_object _bfc_object_from_str(const char *str)
 {
     assert(str);
 
@@ -90,7 +90,7 @@ static const char *bfc_action_to_str(enum bfc_action action)
     return _bfc_action_strs[action];
 }
 
-enum bfc_action bfc_action_from_str(const char *str)
+static enum bfc_action _bfc_action_from_str(const char *str)
 {
     assert(str);
 
@@ -320,8 +320,8 @@ static void _bfc_opts_version(struct argp_state *state, const char *arg,
     exit(0);
 };
 
-const struct bfc_opts_cmd *_bfc_opts_get_cmd(enum bfc_object object,
-                                             enum bfc_action action)
+static const struct bfc_opts_cmd *_bfc_opts_get_cmd(enum bfc_object object,
+                                                    enum bfc_action action)
 {
     for (size_t i = 0; i < ARRAY_SIZE(_bfc_opts_cmds); ++i) {
         if (_bfc_opts_cmds[i].object == object &&
@@ -377,11 +377,11 @@ static error_t _bfc_opts_parser(int key, char *arg, struct argp_state *state)
     }
     case ARGP_KEY_ARG:
         if (state->arg_num == 0) {
-            opts->object = bfc_object_from_str(arg);
+            opts->object = _bfc_object_from_str(arg);
             if ((int)opts->object < 0)
                 argp_error(state, "unknown object '%s'", arg);
         } else if (state->arg_num == 1) {
-            opts->action = bfc_action_from_str(arg);
+            opts->action = _bfc_action_from_str(arg);
             if ((int)opts->action < 0)
                 argp_error(state, "unknown action '%s'", arg);
             opts->cmd = _bfc_opts_get_cmd(opts->object, opts->action);

--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -128,10 +128,14 @@ target_compile_definitions(libbpfilter
 target_include_directories(libbpfilter
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/src/external/include
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}/include
+)
+
+target_include_directories(libbpfilter SYSTEM
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/external/include
 )
 
 target_link_libraries(libbpfilter

--- a/src/libbpfilter/CMakeLists.txt
+++ b/src/libbpfilter/CMakeLists.txt
@@ -133,6 +133,8 @@ target_include_directories(libbpfilter
         ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 
+# Vendored kernel headers are SYSTEM so clang-tidy's --system-headers=false
+# default skips the reserved identifiers they use.
 target_include_directories(libbpfilter SYSTEM
     PRIVATE
         ${CMAKE_SOURCE_DIR}/src/external/include

--- a/src/libbpfilter/bpf.c
+++ b/src/libbpfilter/bpf.c
@@ -165,12 +165,12 @@ int bf_bpf_prog_run(int prog_fd, const void *pkt, size_t pkt_len,
 
     attr.test.prog_fd = prog_fd;
     attr.test.data_size_in = pkt_len;
-    attr.test.data_in = ((unsigned long long)(pkt));
+    attr.test.data_in = (unsigned long long)pkt;
     attr.test.repeat = 1;
 
     if (ctx_len) {
         attr.test.ctx_size_in = ctx_len;
-        attr.test.ctx_in = ((unsigned long long)(ctx));
+        attr.test.ctx_in = (unsigned long long)ctx;
     }
 
     r = bf_bpf(BF_BPF_PROG_TEST_RUN, &attr);

--- a/src/libbpfilter/cgen/matcher/cmp.c
+++ b/src/libbpfilter/cgen/matcher/cmp.c
@@ -94,7 +94,7 @@ static void _bf_prefix_to_mask(unsigned int prefixlen, uint8_t *mask,
     memset(mask, 0x00, mask_len);
     memset(mask, 0xff, prefixlen / 8);
     if (prefixlen % 8)
-        mask[prefixlen / 8] = (0xff << (8 - prefixlen % 8)) & 0xff;
+        mask[prefixlen / 8] = (0xff << (8 - (prefixlen % 8))) & 0xff;
 }
 
 int bf_cmp_value(struct bf_program *program, const struct bf_matcher *matcher,

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -194,6 +194,10 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
         [BF_MAP_TYPE_COUNTERS] = BF_BPF_MAP_TYPE_ARRAY,
         [BF_MAP_TYPE_PRINTER] = BF_BPF_MAP_TYPE_ARRAY,
         [BF_MAP_TYPE_LOG] = BF_BPF_MAP_TYPE_RINGBUF,
+        /* Unreachable: bf_map_new() rejects BF_MAP_TYPE_SET; use
+         * bf_map_new_from_set() instead. Listed here to give the entry a
+         * valid bf_bpf_map_type value. */
+        [BF_MAP_TYPE_SET] = BF_BPF_MAP_TYPE_HASH,
         [BF_MAP_TYPE_CTX] = BF_BPF_MAP_TYPE_ARRAY,
     };
 

--- a/src/libbpfilter/cgen/program.c
+++ b/src/libbpfilter/cgen/program.c
@@ -1037,15 +1037,6 @@ int bf_program_get_counter(const struct bf_program *program,
     return bf_handle_get_counter(program->handle, counter_idx, counter);
 }
 
-int bf_cgen_set_counters(struct bf_program *program,
-                         const struct bf_counter *counters)
-{
-    (void)program;
-    (void)counters;
-
-    return -ENOTSUP;
-}
-
 size_t bf_program_chain_counter_idx(const struct bf_program *program)
 {
     return bf_list_size(&program->runtime.chain->rules);

--- a/src/libbpfilter/cgen/xdp.c
+++ b/src/libbpfilter/cgen/xdp.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2023 Meta Platforms, Inc. and affiliates.
  */
 
+#include "cgen/xdp.h"
+
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 

--- a/src/libbpfilter/chain.c
+++ b/src/libbpfilter/chain.c
@@ -151,7 +151,7 @@ static int _bf_rule_has_incompatible_matchers(const struct bf_chain *chain,
     return 0;
 }
 
-int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
+static int _bf_chain_check_rule(struct bf_chain *chain, struct bf_rule *rule)
 {
     int r;
 

--- a/src/libbpfilter/cli.c
+++ b/src/libbpfilter/cli.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <bpfilter/bpfilter.h>
 #include <bpfilter/ctx.h>
 
 #include "bpfilter/chain.h"

--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -14,6 +14,9 @@
 #include <string.h>
 #include <strings.h>
 
+/* Forward declaration: <string.h> only exposes strerrordesc_np() under
+ * _GNU_SOURCE, which we don't define globally. */
+// NOLINTNEXTLINE(readability-redundant-declaration,readability-inconsistent-declaration-parameter-name)
 extern const char *strerrordesc_np(int errnum);
 
 #define _BF_APPLY0(t, s, dummy)

--- a/src/libbpfilter/include/bpfilter/logger.h
+++ b/src/libbpfilter/include/bpfilter/logger.h
@@ -67,11 +67,13 @@ enum bf_log_level
  * @param ... Format arguments.
  */
 #define _bf_log_impl(level, color, fmt, ...)                                   \
-    if (level >= bf_log_get_level()) {                                         \
-        (void)fprintf(stderr, _bf_logger_prefix_fmt fmt "\n",                  \
-                      _bf_logger_prefix_fmt_args(level, color),                \
-                      ##__VA_ARGS__);                                          \
-    }
+    do {                                                                       \
+        if (level >= bf_log_get_level()) {                                     \
+            (void)fprintf(stderr, _bf_logger_prefix_fmt fmt "\n",              \
+                          _bf_logger_prefix_fmt_args(level, color),            \
+                          ##__VA_ARGS__);                                      \
+        }                                                                      \
+    } while (0)
 
 #define bf_abort(fmt, ...)                                                     \
     ({                                                                         \
@@ -146,12 +148,14 @@ enum bf_log_level
  * @param vargs @p va_list of arguments.
  */
 #define _bf_log_v_impl(level, color, fmt, vargs)                               \
-    if ((level) >= bf_log_get_level()) {                                       \
-        (void)fprintf(stderr, _bf_logger_prefix_fmt,                           \
-                      _bf_logger_prefix_fmt_args(level, color));               \
-        (void)vfprintf(stderr, (fmt), (vargs));                                \
-        (void)fprintf(stderr, "\n");                                           \
-    }
+    do {                                                                       \
+        if ((level) >= bf_log_get_level()) {                                   \
+            (void)fprintf(stderr, _bf_logger_prefix_fmt,                       \
+                          _bf_logger_prefix_fmt_args(level, color));           \
+            (void)vfprintf(stderr, (fmt), (vargs));                            \
+            (void)fprintf(stderr, "\n");                                       \
+        }                                                                      \
+    } while (0)
 
 #define bf_err_v(fmt, vargs)                                                   \
     _bf_log_v_impl(BF_LOG_ERR, BF_COLOR_RED, fmt, vargs)

--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -183,8 +183,8 @@ static void _bf_print_u32_range(const void *payload)
     (void)fprintf(stdout, "0x%" PRIx32 "-0x%" PRIx32, range[0], range[1]);
 }
 
-int _bf_parse_iface(enum bf_matcher_type type, enum bf_matcher_op op,
-                    void *payload, const char *raw_payload)
+static int _bf_parse_iface(enum bf_matcher_type type, enum bf_matcher_op op,
+                           void *payload, const char *raw_payload)
 {
     assert(payload);
     assert(raw_payload);
@@ -203,7 +203,7 @@ int _bf_parse_iface(enum bf_matcher_type type, enum bf_matcher_op op,
     return 0;
 }
 
-void _bf_print_iface(const void *payload)
+static void _bf_print_iface(const void *payload)
 {
     assert(payload);
 
@@ -217,8 +217,8 @@ void _bf_print_iface(const void *payload)
         (void)fprintf(stdout, "%" PRIu32, ifindex);
 }
 
-int _bf_parse_l3_proto(enum bf_matcher_type type, enum bf_matcher_op op,
-                       void *payload, const char *raw_payload)
+static int _bf_parse_l3_proto(enum bf_matcher_type type, enum bf_matcher_op op,
+                              void *payload, const char *raw_payload)
 {
     unsigned long value;
 
@@ -239,7 +239,7 @@ int _bf_parse_l3_proto(enum bf_matcher_type type, enum bf_matcher_op op,
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
-void _bf_print_l3_proto(const void *payload)
+static void _bf_print_l3_proto(const void *payload)
 {
     assert(payload);
 
@@ -251,8 +251,8 @@ void _bf_print_l3_proto(const void *payload)
         (void)fprintf(stdout, "0x%04" PRIx16, *(uint16_t *)payload);
 }
 
-int _bf_parse_l4_proto(enum bf_matcher_type type, enum bf_matcher_op op,
-                       void *payload, const char *raw_payload)
+static int _bf_parse_l4_proto(enum bf_matcher_type type, enum bf_matcher_op op,
+                              void *payload, const char *raw_payload)
 {
     unsigned long value;
 
@@ -273,7 +273,7 @@ int _bf_parse_l4_proto(enum bf_matcher_type type, enum bf_matcher_op op,
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
-void _bf_print_l4_proto(const void *payload)
+static void _bf_print_l4_proto(const void *payload)
 {
     assert(payload);
 
@@ -285,8 +285,8 @@ void _bf_print_l4_proto(const void *payload)
         (void)fprintf(stdout, "%" PRIu8, *(uint8_t *)payload);
 }
 
-int _bf_parse_l4_port(enum bf_matcher_type type, enum bf_matcher_op op,
-                      void *payload, const char *raw_payload)
+static int _bf_parse_l4_port(enum bf_matcher_type type, enum bf_matcher_op op,
+                             void *payload, const char *raw_payload)
 {
     assert(payload);
     assert(raw_payload);
@@ -306,7 +306,7 @@ int _bf_parse_l4_port(enum bf_matcher_type type, enum bf_matcher_op op,
     return -EINVAL;
 }
 
-void _bf_print_l4_port(const void *payload)
+static void _bf_print_l4_port(const void *payload)
 {
     assert(payload);
 
@@ -364,7 +364,7 @@ err:
     return -EINVAL;
 }
 
-void _bf_print_l4_port_range(const void *payload)
+static void _bf_print_l4_port_range(const void *payload)
 {
     assert(payload);
 
@@ -438,7 +438,7 @@ static int _bf_parse_mark(enum bf_matcher_type type, enum bf_matcher_op op,
     return 0;
 }
 
-void _bf_print_mark(const void *payload)
+static void _bf_print_mark(const void *payload)
 {
     assert(payload);
 
@@ -464,7 +464,7 @@ static int _bf_parse_ipv4_addr(enum bf_matcher_type type, enum bf_matcher_op op,
     return -EINVAL;
 }
 
-void _bf_print_ipv4_addr(const void *payload)
+static void _bf_print_ipv4_addr(const void *payload)
 {
     assert(payload);
 
@@ -517,7 +517,7 @@ err:
     return -EINVAL;
 }
 
-void _bf_print_ipv4_net(const void *payload)
+static void _bf_print_ipv4_net(const void *payload)
 {
     assert(payload);
 
@@ -549,7 +549,7 @@ static int _bf_parse_ipv6_addr(enum bf_matcher_type type, enum bf_matcher_op op,
     return -EINVAL;
 }
 
-void _bf_print_ipv6_addr(const void *payload)
+static void _bf_print_ipv6_addr(const void *payload)
 {
     assert(payload);
 
@@ -601,7 +601,7 @@ err:
     return -EINVAL;
 }
 
-void _bf_print_ipv6_net(const void *payload)
+static void _bf_print_ipv6_net(const void *payload)
 {
     assert(payload);
 
@@ -656,7 +656,7 @@ err:
     return -EINVAL;
 }
 
-void _bf_print_tcp_flags(const void *payload)
+static void _bf_print_tcp_flags(const void *payload)
 {
     assert(payload);
 
@@ -693,7 +693,7 @@ static int _bf_parse_icmp_type(enum bf_matcher_type type, enum bf_matcher_op op,
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
-void _bf_print_icmp_type(const void *payload)
+static void _bf_print_icmp_type(const void *payload)
 {
     assert(payload);
 
@@ -724,7 +724,7 @@ static int _bf_parse_icmp_code(enum bf_matcher_type type, enum bf_matcher_op op,
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
-void _bf_print_icmp_code(const void *payload)
+static void _bf_print_icmp_code(const void *payload)
 {
     assert(payload);
 
@@ -790,7 +790,7 @@ static int _bf_parse_icmpv6_type(enum bf_matcher_type type,
         bf_matcher_type_to_str(type), bf_matcher_op_to_str(op), raw_payload);
 }
 
-void _bf_print_icmpv6_type(const void *payload)
+static void _bf_print_icmpv6_type(const void *payload)
 {
     assert(payload);
 

--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -73,7 +73,7 @@ int bf_set_new(struct bf_set **set, const char *name, enum bf_matcher_type *key,
             return bf_err_r(-ENOMEM, "failed to allocate memory for set name");
     }
 
-    memcpy(&(_set)->key, key, n_comps * sizeof(enum bf_matcher_type));
+    memcpy(&_set->key, key, n_comps * sizeof(enum bf_matcher_type));
     _set->n_comps = n_comps;
     _set->elem_size = 0;
     bf_hashset_init(&_set->elems, &_bf_set_elem_ops, &_set->elem_size);

--- a/tests/check/CMakeLists.txt
+++ b/tests/check/CMakeLists.txt
@@ -17,11 +17,18 @@ file(GLOB_RECURSE bf_test_srcs
 )
 set(bf_all_srcs ${bf_srcs} ${bf_test_srcs})
 
+# Only report diagnostics from headers in the project source tree. This
+# excludes build-generated headers (flex/bison output, version.h, rawstubs.h
+# and the elfstub .inc.c files) which we don't write by hand and shouldn't be
+# held to clang-tidy's style rules.
+set(LINT_HEADER_FILTER "^${CMAKE_SOURCE_DIR}/src/(core|libbpfilter|bfcli)/.*")
+
 add_test(NAME "check.lint"
     COMMAND
         ${RUN_CLANG_TIDY_BIN}
             -config-file=${CMAKE_SOURCE_DIR}/.clang-tidy
             -p ${CMAKE_BINARY_DIR}
+            -header-filter=${LINT_HEADER_FILTER}
             -extra-arg=-fno-caret-diagnostics
             -j ${CPU_COUNT}
             ${bf_srcs}

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -37,13 +37,17 @@ target_compile_definitions(fuzz_parser
 target_include_directories(fuzz_parser
     PRIVATE
         ${CMAKE_SOURCE_DIR}/src/bfcli
-        ${CMAKE_SOURCE_DIR}/src/external
-        ${CMAKE_SOURCE_DIR}/src/external/include
         ${CMAKE_SOURCE_DIR}/src/libbpfilter
         ${CMAKE_SOURCE_DIR}/src/libbpfilter/include
         ${CMAKE_BINARY_DIR}/src/libbpfilter/include
         ${CMAKE_BINARY_DIR}/src/libbpfilter/elfstubs/src
         ${CMAKE_BINARY_DIR}/src/bfcli/include
+)
+
+target_include_directories(fuzz_parser SYSTEM
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/external
+        ${CMAKE_SOURCE_DIR}/src/external/include
 )
 
 target_link_options(fuzz_parser

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -44,6 +44,8 @@ target_include_directories(fuzz_parser
         ${CMAKE_BINARY_DIR}/src/bfcli/include
 )
 
+# Vendored kernel headers are SYSTEM so clang-tidy's --system-headers=false
+# default skips the reserved identifiers they use.
 target_include_directories(fuzz_parser SYSTEM
     PRIVATE
         ${CMAKE_SOURCE_DIR}/src/external


### PR DESCRIPTION
CI will run the `clang-tidy` packaged with Fedora 44, which surfaced a lot of error vs Fedora 43. This PR fixes those errors before switching the CI to Fedora 44 by default.

See the commits description for details.