### PR TITLE
build: add Fedora Rawhide as experimental CI target

### DIFF
--- a/.github/fedora-rawhide.Dockerfile
+++ b/.github/fedora-rawhide.Dockerfile
@@ -1,0 +1,41 @@
+FROM fedora:rawhide
+
+# Rawhide does not have an `updates` repo (it is the rolling development
+# branch; all updates land directly in `fedora`).
+RUN dnf --disablerepo=* --enablerepo=fedora --nodocs --setopt=install_weak_deps=False -y install \
+    autoconf \
+    automake \
+    gawk \
+    bpftool \
+    bison \
+    clang \
+    clang-tools-extra \
+    cmake \
+    compiler-rt \
+    doxygen \
+    flex \
+    gcc \
+    gcc-c++ \
+    git-core \
+    google-benchmark-devel \
+    include-what-you-use \
+    iproute \
+    iputils \
+    jq \
+    lcov \
+    libbpf-devel \
+    libcmocka-devel \
+    libgit2-devel \
+    libpfm-devel \
+    libtool \
+    procps-ng \
+    python3-breathe \
+    python3-dateutil \
+    python3-furo \
+    python3-GitPython \
+    python3-linuxdoc \
+    python3-scapy \
+    python3-sphinx \
+    sed \
+    xxd && \
+    dnf clean all -y

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,13 @@ jobs:
   create-images:
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         host:
           - { name: 8-core-ubuntu, arch: x64 }
           - { name: 4-core-ubuntu-arm, arch: arm64 }
         distribution:
+          - { name: fedora, version: "rawhide", experimental: true }
           - { name: fedora, version: "44" }
           - { name: fedora, version: "43" }
           - { name: fedora, version: "42" }
@@ -38,7 +40,8 @@ jobs:
           - { name: ubuntu, version: "25.04" }
           - { name: ubuntu, version: "25.10" }
     runs-on: [ "${{ matrix.host.name }}" ]
-    name: "Image: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})"
+    continue-on-error: ${{ matrix.distribution.experimental || false }}
+    name: "Image: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})${{ matrix.distribution.experimental && ' [experimental]' || '' }}"
     steps:
       - name: Checkout bpfilter
         uses: actions/checkout@v2
@@ -64,11 +67,13 @@ jobs:
     needs: create-images
     timeout-minutes: 5
     strategy:
+      fail-fast: false
       matrix:
         host:
           - { name: 8-core-ubuntu, arch: x64 }
           - { name: 4-core-ubuntu-arm, arch: arm64 }
         distribution:
+          - { name: fedora, version: "rawhide", experimental: true }
           - { name: fedora, version: "44" }
           - { name: fedora, version: "43" }
           - { name: fedora, version: "42" }
@@ -76,8 +81,9 @@ jobs:
           - { name: ubuntu, version: "25.04" }
           - { name: ubuntu, version: "25.10" }
     runs-on: [ "${{ matrix.host.name }}" ]
+    continue-on-error: ${{ matrix.distribution.experimental || false }}
     container: ghcr.io/facebook/bpfilter:${{ matrix.distribution.name }}-${{ matrix.distribution.version }}-${{ matrix.host.arch}}
-    name: "Build: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})"
+    name: "Build: ${{ matrix.distribution.name }} ${{ matrix.distribution.version }} (${{ matrix.host.arch}})${{ matrix.distribution.experimental && ' [experimental]' || '' }}"
     steps:
       - name: Checkout bpfilter
         uses: actions/checkout@v2
@@ -85,6 +91,41 @@ jobs:
         run: cmake -S $GITHUB_WORKSPACE -B $GITHUB_WORKSPACE/build -DNO_BENCHMARKS=1
       - name: Build all
         run: make -C $GITHUB_WORKSPACE/build -j `nproc`
+
+  label-experimental-failure:
+    needs: build
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: "Experimental label"
+    steps:
+      - name: Apply breakage label if any experimental job failed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'breaks: experimental distros';
+            const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const failed = jobsResp.jobs.filter(
+              (j) => j.name.includes('[experimental]') && j.conclusion === 'failure'
+            );
+            const issueParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            };
+            if (failed.length > 0) {
+              await github.rest.issues.addLabels({ ...issueParams, labels: [LABEL] });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ ...issueParams, name: LABEL });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }
 
   test:
     needs: create-images


### PR DESCRIPTION
Rawhide is Fedora's rolling development branch, always tracking the next-next stable release (currently Fedora 45, becomes Fedora 46 once 45 branches). Tracking it in CI catches upcoming toolchain regressions (newer clang, glibc, libbpf, kernel headers) months before they reach a stable Fedora. But it can break for reasons unrelated to bpfilter (transient package issues, daily image churn), so it must be advisory rather than gating.

Dockerfile (.github/fedora-rawhide.Dockerfile):

Mirrors fedora-44 minus the `updates` repo. Rawhide is the rolling branch and has no separate updates feed: all updates land directly in `fedora`.

CI workflow (.github/workflows/ci.yaml):

- Add { fedora, rawhide, experimental: true } to the create-images and build matrices.
- Set fail-fast: false on both matrix strategies so a Rawhide failure does not cancel the other 12 distro builds.
- Set continue-on-error: ${{ matrix.distribution.experimental || false }} on both jobs so the rawhide row failing is reported but does not fail the overall workflow.
- Append ` [experimental]` to the job name when the row is flagged experimental; the suffix is visible in the workflow UI and lets the notification job identify experimental rows from the Actions API (which does not expose matrix attributes).

Reviewer signal (label-experimental-failure job):

A new job runs after `build` on pull_request events. It scans the workflow run's jobs for any whose name contains `[experimental]` and whose conclusion is `failure`, then applies the `breaks: experimental distros` label to the PR. If all experimental jobs pass on re-run, the label is removed. This gives a passive, repo-wide signal visible in the PR list, search filters, and notification subjects.