### PR TITLE
Add flags support to benchmarks to report log/set/userspace benchmarks specificities

### DIFF
--- a/tests/benchmarks/benchmark.cpp
+++ b/tests/benchmarks/benchmark.cpp
@@ -403,3 +403,18 @@ bool Sources::isDirty() const
 }
 
 } // namespace bft
+
+namespace bft::benchmark
+{
+
+void set_flags(::benchmark::State &state, Flags flags)
+{
+    if (flags.use_set)
+        state.counters["use_set"] = 1;
+    if (flags.use_log)
+        state.counters["use_log"] = 1;
+    if (flags.userspace_only)
+        state.counters["userspace_only"] = 1;
+}
+
+} // namespace bft::benchmark

--- a/tests/benchmarks/benchmark.hpp
+++ b/tests/benchmarks/benchmark.hpp
@@ -8,6 +8,7 @@
 #include <linux/bpf.h>
 
 #include <array>
+#include <benchmark/benchmark.h>
 #include <bpf/bpf.h>
 #include <bpf/libbpf_common.h>
 #include <cstdint>
@@ -176,3 +177,17 @@ public:
 };
 
 } // namespace bft
+
+namespace bft::benchmark
+{
+
+struct Flags
+{
+    bool use_set = false;
+    bool use_log = false;
+    bool userspace_only = false;
+};
+
+void set_flags(::benchmark::State &state, Flags flags);
+
+} // namespace bft::benchmark

--- a/tests/benchmarks/bfbencher/__init__.py
+++ b/tests/benchmarks/bfbencher/__init__.py
@@ -200,6 +200,9 @@ class Result:
             json["cpu_time"] * ureg(json["time_unit"]),
             json.get("nInsn", 0),
             json.get("label", ""),
+            bool(json.get("use_set", 0)),
+            bool(json.get("use_log", 0)),
+            bool(json.get("userspace_only", 0)),
         )
 
     def __init__(
@@ -211,6 +214,9 @@ class Result:
         cpu_time: pint.Quantity,
         n_insn: int,
         label: str,
+        use_set: bool = False,
+        use_log: bool = False,
+        userspace_only: bool = False,
     ):
         self.commit_sha = commit.hexsha
         self.commit_summary = commit.summary
@@ -220,6 +226,9 @@ class Result:
         self.cpu_time = cpu_time
         self.nInsn = n_insn
         self.label = label
+        self.use_set = use_set
+        self.use_log = use_log
+        self.userspace_only = userspace_only
 
     @property
     def short_commit_sha(self) -> str:
@@ -282,6 +291,18 @@ class Benchmark:
         if any(n == 0 for n in nInsns):
             return None
         return nInsns
+
+    @property
+    def use_set(self) -> bool:
+        return self.last.use_set if self.last else False
+
+    @property
+    def use_log(self) -> bool:
+        return self.last.use_log if self.last else False
+
+    @property
+    def userspace_only(self) -> bool:
+        return self.last.userspace_only if self.last else False
 
     @property
     def commits_sha(self) -> list[str]:
@@ -969,6 +990,9 @@ class Report:
         ]  # term -> {"time": ..., "nInsn": ...}
         runtime_ns: float = 0  # Runtime in nanoseconds for sorting
         insn_count: int = 0  # Instruction count for sorting
+        use_set: bool = False
+        use_log: bool = False
+        userspace_only: bool = False
 
     @dataclasses.dataclass
     class CompareRow:
@@ -986,6 +1010,9 @@ class Report:
         delta_insn_pct: float | None
         base_time_ns: float
         ref_time_ns: float
+        use_set: bool = False
+        use_log: bool = False
+        userspace_only: bool = False
 
     def __init__(self, history: History):
         self._history = history
@@ -1037,6 +1064,9 @@ class Report:
                     terms=term_data,
                     runtime_ns=runtime_ns,
                     insn_count=insn_count,
+                    use_set=benchmark.use_set,
+                    use_log=benchmark.use_log,
+                    userspace_only=benchmark.userspace_only,
                 )
             )
 
@@ -1173,6 +1203,9 @@ class Report:
                     delta_insn_pct=delta_insn_pct,
                     base_time_ns=base_ns,
                     ref_time_ns=ref_ns,
