### PR TITLE
lib: cgen: replace counters map with per-CPU array

### DIFF
--- a/src/libbpfilter/cgen/cgen.c
+++ b/src/libbpfilter/cgen/cgen.c
@@ -455,7 +455,7 @@ static int _bf_cgen_transfer_counters(const struct bf_handle *old_handle,
         if (!counter.count && !counter.size)
             continue;
 
-        r = bf_map_set_elem(new_handle->cmap, &i, &counter);
+        r = bf_handle_set_counter(new_handle, i, &counter);
         if (r)
             return bf_err_r(r, "failed to write counter %u", i);
     }

--- a/src/libbpfilter/cgen/handle.c
+++ b/src/libbpfilter/cgen/handle.c
@@ -6,6 +6,7 @@
 #include "cgen/handle.h"
 
 #include <assert.h>
+#include <bpf/libbpf.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
@@ -366,6 +367,8 @@ void bf_handle_unpin(struct bf_handle *handle, struct bf_lock *lock)
 int bf_handle_get_counter(const struct bf_handle *handle, uint32_t counter_idx,
                           struct bf_counter *counter)
 {
+    _cleanup_free_ struct bf_counter *percpu = NULL;
+    int num_cpus;
     int r;
 
     assert(handle);
@@ -374,9 +377,54 @@ int bf_handle_get_counter(const struct bf_handle *handle, uint32_t counter_idx,
     if (!handle->cmap)
         return bf_err_r(-ENOENT, "handle has no counters map");
 
-    r = bf_bpf_map_lookup_elem(handle->cmap->fd, &counter_idx, counter);
+    num_cpus = libbpf_num_possible_cpus();
+    if (num_cpus < 0)
+        return bf_err_r(num_cpus, "failed to get number of possible CPUs");
+
+    percpu = calloc(num_cpus, sizeof(*percpu));
+    if (!percpu)
+        return -ENOMEM;
+
+    r = bf_bpf_map_lookup_elem(handle->cmap->fd, &counter_idx, percpu);
     if (r < 0)
         return bf_err_r(r, "failed to lookup counters map");
+
+    counter->count = 0;
+    counter->size = 0;
+    for (int i = 0; i < num_cpus; i++) {
+        counter->count += percpu[i].count;
+        counter->size += percpu[i].size;
+    }
+
+    return 0;
+}
+
+int bf_handle_set_counter(struct bf_handle *handle, uint32_t counter_idx,
+                          const struct bf_counter *counter)
+{
+    _cleanup_free_ struct bf_counter *percpu = NULL;
+    int num_cpus;
+    int r;
+
+    assert(handle);
+    assert(counter);
+
+    if (!handle->cmap)
+        return bf_err_r(-ENOENT, "handle has no counters map");
+
+    num_cpus = libbpf_num_possible_cpus();
+    if (num_cpus < 0)
+        return bf_err_r(num_cpus, "failed to get number of possible CPUs");
+
+    percpu = calloc(num_cpus, sizeof(*percpu));
+    if (!percpu)
+        return -ENOMEM;
+
+    percpu[0] = *counter;
+
+    r = bf_bpf_map_update_elem(handle->cmap->fd, &counter_idx, percpu, 0);
+    if (r < 0)
+        return bf_err_r(r, "failed to update counters map");
 
     return 0;
 }

--- a/src/libbpfilter/cgen/handle.h
+++ b/src/libbpfilter/cgen/handle.h
@@ -145,6 +145,20 @@ int bf_handle_get_counter(const struct bf_handle *handle, uint32_t counter_idx,
                           struct bf_counter *counter);
 
 /**
+ * @brief Set a counter value in the handle's counters map.
+ *
+ * Writes `counter` into the per-CPU map at `counter_idx` by placing the
+ * value in CPU 0's slot and zeroing all other slots.
+ *
+ * @param handle Handle to write the counter to. Can't be NULL.
+ * @param counter_idx Index of the counter to set.
+ * @param counter Counter value to write. Can't be NULL.
+ * @return 0 on success, or a negative errno value on failure.
+ */
+int bf_handle_set_counter(struct bf_handle *handle, uint32_t counter_idx,
+                          const struct bf_counter *counter);
+
+/**
  * @brief Attach the BPF program to a hook.
  *
  * Creates a `bf_link` to attach the program to the specified hook.

--- a/src/libbpfilter/cgen/prog/map.c
+++ b/src/libbpfilter/cgen/prog/map.c
@@ -191,7 +191,7 @@ int bf_map_new(struct bf_map **map, const char *name, enum bf_map_type type,
                size_t key_size, size_t value_size, size_t n_elems)
 {
     static enum bf_bpf_map_type _map_type_to_bpf[_BF_MAP_TYPE_MAX] = {
-        [BF_MAP_TYPE_COUNTERS] = BF_BPF_MAP_TYPE_ARRAY,
+        [BF_MAP_TYPE_COUNTERS] = BF_BPF_MAP_TYPE_PERCPU_ARRAY,
         [BF_MAP_TYPE_PRINTER] = BF_BPF_MAP_TYPE_ARRAY,
         [BF_MAP_TYPE_LOG] = BF_BPF_MAP_TYPE_RINGBUF,
         /* Unreachable: bf_map_new() rejects BF_MAP_TYPE_SET; use
@@ -331,6 +331,7 @@ static const char *_bf_bpf_type_to_str(enum bf_bpf_map_type type)
     static const char *type_strs[] = {
         [BF_BPF_MAP_TYPE_HASH] = "BF_BPF_MAP_TYPE_HASH",
         [BF_BPF_MAP_TYPE_ARRAY] = "BF_BPF_MAP_TYPE_ARRAY",
+        [BF_BPF_MAP_TYPE_PERCPU_ARRAY] = "BF_BPF_MAP_TYPE_PERCPU_ARRAY",
         [BF_BPF_MAP_TYPE_LPM_TRIE] = "BF_BPF_MAP_TYPE_LPM_TRIE",
         [BF_BPF_MAP_TYPE_RINGBUF] = "BF_BPF_MAP_TYPE_RINGBUF",
     };

--- a/src/libbpfilter/include/bpfilter/bpf_types.h
+++ b/src/libbpfilter/include/bpfilter/bpf_types.h
@@ -50,6 +50,7 @@ enum bf_bpf_map_type
 {
     BF_BPF_MAP_TYPE_HASH = 1,
     BF_BPF_MAP_TYPE_ARRAY = 2,
+    BF_BPF_MAP_TYPE_PERCPU_ARRAY = 6,
     BF_BPF_MAP_TYPE_LPM_TRIE = 11,
     BF_BPF_MAP_TYPE_RINGBUF = 27,
 };

--- a/tests/e2e/cli/chain_update.sh
+++ b/tests/e2e/cli/chain_update.sh
@@ -28,11 +28,11 @@ ${FROM_NS} ${BFCLI} chain set --from-str "chain chain_load_xdp_4 BF_HOOK_XDP{ifi
     rule ip4.proto icmp counter DROP
 "
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/chain_load_xdp_4/bf_cmap | jq '.[0].value.count')
+counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/chain_load_xdp_4/bf_cmap | jq '.[0].values | map(.value.count) | add')
 test "$counter" = "1"
 ${FROM_NS} ${BFCLI} chain update --from-str "chain chain_load_xdp_4 BF_HOOK_XDP ACCEPT
     rule ip4.proto icmp counter DROP
 "
-counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/chain_load_xdp_4/bf_cmap | jq '.[0].value.count')
+counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/chain_load_xdp_4/bf_cmap | jq '.[0].values | map(.value.count) | add')
 test "$counter" = "0"
 ${FROM_NS} ${BFCLI} chain flush --name chain_load_xdp_4

--- a/tests/e2e/cli/chain_update_set.sh
+++ b/tests/e2e/cli/chain_update_set.sh
@@ -231,8 +231,8 @@ ${FROM_NS} ${BFCLI} chain update-set \
     --set-name blocked_ips \
     --add 10.0.0.2
 
-counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/test_xdp/bf_cmap | jq '.[0].value.count')
+counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/test_xdp/bf_cmap | jq '.[0].values | map(.value.count) | add')
 test "$counter" = "1"
-counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/test_xdp/bf_cmap | jq '.[1].value.count')
+counter=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/test_xdp/bf_cmap | jq '.[1].values | map(.value.count) | add')
 test "$counter" = "1"
 ${FROM_NS} ${BFCLI} chain flush --name test_xdp

--- a/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
@@ -69,7 +69,7 @@ udp4_connect() {
 }
 
 get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
 }
 
 # meta.l3_proto

--- a/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
@@ -79,7 +79,7 @@ s.close()
 }
 
 get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
 }
 
 # meta.l3_proto

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
@@ -62,7 +62,7 @@ s.close()
 }
 
 get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
 }
 
 # meta.l3_proto

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
@@ -66,7 +66,7 @@ s.close()
 }
 
 get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
 }
 
 # meta.l3_proto

--- a/tests/e2e/rules/next_tc.sh
+++ b/tests/e2e/rules/next_tc.sh
@@ -3,7 +3,7 @@
 . "$(dirname "$0")"/../e2e_test_util.sh
 
 get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].value.count"
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
 }
 
 make_sandbox

--- a/tests/e2e/rules/set_grouping.sh
+++ b/tests/e2e/rules/set_grouping.sh
@@ -53,8 +53,8 @@ ${FROM_NS} ${BFCLI} chain set --from-str "chain multibyte BF_HOOK_XDP{ifindex=${
 (! ping -c 1 -W 1 ${NS_IP_ADDR}) || { echo "ERROR: ping should have been dropped via s8 (bit 8)"; exit 1; }
 count=$(${FROM_NS} find ${WORKDIR}/bpf/bpfilter/multibyte/ -name 'bf_set_*' | wc -l)
 [ "${count}" -eq 1 ] || { echo "ERROR: expected 1 map for 9 same-key sets, got ${count}"; exit 1; }
-miss=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/multibyte/bf_cmap | jq '.[0].value.count')
+miss=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/multibyte/bf_cmap | jq '.[0].values | map(.value.count) | add')
 [ "${miss}" = "0" ] || { echo "ERROR: s0 rule (byte 0) should not match, got ${miss}"; exit 1; }
-hit=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/multibyte/bf_cmap | jq '.[1].value.count')
+hit=$(${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/multibyte/bf_cmap | jq '.[1].values | map(.value.count) | add')
 [ "${hit}" -ge 1 ] || { echo "ERROR: s8 rule (byte 1) should match at least once, got ${hit}"; exit 1; }
 ${FROM_NS} ${BFCLI} chain flush --name multibyte


### PR DESCRIPTION
Switch BF_MAP_TYPE_COUNTERS from BPF_MAP_TYPE_ARRAY to
BPF_MAP_TYPE_PERCPU_ARRAY. Each CPU updates its own counter slot
without contention, which eliminates the need for atomic operations
in the BPF fast path (bpf_map_lookup_elem on a per-CPU map returns
a direct pointer to the current CPU's value).

## Changes

**lib:**
- Add `BF_BPF_MAP_TYPE_PERCPU_ARRAY` to `bf_bpf_map_type`
- Switch the counters map to `BF_BPF_MAP_TYPE_PERCPU_ARRAY`
- `bf_handle_get_counter()`: allocate a per-CPU buffer, do one lookup,
  then sum all CPU slots into the returned `bf_counter`
- Add `bf_handle_set_counter()`: builds a per-CPU buffer with the value
  in CPU 0's slot and zeroes elsewhere, then calls
  `bf_bpf_map_update_elem()` with the full buffer
- `_bf_cgen_transfer_counters()`: replace `bf_map_set_elem()` with
  `bf_handle_set_counter()` — the old call passed a 16-byte buffer to
  a syscall that reads `num_cpus × 16` bytes, writing garbage from the
  stack into the new map

**tests:**
- Update `bpftool map dump` jq queries in 8 e2e tests: per-CPU dumps
  use `values` (array per CPU) instead of `value`, so counter reads
  change from `.[N].value.count` to
  `.[N].values | map(.value.count) | add`
