### PR TITLE
build: fix building benchmark

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -186,6 +186,7 @@ jobs:
             --pr-report-path $GITHUB_STEP_SUMMARY \
             $BENCH_RETRY \
             $BENCH_FAIL_ON \
+            --fail-on-last-commit-failure \
             --bind-node 0 \
             --no-preempt \
             --cpu-pin 3 \

--- a/tools/benchmarks/bfbencher
+++ b/tools/benchmarks/bfbencher
@@ -53,6 +53,7 @@ class Stats:
         self.n_failures = 0
         self.n_cache_hits = 0
         self.n_cache_misses = 0
+        self.failed_shas: set[str] = set()
 
     def success(self, from_cache: bool = False) -> None:
         if from_cache:
@@ -61,12 +62,14 @@ class Stats:
             self.n_cache_misses += 1
         self.n_successes += 1
 
-    def failure(self, from_cache: bool = False) -> None:
+    def failure(self, commit_sha: str | None = None, from_cache: bool = False) -> None:
         if from_cache:
             self.n_cache_hits += 1
         else:
             self.n_cache_misses += 1
         self.n_failures += 1
+        if commit_sha is not None:
+            self.failed_shas.add(commit_sha)
 
 
 class Renderer:
@@ -406,7 +409,7 @@ class Executor(ABC):
         r = self._run(self._substitute_workdir(cmd), timeout)
         if r:
             self.log(f"[red bold]{message} failed[/]")
-            self.stats.failure(from_cache=False)
+            self.stats.failure(commit_sha=commit.hexsha, from_cache=False)
             self.cache[get_cache_key(commit, self._host)] = {"success": False}
 
         return r == 0
@@ -847,7 +850,7 @@ class BenchmarkContext:
                 continue
             elif cached_data and not executor._source.retry_failed:
                 executor.log("Skipping (cached failure)")
-                executor.stats.failure(from_cache=True)
+                executor.stats.failure(commit_sha=commit.hexsha, from_cache=True)
                 continue
 
             executor.log(
@@ -1072,6 +1075,23 @@ def run_benchmarks(args: argparse.Namespace):
             )
         report.print_report([20])
 
+    failed_shas = executor.stats.failed_shas
+    if args.fail_on_last_commit_failure and executor.commits:
+        last_sha = executor.commits[-1].hexsha
+        if last_sha in failed_shas:
+            renderer.log(
+                f"[red bold]The last commit ({last_sha[:SHORT_SHA_LEN]}) failed "
+                f"to build or run; failing the bfbencher invocation.[/]"
+            )
+            raise SystemExit(1)
+
+    if args.fail_on_any_commit_failure and failed_shas:
+        renderer.log(
+            f"[red bold]{len(failed_shas)} commit(s) failed to build or run; "
+            f"failing the bfbencher invocation.[/]"
+        )
+        raise SystemExit(1)
+
     if args.fail_on_significant_change:
         terms = [20]
         for benchmark in executor.results.sorted_benchmarks():
@@ -1159,6 +1179,18 @@ def main():
         choices=["better", "worse", "any"],
         help="exit with non-zero status if any benchmark has a statistically significant change (better=improvement, worse=regression, any=either)",
         default=None,
+    )
+    parser.add_argument(
+        "--fail-on-last-commit-failure",
+        action="store_true",
+        help="exit with non-zero status if the last (newest) commit failed to build or run, including cached failures.",
+        default=False,
+    )
+    parser.add_argument(
+        "--fail-on-any-commit-failure",
+        action="store_true",
+        help="exit with non-zero status if any commit failed to build or run, including cached failures.",
+        default=False,
     )
     parser.add_argument(
         "--bind-node",

--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -97,7 +97,7 @@ BENCHMARK(chain_policy_c);
 void single_rule__ip4_saddr(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -131,13 +131,13 @@ void multiple_rules__ip4_saddr(::benchmark::State &state)
     uint32_t nrules = state.range(0);
     for (uint32_t i = 0; i < nrules - 1; ++i) {
         chain << Rule(
-            BF_VERDICT_DROP, false, {},
+            BF_VERDICT_DROP, std::nullopt, 0,
             std::vector<Matcher> {
                 Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ, uint32ToIp4(i)),
             });
     }
 
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -176,7 +176,7 @@ void single_rule__ip4_saddr__x_elem_set(::benchmark::State &state)
 
     s << std::vector<uint8_t> {0x7f, 0x02, 0x0a, 0x0a};
 
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_SET, BF_MATCHER_IN, {0, 0, 0, 0}),
                   });
