### PR TITLE
lib: helper: fix const-discard warning in `BF_FREEP`

### DIFF
--- a/src/libbpfilter/include/bpfilter/helper.h
+++ b/src/libbpfilter/include/bpfilter/helper.h
@@ -257,13 +257,20 @@ static inline void bf_freep(void *ptr)
  * call site. Use this for direct manual frees; use `bf_freep` when a
  * function pointer is needed.
  *
+ * Only the `free()` argument is reinterpreted as `void **` to strip any
+ * `const` qualifier on the pointed-to type, so owned-but-`const`-typed
+ * buffers (e.g. `const char *name` fields backed by `strdup`) can be
+ * freed without a call-site cast. The `*(p) = NULL` assignment is left
+ * uncasted on purpose: it requires `*(p)` to be a pointer lvalue, which
+ * preserves the macro's `T **` type-check on `p`.
+ *
  * @pre `p` is not NULL.
  *
  * @param p Address of the pointer to free.
  */
 #define BF_FREEP(p)                                                            \
     do {                                                                       \
-        free(*(p));                                                            \
+        free(*(void **)(p));                                                   \
         *(p) = NULL;                                                           \
     } while (0)
 


### PR DESCRIPTION
`BF_FREEP()` triggered `-Wdiscarded-qualifiers` in four cleanup paths (`bf_chain_free`, `bf_set_free`, `_bf_ctx_free`, `bf_hookopts_clean`) where the freed field is typed `const char *` in the public API but backed by a strdup'd buffer the owner is responsible for releasing. The const-qualifier is part of the read-only contract exposed to callers, not a property of the storage itself, so stripping it at the owner's free site is correct.

Cast only the free() argument as `void **`, leaving `*(p) = NULL` untouched. The assignment still requires `*(p)` to be a pointer lvalue, so the macro's `T **` type-check on `p` is preserved: passing an `int *`, a `struct foo *`, or a flat `T *` is still a compile error.