### PR TITLE
tools: add benchmark for loading sets

### DIFF
--- a/tools/benchmarks/main.cpp
+++ b/tools/benchmarks/main.cpp
@@ -207,6 +207,50 @@ BENCHMARK(single_rule__ip4_saddr__x_elem_set)
     ->Arg(1 << 7)
     ->Arg(1 << 15);
 
+void chain_set__ip4_saddr__x_elem_set(::benchmark::State &state)
+{
+    const std::string chain_name = "bf_benchmark";
+    Chain chain(chain_name, BF_HOOK_XDP, BF_VERDICT_ACCEPT);
+
+    Set s = Set({BF_MATCHER_IP4_SADDR});
+    uint32_t nelems = state.range(0);
+    for (uint32_t i = 0; i < nelems; ++i)
+        s << uint32ToIp4(i);
+    chain << s;
+
+    chain << Rule(BF_VERDICT_DROP, std::nullopt, 0,
+                  std::vector<Matcher> {
+                      Matcher(BF_MATCHER_SET, BF_MATCHER_IN, {0, 0, 0, 0}),
+                  });
+
+    auto chainp = chain.get();
+
+    for (auto _: state) {
+        int ret = bf_chain_set(chainp.get(), nullptr);
+        if (ret < 0) {
+            state.SkipWithError("failed to load chain");
+            break;
+        }
+
+        state.PauseTiming();
+        ret = bf_chain_flush(chain_name.c_str());
+        if (ret < 0) {
+            state.SkipWithError("failed to flush chain");
+            break;
+        }
+        state.ResumeTiming();
+    }
+
+    state.SetLabel(
+        std::format("load chain, ip4.saddr, {} elements set", nelems));
+}
+
+BENCHMARK(chain_set__ip4_saddr__x_elem_set)
+    ->Arg(1 << 3)
+    ->Arg(1 << 16)
+    ->Arg(1 << 20)
+    ->Unit(::benchmark::kMillisecond);
+
 void single_rule__ip4_saddr_c(::benchmark::State &state)
 {
     Chain chain("bf_benchmark", BF_HOOK_XDP, BF_VERDICT_ACCEPT);


### PR DESCRIPTION
Measure time it takes to load a chain that contains a large set. This will be a common operation (especially since sets can update).

Requires https://github.com/facebook/bpfilter/pull/532.

```
$ rm -rf build && cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=release -DNO_DOCS=1 -DNO_CHECKS=1
$ ninja -C build benchmark_bin bfcli
$ sudo build/output/sbin/benchmark_bin \
    --cli build/output/sbin/bfcli \
    --srcdir . \
    --outfile /tmp/load.json \
    --filter chain_load

...
Run on (4 X 2396.4 MHz CPU s)
...
chain_load__ip4_saddr__x_elem_set/8/manual_time           7.20 ms         7.08 ms          106 load chain, ip4.saddr, 8 elements set
chain_load__ip4_saddr__x_elem_set/128/manual_time         7.69 ms         7.61 ms          107 load chain, ip4.saddr, 128 elements set
chain_load__ip4_saddr__x_elem_set/32768/manual_time       55.3 ms         61.5 ms           12 load chain, ip4.saddr, 32768 elements set
```