### PR TITLE
core: make vector foreach standard C compliant

### DIFF
--- a/src/libbpfilter/include/bpfilter/core/vector.h
+++ b/src/libbpfilter/include/bpfilter/core/vector.h
@@ -62,9 +62,11 @@ void bf_vector_init(bf_vector *vec, size_t elem_size);
 #define bf_vector_foreach(vec, elem)                                           \
     for (void *(elem) = (vec)->data,                                           \
               *__end = (vec)->data ?                                           \
-                           (vec)->data + ((vec)->size * (vec)->elem_size) :    \
+                           (char *)(vec)->data +                               \
+                               ((vec)->size * (vec)->elem_size) :              \
                            NULL;                                               \
-         (elem) && (elem) < __end; (elem) = (elem) + (vec)->elem_size)
+         (elem) && (elem) < __end;                                             \
+         (elem) = (char *)(elem) + (vec)->elem_size)
 
 /**
  * @brief Allocate and initialise a new vector on the heap.


### PR DESCRIPTION
## Summary
- avoid GNU void-pointer arithmetic in bf_vector_foreach
- use char-pointer arithmetic internally so the public macro compiles under standard C

Fixes #509.

## Testing
- git diff --check
- cc -std=c17 -pedantic-errors -Werror -I src/libbpfilter/include -c /tmp/bpfilter-vector-XXXXXX.c

Note: full CMake configuration is blocked locally because libbpf is not installed.