### PR TITLE
build: elfstubs: track runtime headers as compilation dependencies

### DIFF
--- a/tools/cmake/ElfStubs.cmake
+++ b/tools/cmake/ElfStubs.cmake
@@ -79,6 +79,8 @@ function(bf_target_add_elfstubs TARGET)
             DEPENDS
                 ${_LOCAL_DIR}/${_stub}.bpf.c
                 ${DECL_TEMPLATE_PATH}
+                ${CMAKE_SOURCE_DIR}/src/libbpfilter/include/bpfilter/runtime.h
+                ${CMAKE_SOURCE_DIR}/src/libbpfilter/cgen/runtime.h
             OUTPUT
                 ${ELFSTUBS_INC_DIR}/${_stub}.inc.c
             COMMENT "Generate ${_stub} stub"


### PR DESCRIPTION
BPF elfstubs include bpfilter/runtime.h and cgen/runtime.h to lay out bf_runtime on the BPF stack, but those headers were not listed as dependencies of the custom compilation commands.  Any change to the struct layout (e.g. adding or removing a field) silently left cached stub objects with stale field offsets, causing BPF verifier rejections when the main program was loaded.