@@ -210,7 +210,7 @@ BENCHMARK(single_rule__ip4_saddr__x_elem_set)
 void single_rule__ip4_saddr_c(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, true, {},
+    chain << Rule(BF_VERDICT_DROP, bf_counter(), 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -240,7 +240,7 @@ BENCHMARK(single_rule__ip4_saddr_c);
 void single_rule__ip4_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false, BF_FLAG(BF_LOG_OPT_LINK),
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, BF_FLAG(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP4_SADDR, BF_MATCHER_EQ,
                               {0x7f, 0x02, 0x0a, 0x0a}),
@@ -270,7 +270,7 @@ BENCHMARK(single_rule__ip4_saddr_l);
 void single_rule__ip6_saddr(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -305,13 +305,13 @@ void multiple_rules__ip6_saddr(::benchmark::State &state)
     uint32_t nrules = state.range(0);
     for (uint32_t i = 0; i < nrules - 1; ++i) {
         chain << Rule(
-            BF_VERDICT_DROP, false, {},
+            BF_VERDICT_DROP, std::nullopt, 0,
             std::vector<Matcher> {
                 Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ, uint32ToIp6(i)),
             });
     }
 
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -352,7 +352,7 @@ void single_rule__ip6_saddr__x_elem_set(::benchmark::State &state)
     s << std::vector<uint8_t> {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
 
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_SET, BF_MATCHER_IN, {0, 0, 0, 0}),
                   });
