### PR TITLE
lib: ctx: reject double-init in bf_ctx_setup

### DIFF
--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -270,6 +270,9 @@ int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose)
 {
     int r;
 
+    if (_bf_global_ctx)
+        return bf_err_r(-EBUSY, "context is already initialized");
+
     r = _bf_ctx_new(&_bf_global_ctx, with_bpf_token, bpffs_path, verbose);
     if (r)
         return bf_err_r(r, "failed to create new context");

--- a/src/libbpfilter/include/bpfilter/ctx.h
+++ b/src/libbpfilter/include/bpfilter/ctx.h
@@ -40,6 +40,10 @@ enum bf_verbose
 /**
  * Initialise the global context.
  *
+ * Only one global context may exist at a time. Calling `bf_ctx_setup` while
+ * a context is already initialised returns `-EBUSY` and leaves the existing
+ * context untouched; the caller must `bf_ctx_teardown` first to re-initialise.
+ *
  * @param with_bpf_token If true, create a BPF token from bpffs.
  * @param bpffs_path Path to the bpffs mountpoint. Can't be NULL.
  * @param verbose Bitmask of verbose flags.

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -159,11 +159,46 @@ static void verbose_flags(void **state)
     assert_false(bf_ctx_is_verbose(BF_VERBOSE_BYTECODE));
 }
 
+static void setup_twice_fails(void **state)
+{
+    /* The fixture has already called bf_ctx_setup successfully. A second
+     * call without an intervening teardown must reject with -EBUSY rather
+     * than silently overwriting (and leaking) the existing global context. */
+    struct bft_tmpdir *tmpdir = *state;
+
+    assert_err(
+        bf_ctx_setup(false, tmpdir->dir_path, BF_FLAG(BF_VERBOSE_DEBUG)));
+
+    /* The original context is untouched and remains usable. */
+    assert_non_null(bf_ctx_get_bpffs_path());
+    assert_string_equal(bf_ctx_get_bpffs_path(), tmpdir->dir_path);
+    assert_true(bf_ctx_is_verbose(BF_VERBOSE_DEBUG));
+}
+
+static void setup_after_teardown(void **state)
+{
+    _free_bft_tmpdir_ struct bft_tmpdir *tmpdir = NULL;
+
+    (void)state;
+
+    /* No fixture: this test manages the setup/teardown sequence itself. */
+    assert_ok(bft_tmpdir_new(&tmpdir));
+
+    /* Setup, then teardown, then setup again: the second setup must succeed
+     * because teardown clears the global context. */
+    assert_ok(bf_ctx_setup(false, tmpdir->dir_path, 0));
+    bf_ctx_teardown();
+
+    assert_ok(bf_ctx_setup(false, tmpdir->dir_path, 0));
+    bf_ctx_teardown();
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(no_setup),
         cmocka_unit_test(bpffs_path_is_owned_copy),
+        cmocka_unit_test(setup_after_teardown),
         cmocka_unit_test_setup_teardown(bpffs_path_matches_setup, bft_setup_ctx,
                                         bft_teardown_ctx),
         cmocka_unit_test_setup_teardown(get_cgens_empty, bft_setup_ctx,
@@ -173,6 +208,8 @@ int main(void)
         cmocka_unit_test_setup_teardown(get_cgen_corrupt_returns_error,
                                         bft_setup_ctx, bft_teardown_ctx),
         cmocka_unit_test_setup_teardown(verbose_flags, bft_setup_ctx,
+                                        bft_teardown_ctx),
+        cmocka_unit_test_setup_teardown(setup_twice_fails, bft_setup_ctx,
                                         bft_teardown_ctx),
     };
 


### PR DESCRIPTION
`bf_ctx_setup()` previously called `_bf_ctx_new(&_bf_global_ctx, ...)` directly. If a caller invoked it twice without an intervening `bf_ctx_teardown()`, the second call would silently overwrite the global context, leaking the previous context's heap allocations, file descriptors, and BPF map handles.

Reject the second call with `-EBUSY` and leave the existing context untouched. The caller must `bf_ctx_teardown()` first to re-initialise.