### PR TITLE
ci: move experimental-failure label to workflow_run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,41 +92,6 @@ jobs:
       - name: Build all
         run: make -C $GITHUB_WORKSPACE/build -j `nproc`
 
-  label-experimental-failure:
-    needs: build
-    if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    name: "Experimental label"
-    steps:
-      - name: Apply breakage label if any experimental job failed
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const LABEL = 'breaks: experimental distros';
-            const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.runId,
-              per_page: 100,
-            });
-            const failed = jobsResp.jobs.filter(
-              (j) => j.name.includes('[experimental]') && j.conclusion === 'failure'
-            );
-            const issueParams = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            };
-            if (failed.length > 0) {
-              await github.rest.issues.addLabels({ ...issueParams, labels: [LABEL] });
-            } else {
-              try {
-                await github.rest.issues.removeLabel({ ...issueParams, name: LABEL });
-              } catch (e) {
-                if (e.status !== 404) throw e;
-              }
-            }
-
   test:
     needs: create-images
     timeout-minutes: 5

--- a/.github/workflows/label-experimental.yaml
+++ b/.github/workflows/label-experimental.yaml
@@ -1,0 +1,72 @@
+name: Label experimental failures
+
+# Runs after the CI workflow completes. This file uses `workflow_run` (rather
+# than `pull_request`) so it can apply/remove PR labels on fork-originated
+# pull requests as well: `workflow_run` runs in the base repository's context
+# with the requested write permissions, while `pull_request` from a fork gets
+# a read-only GITHUB_TOKEN regardless of the workflow's `permissions:` block.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    name: "Apply 'breaks: experimental distros' label"
+    steps:
+      - name: Apply or clear the label based on experimental job outcomes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'breaks: experimental distros';
+            const runId = context.payload.workflow_run.id;
+            const headSha = context.payload.workflow_run.head_sha;
+
+            // Resolve the PR number. For in-repo PRs the payload exposes it
+            // directly; for fork-originated runs `pull_requests` is empty
+            // and we fall back to looking the PR up by head SHA.
+            let issueNumber;
+            const payloadPrs = context.payload.workflow_run.pull_requests;
+            if (payloadPrs.length > 0) {
+              issueNumber = payloadPrs[0].number;
+            } else {
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+              const openPrs = prs.filter((pr) => pr.state === 'open');
+              if (openPrs.length === 0) return;
+              issueNumber = openPrs[0].number;
+            }
+
+            const { data: jobsResp } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+              per_page: 100,
+            });
+            const failed = jobsResp.jobs.filter(
+              (j) => j.name.includes('[experimental]') && j.conclusion === 'failure'
+            );
+
+            const issueParams = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            };
+            if (failed.length > 0) {
+              await github.rest.issues.addLabels({ ...issueParams, labels: [LABEL] });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ ...issueParams, name: LABEL });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }


### PR DESCRIPTION
The label-experimental-failure job introduced in commit 0ac3c849 failed on fork PRs with HTTP 403:

  DELETE /repos/.../issues/538/labels/breaks%3A%20experimental%20distros
  Resource not accessible by integration

GitHub Actions overrides GITHUB_TOKEN's `pull-requests: write` to read-only when a `pull_request` workflow runs from a fork, as a security measure: a malicious fork could otherwise modify the workflow file and exfiltrate write access to the upstream. The `permissions:` block in ci.yaml has no effect on fork PRs.

Move the label job to its own workflow that triggers on `workflow_run`. That event runs in the BASE repository's context with the requested write permissions, regardless of whether the triggering run came from a fork. This is the documented pattern for "privileged operations after an untrusted workflow":

  https://docs.github.com/en/actions/security-for-github-actions
    /security-guides/automatic-token-authentication

Two consequences:

- workflow_run events don't propagate the PR number for fork- triggered runs (the `pull_requests` payload field is empty). The new workflow resolves the PR via listPullRequestsAssociatedWith- Commit using the run's head SHA in that case. For in-repo PRs the field is populated and used directly.
- The label appears or disappears with a small additional delay (workflow_run takes a few seconds to queue after CI completes).