@@ -386,7 +386,7 @@ BENCHMARK(single_rule__ip6_saddr__x_elem_set)
 void single_rule__ip6_saddr_c(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, true, {},
+    chain << Rule(BF_VERDICT_DROP, bf_counter(), 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -417,7 +417,7 @@ BENCHMARK(single_rule__ip6_saddr_c);
 void single_rule__ip6_saddr_l(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false, BF_FLAG(BF_LOG_OPT_LINK),
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, BF_FLAG(BF_LOG_OPT_LINK),
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_IP6_SADDR, BF_MATCHER_EQ,
                               {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -449,7 +449,7 @@ void single_rule__ip6_nexthdr(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
     chain << Rule(
-        BF_VERDICT_DROP, false, {},
+        BF_VERDICT_DROP, std::nullopt, 0,
         std::vector<Matcher> {
             Matcher(BF_MATCHER_IP6_NEXTHDR, BF_MATCHER_EQ, {0x00, 0x00}),
         });
@@ -479,7 +479,7 @@ void single_rule__meta_sport_eq(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
     chain << Rule(
-        BF_VERDICT_DROP, false, {},
+        BF_VERDICT_DROP, std::nullopt, 0,
         std::vector<Matcher> {
             Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_EQ, {0x00, 0x17}),
         });
@@ -508,7 +508,7 @@ BENCHMARK(single_rule__meta_sport_eq);
 void single_rule__meta_sport_range(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_META_SPORT, BF_MATCHER_RANGE,
                               {0x16, 0x00, 0x18, 0x00}),
@@ -539,7 +539,7 @@ void single_rule__tcp_sport(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);
     chain << Rule(
-        BF_VERDICT_DROP, false, {},
+        BF_VERDICT_DROP, std::nullopt, 0,
         std::vector<Matcher> {
             Matcher(BF_MATCHER_TCP_SPORT, BF_MATCHER_EQ, {0x00, 0x17}),
         });
@@ -571,7 +571,7 @@ void single_rule__meta_flow_hash(::benchmark::State &state)
     Chain chain("bf_benchmark", BF_HOOK_TC_INGRESS, BF_VERDICT_ACCEPT);
 
     // Match flow hash in full range 0-UINT32_MAX (little-endian uint32_t: min, max)
-    chain << Rule(BF_VERDICT_DROP, false, {},
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
                   std::vector<Matcher> {
                       Matcher(BF_MATCHER_META_FLOW_HASH, BF_MATCHER_RANGE,
                               {0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff}),
@@ -610,7 +610,7 @@ void single_rule__meta_flow_probability(::benchmark::State &state)
     std::memcpy(payload.data(), &prob, sizeof(float));
 
     chain << Rule(
-        BF_VERDICT_DROP, false, {},
+        BF_VERDICT_DROP, std::nullopt, 0,
         std::vector<Matcher> {
             Matcher(BF_MATCHER_META_FLOW_PROBABILITY, BF_MATCHER_EQ, payload),
         });


### PR DESCRIPTION
`benchmark_bin` currently cannot be built:

```
$ ninja -C build benchmark_bin
ninja: Entering directory `build'
[1/2] Building CXX object tools/benchmarks/CMakeFiles/benchmark_bin.dir/main.cpp.o
FAILED: [code=1] tools/benchmarks/CMakeFiles/benchmark_bin.dir/main.cpp.o
/usr/bin/c++  -I/root/repos/bpfilter-merge-bpf-maps/tools/benchmarks -I/root/repos/bpfilter-merge-bpf-maps/tests/harness -I/root/repos/bpfilter-merge-bpf-maps/src/libbpfilter/include -I/root/repos/bpfilter-merge-bpf-maps/build/src/libbpfilter/include -g -std=c++20 -DWITH_GZFILEOP -MD -MT tools/benchmarks/CMakeFiles/benchmark_bin.dir/main.cpp.o -MF tools/benchmarks/CMakeFiles/benchmark_bin.dir/main.cpp.o.d -o tools/benchmarks/CMakeFiles/benchmark_bin.dir/main.cpp.o -c /root/repos/bpfilter-merge-bpf-maps/tools/benchmarks/main.cpp
/root/repos/bpfilter-merge-bpf-maps/tools/benchmarks/main.cpp: In function ‘void {anonymous}::single_rule__ip4_saddr(benchmark::State&)’:
/root/repos/bpfilter-merge-bpf-maps/tools/benchmarks/main.cpp:105:20: error: no matching function for call to ‘bf::Rule::Rule(bf_verdict, bool, <brace-enclosed initializer list>, std::vector<bf::Matcher>)’
  105 |                   });
      |                    ^
  • there are 3 candidates
In file included from /root/repos/bpfilter-merge-bpf-maps/tests/harness/Chain.hpp:17,
                 from /root/repos/bpfilter-merge-bpf-maps/tools/benchmarks/main.cpp:31:
    • candidate 1: ‘bf::Rule::Rule(bf_verdict, std::optional<bf_counter>, uint8_t, std::vector<bf::Matcher>)’
      /root/repos/bpfilter-merge-bpf-maps/tests/harness/Rule.hpp:42:5:
         42 |     Rule(bf_verdict verdict,
            |     ^~~~
      • no known conversion for argument 2 from ‘bool’ to ‘std::optional<bf_counter>’
        /root/repos/bpfilter-merge-bpf-maps/tests/harness/Rule.hpp:43:43:
           43 |          std::optional<struct bf_counter> counters = std::nullopt,
              |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
    • candidate 2: ‘constexpr bf::Rule::Rule(const bf::Rule&)’
      /root/repos/bpfilter-merge-bpf-maps/tests/harness/Rule.hpp:25:7:
         25 | class Rule
            |       ^~~~
      • candidate expects 1 argument, 4 provided
    • candidate 3: ‘constexpr bf::Rule::Rule(bf::Rule&&)’
      • candidate expects 1 argument, 4 provided
```

`tools/benchmarks/main.cpp` has been broken since `lib: rule: convert counters bool to a uint8_t bitfield` (0e6c660f15de1f2873e34e528721ecc0c9ed8946, 2026-05-08), which updated `tests/harness/Rule.hpp` but didn't update the benchmark file. Result: every benchmark CI run since then has been silently skipping the benchmark, loading latest results (from 2026-05-08), and reporting "no significant change", i.e. green, for them.

Example: https://github.com/facebook/bpfilter/actions/runs/25743097177/job/75598766760

This PR fixes `main.cpp`, and updates `bfbencher` script so that it should fail when it fails to benchmark something.