+                    use_set=benchmark.use_set,
+                    use_log=benchmark.use_log,
+                    userspace_only=benchmark.userspace_only,
                 )
             )
 
@@ -1205,6 +1238,9 @@ class Report:
                     "ref_insn": r.ref_insn,
                     "delta_insn": r.delta_insn,
                     "delta_insn_pct": r.delta_insn_pct,
+                    "use_set": r.use_set,
+                    "use_log": r.use_log,
+                    "userspace_only": r.userspace_only,
                 }
                 for r in rows
             ],

--- a/tests/benchmarks/main.cpp
+++ b/tests/benchmarks/main.cpp
@@ -40,6 +40,7 @@ using bf::Chain;
 using bf::Matcher;
 using bf::Rule;
 using bf::Set;
+namespace bm = bft::benchmark;
 
 std::vector<uint8_t> uint32ToIp4(uint32_t val)
 {
@@ -301,6 +302,7 @@ void single_rule__ip4_saddr__x_elem_set(::benchmark::State &state)
     }
 
     state.counters["nInsn"] = prog.nInsn();
+    bm::set_flags(state, {.use_set = true});
     state.SetLabel(std::format("1 rule, ip4.saddr, {} elements set", nrules));
 }
 
@@ -343,6 +345,7 @@ void chain_set__ip4_saddr__x_elem_set(::benchmark::State &state)
         state.ResumeTiming();
     }
 
+    bm::set_flags(state, {.use_set = true, .userspace_only = true});
     state.SetLabel(
         std::format("load chain, ip4.saddr, {} elements set", nelems));
 }
@@ -408,6 +411,7 @@ void single_rule__ip4_saddr_l(::benchmark::State &state)
     }
 
     state.counters["nInsn"] = prog.nInsn();
+    bm::set_flags(state, {.use_log = true});
     state.SetLabel("1 rule, ip4.saddr, log link");
 }
 
@@ -521,6 +525,7 @@ void single_rule__ip6_saddr__x_elem_set(::benchmark::State &state)
     }
 
     state.counters["nInsn"] = prog.nInsn();
+    bm::set_flags(state, {.use_set = true});
     state.SetLabel(std::format("1 rule, ip6.saddr, {} elements set", nrules));
 }
 
@@ -586,6 +591,7 @@ void single_rule__ip6_saddr_l(::benchmark::State &state)
     }
 
     state.counters["nInsn"] = prog.nInsn();
+    bm::set_flags(state, {.use_log = true});
     state.SetLabel("1 rule, ip6.saddr, log link");
 }
 

--- a/tests/benchmarks/summary.html.j2
+++ b/tests/benchmarks/summary.html.j2
@@ -124,7 +124,12 @@ The <strong>Δ</strong> columns show the percentage change compared to the mean 
     <tbody class="table-group-divider">
         {%- for row in rows %}
         <tr data-name="{{ row.label }}" data-runtime="{{ row.runtime_ns | default(0) }}" data-instructions="{{ row.insn_count | default(0) }}">
-            <td class="fw-medium"><a href="#chart-{{ row.name }}" class="benchmark-link">{{ row.label }}</a></td>
+            <td class="fw-medium">
+                <a href="#chart-{{ row.name }}" class="benchmark-link">{{ row.label }}</a>
+                {%- if row.use_set %}<span class="badge bg-warning text-dark ms-1" data-bs-toggle="tooltip" data-bs-title="uses a BPF set map">set</span>{% endif %}
+                {%- if row.use_log %}<span class="badge bg-info text-dark ms-1" data-bs-toggle="tooltip" data-bs-title="emits log entries">log</span>{% endif %}
+                {%- if row.userspace_only %}<span class="badge bg-secondary ms-1" data-bs-toggle="tooltip" data-bs-title="measures userspace only, not BPF execution">userspace</span>{% endif %}
+            </td>
             <td class="text-end">{{ row.time_str }}</td>
             {%- if row.insn_str %}
             <td class="text-end">{{ row.insn_str }}</td>


### PR DESCRIPTION
Benchmarks results can be influenced by the matchers used:
- Logging benchmarks are more volatile, so are benchmarks using sets
- Some benchmarks do not generate bytecode, but bench the generation step

Those flags are reflected in the benchmark results, and in the HTML report.

Those flags will be used to later in `bfoptimizer` to detect benchmarks results to ignore.