### PR TITLE
lib: ctx: bf_ctx_is_setup reflects context lifecycle

### DIFF
--- a/src/libbpfilter/ctx.c
+++ b/src/libbpfilter/ctx.c
@@ -288,6 +288,11 @@ void bf_ctx_teardown(void)
     _bf_ctx_free(&_bf_global_ctx);
 }
 
+bool bf_ctx_is_setup(void)
+{
+    return _bf_global_ctx != NULL;
+}
+
 void bf_ctx_dump(prefix_t *prefix)
 {
     if (!_bf_global_ctx)

--- a/src/libbpfilter/include/bpfilter/ctx.h
+++ b/src/libbpfilter/include/bpfilter/ctx.h
@@ -57,6 +57,13 @@ int bf_ctx_setup(bool with_bpf_token, const char *bpffs_path, uint16_t verbose);
 void bf_ctx_teardown(void);
 
 /**
+ * @brief Check if the global context is setup.
+ *
+ * @return True if the global context is setup, false otherwise.
+ */
+bool bf_ctx_is_setup(void);
+
+/**
  * Dump the global context.
  *
  * @param prefix Prefix to use for the dump.

--- a/tests/unit/libbpfilter/ctx.c
+++ b/tests/unit/libbpfilter/ctx.c
@@ -32,6 +32,22 @@ static void no_setup(void **state)
     assert_false(bf_ctx_is_verbose(BF_VERBOSE_DEBUG));
 }
 
+static void is_setup(void **state)
+{
+    _free_bft_tmpdir_ struct bft_tmpdir *tmpdir = NULL;
+
+    (void)state;
+
+    assert_false(bf_ctx_is_setup());
+
+    assert_ok(bft_tmpdir_new(&tmpdir));
+    assert_ok(bf_ctx_setup(false, tmpdir->dir_path, 0));
+    assert_true(bf_ctx_is_setup());
+
+    bf_ctx_teardown();
+    assert_false(bf_ctx_is_setup());
+}
+
 static void bpffs_path_matches_setup(void **state)
 {
     struct bft_tmpdir *tmpdir = *state;
@@ -197,6 +213,7 @@ int main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(no_setup),
+        cmocka_unit_test(is_setup),
         cmocka_unit_test(bpffs_path_is_owned_copy),
         cmocka_unit_test(setup_after_teardown),
         cmocka_unit_test_setup_teardown(bpffs_path_matches_setup, bft_setup_ctx,


### PR DESCRIPTION
Returns false before any setup, true while a context is active, and false again after teardown.