### PR TITLE
Add bfoptimizer to improve the bytecode-generation logic using Claude

### DIFF
--- a/tests/benchmarks/bfbencher/__init__.py
+++ b/tests/benchmarks/bfbencher/__init__.py
@@ -502,24 +502,34 @@ class RemoteExecutor(Executor):
 
         self.log(f"Connecting to remote host {self._host}")
         self._remote_workdir = self._workdir
-        self._agent: paramiko.Agent = paramiko.Agent()
+        self._agent: paramiko.Agent | None = None
 
         self._client = paramiko.SSHClient()
         self._client.set_missing_host_key_policy(paramiko.WarningPolicy())
 
-        for key in self._agent.get_keys():
-            if self._host.lower() in key.comment.lower():
-                pkey = key
-                break
+        if self._args.ssh_key:
+            self._client.connect(
+                self._host,
+                username=DEFAULT_USERNAME,
+                key_filename=str(self._args.ssh_key.expanduser()),
+                allow_agent=False,
+                look_for_keys=False,
+            )
         else:
-            raise RuntimeError(f"No SSH agent key found matching '{self._host}'")
+            self._agent = paramiko.Agent()
+            for key in self._agent.get_keys():
+                if self._host.lower() in key.comment.lower():
+                    pkey = key
+                    break
+            else:
+                raise RuntimeError(f"No SSH agent key found matching '{self._host}'")
 
-        self._client.connect(
-            self._host,
-            username=DEFAULT_USERNAME,
-            pkey=pkey,
-            allow_agent=False,
-        )
+            self._client.connect(
+                self._host,
+                username=DEFAULT_USERNAME,
+                pkey=pkey,
+                allow_agent=False,
+            )
 
         # From now on, all self.run() commands are run on the remote host
         self.run(["hostname"])
@@ -573,7 +583,8 @@ class RemoteExecutor(Executor):
         self.run(["umount", "-l", str(self._remote_workdir)])
         self.run(["rm", "-rf", str(self._remote_workdir)])
         self._client.close()
-        self._agent.close()
+        if self._agent:
+            self._agent.close()
         super().__exit__(exc_type, exc_value, traceback)
 
 
@@ -1386,6 +1397,7 @@ def compare(
     *,
     sources: pathlib.Path = DEFAULT_SOURCE_PATH,
     host: str = DEFAULT_HOST[0],
+    ssh_key: pathlib.Path | None = None,
     cache_dir: pathlib.Path = DEFAULT_CACHE_PATH,
     bind_node: int | None = None,
     no_preempt: bool = False,
@@ -1404,6 +1416,7 @@ def compare(
     args = argparse.Namespace(
         sources=sources,
         host=host,
+        ssh_key=ssh_key,
         cache_dir=cache_dir,
         bind_node=bind_node,
         no_preempt=no_preempt,
@@ -1449,6 +1462,12 @@ def main():
         type=str,
         help=f'host to run the benchmark on. bfbencher will connect to the host using SSH, copy the project sources on it, and run the benchmarks. Defaults to "{DEFAULT_HOST[0]}" (current host).',
         default=DEFAULT_HOST[0],
+    )
+    shared.add_argument(
+        "--ssh-key",
+        type=pathlib.Path,
+        help="path to the SSH private key used to authenticate to the remote host. If not set, the key is looked up in the SSH agent by matching the host name against the key comments.",
+        default=None,
     )
     shared.add_argument(
         "--cache-dir",

--- a/tests/benchmarks/bfbencher/__init__.py
+++ b/tests/benchmarks/bfbencher/__init__.py
@@ -69,6 +69,45 @@ class Stats:
             self.failed_shas.add(commit_sha)
 
 
+def compare_table(
+    rows: list[Report.CompareRow], base_sha: str, ref_sha: str
+) -> rich.table.Table:
+    """Build the base/ref comparison table (negative Δ = faster = green)."""
+
+    def format_pct(pct: float) -> str:
+        color = "green" if pct < 0 else ("red" if pct > 0 else "white")
+        return f"[{color}]{pct:+.1f}%[/{color}]"
+
+    table = rich.table.Table(
+        title=f"{base_sha[:SHORT_SHA_LEN]} → {ref_sha[:SHORT_SHA_LEN]}",
+        show_header=True,
+    )
+    table.add_column("Benchmark", style="cyan")
+    table.add_column("Base", justify="right")
+    table.add_column("Ref", justify="right")
+    table.add_column("ΔTime", justify="right")
+    table.add_column("ΔTime%", justify="right")
+    table.add_column("Base Insn", justify="right")
+    table.add_column("Ref Insn", justify="right")
+    table.add_column("ΔInsn", justify="right")
+    table.add_column("ΔInsn%", justify="right")
+
+    for row in rows:
+        table.add_row(
+            row.name,
+            row.base_time_str,
+            row.ref_time_str,
+            row.delta_time_str,
+            format_pct(row.delta_time_pct),
+            str(row.base_insn) if row.base_insn is not None else "-",
+            str(row.ref_insn) if row.ref_insn is not None else "-",
+            f"{row.delta_insn:+d}" if row.delta_insn is not None else "-",
+            format_pct(row.delta_insn_pct) if row.delta_insn_pct is not None else "-",
+        )
+
+    return table
+
+
 class Renderer:
     """Console output handler for benchmark progress and results."""
 
@@ -117,40 +156,7 @@ class Renderer:
         base_sha: str,
         ref_sha: str,
     ) -> None:
-        def format_pct(pct: float) -> str:
-            color = "green" if pct < 0 else ("red" if pct > 0 else "white")
-            return f"[{color}]{pct:+.1f}%[/{color}]"
-
-        table = rich.table.Table(
-            title=f"{base_sha[:SHORT_SHA_LEN]} → {ref_sha[:SHORT_SHA_LEN]}",
-            show_header=True,
-        )
-        table.add_column("Benchmark", style="cyan")
-        table.add_column("Base", justify="right")
-        table.add_column("Ref", justify="right")
-        table.add_column("ΔTime", justify="right")
-        table.add_column("ΔTime%", justify="right")
-        table.add_column("Base Insn", justify="right")
-        table.add_column("Ref Insn", justify="right")
-        table.add_column("ΔInsn", justify="right")
-        table.add_column("ΔInsn%", justify="right")
-
-        for row in rows:
-            table.add_row(
-                row.name,
-                row.base_time_str,
-                row.ref_time_str,
-                row.delta_time_str,
-                format_pct(row.delta_time_pct),
-                str(row.base_insn) if row.base_insn is not None else "-",
-                str(row.ref_insn) if row.ref_insn is not None else "-",
-                f"{row.delta_insn:+d}" if row.delta_insn is not None else "-",
-                format_pct(row.delta_insn_pct)
-                if row.delta_insn_pct is not None
-                else "-",
-            )
-
-        self.console.print(table)
+        self.console.print(compare_table(rows, base_sha, ref_sha))
 
 
 renderer: Renderer = Renderer()

--- a/tests/benchmarks/bfbencher/__init__.py
+++ b/tests/benchmarks/bfbencher/__init__.py
@@ -364,7 +364,7 @@ class Executor(ABC):
     The Executor transparently handle local or remote commands.
     """
 
-    def __init__(self, args: argparse.Namespace):
+    def __init__(self, args: argparse.Namespace, renderer: Renderer | None = None):
         self._host: str = args.host
         self._workdir: pathlib.Path = (
             pathlib.Path(tempfile.gettempdir()) / f"bpfilter-{uuid.uuid4().hex[:8]}"
@@ -376,7 +376,10 @@ class Executor(ABC):
         self._local_workdir.mkdir()
         self._retry_shas: set[str] = set()
         self._commits: list[git.Commit] = []
-        self._source = FilesystemSource(args.sources, self._local_workdir / "bpfilter")
+        self._renderer = renderer
+        self._source = FilesystemSource(
+            args.sources, self._local_workdir / "bpfilter", renderer
+        )
         self._results = History()
         self._args = args
 
@@ -453,7 +456,7 @@ class Executor(ABC):
             log = f"\\[[yellow bold]{commit.hexsha[:SHORT_SHA_LEN]}[/], {index + 1}/{len(self.commits)}] {msg}"
         else:
             log = msg
-        renderer.log(log)
+        (self._renderer or renderer).log(log)
 
     @abstractmethod
     def _run(self, cmd: list[str], timeout: int | None = None) -> int:
@@ -615,15 +618,24 @@ class LocalExecutor(Executor):
 class FilesystemSource:
     """Manages source repository for benchmarking, including WIP commits."""
 
-    def __init__(self, path: str, local_src_dir: pathlib.Path) -> None:
+    def __init__(
+        self,
+        path: str,
+        local_src_dir: pathlib.Path,
+        renderer: Renderer | None = None,
+    ) -> None:
         self._path = pathlib.Path(path)
         self._local = local_src_dir
+        self._renderer = renderer
 
         shutil.copytree(self._path, self._local, dirs_exist_ok=True)
         self._detach_if_worktree()
         self._repo: git.Repo = git.Repo(self._local)
         self._retry_all: bool = False
         self._retry_failed: bool = False
+
+    def _log(self, msg: str) -> None:
+        (self._renderer or renderer).log(msg)
 
     def _detach_if_worktree(self) -> None:
         """Convert a copied git worktree into a standalone repository.
@@ -677,7 +689,7 @@ class FilesystemSource:
     def _commit_wip(self) -> git.Commit:
         """Commit uncommitted changes as WIP and return the commit."""
         if self._repo.is_dirty(untracked_files=True):
-            renderer.log("Committing uncommitted changes as WIP")
+            self._log("Committing uncommitted changes as WIP")
             self._repo.git.add(A=True)
             self._repo.index.commit("bfbencher: WIP")
         return self._repo.head.commit
@@ -728,14 +740,14 @@ class FilesystemSource:
             try:
                 retry_shas.add(self._repo.git.rev_parse(ref))
             except git.exc.GitCommandError:
-                renderer.log(f"Warning: could not resolve retry ref '{ref}'")
+                self._log(f"Warning: could not resolve retry ref '{ref}'")
 
         # Handle uncommitted changes
         if self._repo.is_dirty(untracked_files=True):
             if has_wip:
                 self._commit_wip()
             else:
-                renderer.log("Discarding uncommitted changes in source directory")
+                self._log("Discarding uncommitted changes in source directory")
                 self._repo.git.reset("--hard", "HEAD")
                 self._repo.git.clean("-fd")
 
@@ -758,11 +770,11 @@ class FilesystemSource:
             if commit.hexsha not in commit_set:
                 commits.append(commit)
                 commit_set.add(commit.hexsha)
-                renderer.log(
+                self._log(
                     f"Including commit {commit.hexsha[:SHORT_SHA_LEN]}: {str(commit.summary)}"
                 )
             else:
-                renderer.log(f"Commit {ref} already in range, skipping")
+                self._log(f"Commit {ref} already in range, skipping")
 
         # Sort commits in topological order (oldest first)
         if len(commits) > 1:
@@ -776,11 +788,11 @@ class FilesystemSource:
             ]
 
         if include:
-            renderer.log(
+            self._log(
                 f"Found {len(commits)} commits ({since_ref}..{until_ref} + {len(include)} included)"
             )
         else:
-            renderer.log(f"Found {len(commits)} commits ({since_ref}..{until_ref})")
+            self._log(f"Found {len(commits)} commits ({since_ref}..{until_ref})")
 
         return commits, retry_shas
 
@@ -1380,12 +1392,14 @@ def compare(
     cpu_pin: int | None = None,
     slice: str | None = None,
     retry: list[str] | None = None,
+    renderer: Renderer | None = None,
 ) -> list[Report.CompareRow]:
     """Programmatic compare API.
 
     Runs benchmarks for `base` and `ref` (with cache reuse when possible)
     and returns one CompareRow per benchmark with delta_time / delta_insn
     fields. This is the fitness signal consumed by tools like bfoptimize.
+    Progress messages go to `renderer`, or the module default when None.
     """
     args = argparse.Namespace(
         sources=sources,
@@ -1412,7 +1426,9 @@ def compare(
     ref_sha = source_repo.git.rev_parse(ref)
 
     executor = (
-        LocalExecutor(args) if args.host in DEFAULT_HOST else RemoteExecutor(args)
+        LocalExecutor(args, renderer)
+        if args.host in DEFAULT_HOST
+        else RemoteExecutor(args, renderer)
     )
 
     with executor:

--- a/tools/bfoptimizer/__main__.py
+++ b/tools/bfoptimizer/__main__.py
@@ -1,0 +1,333 @@
+"""Argument parser, optimization loop, and main entry point for bfoptimizer."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import pathlib
+import sys
+import traceback
+from typing import Any
+
+import git
+
+from tests.benchmarks.bfbencher import compare_table
+
+from .ai import generate_commit_message, query_implementation, query_proposal
+from .build import MakeTarget, benchmark, configure, make
+from .log import RenderAs
+from .models import (
+    AttemptResult,
+    AttemptStep,
+    CommitInfo,
+    Config,
+    Effort,
+    History,
+    Model,
+)
+from .tui import Optimizer
+
+DEFAULT_EXCLUDE_FLAGS = ["use_set", "use_log", "userspace_only"]
+
+# (step, log message, make target, failure result) for each validation stage
+# run after an implementation pass, in order.
+_VALIDATION_STAGES = [
+    (
+        AttemptStep.BUILD,
+        "Building bpfilter",
+        MakeTarget.BUILD,
+        AttemptResult.BUILD_FAILED,
+    ),
+    (
+        AttemptStep.BUILD,
+        "Running fixstyle",
+        MakeTarget.FIXSTYLE,
+        AttemptResult.BUILD_FAILED,
+    ),
+    (
+        AttemptStep.TEST,
+        "Building the tests",
+        MakeTarget.TEST_BIN,
+        AttemptResult.TEST_FAILED,
+    ),
+    (
+        AttemptStep.TEST,
+        "Running the tests",
+        MakeTarget.TEST,
+        AttemptResult.TEST_FAILED,
+    ),
+]
+
+# Build/test output fed back to the implementation model is truncated to this
+# many trailing lines: errors are reported last, and full logs would grow the
+# prompt without bound across retries.
+FAILURE_LOG_MAX_LINES = 100
+
+
+def _tail(logs: list[str]) -> str:
+    if len(logs) <= FAILURE_LOG_MAX_LINES:
+        return "\n".join(logs)
+    skipped = len(logs) - FAILURE_LOG_MAX_LINES
+    return "\n".join(
+        [f"[... {skipped} lines truncated ...]", *logs[-FAILURE_LOG_MAX_LINES:]]
+    )
+
+
+def _reset_worktree(repo: git.Repo, ref: str) -> None:
+    """Discard commits, uncommitted changes, and untracked files, back to ref.
+
+    Gitignored files (build directory, caches) are preserved. Attempts start
+    from a clean tree, so anything dangling was created by the current run.
+    """
+
+    repo.git.reset("--hard", ref)
+    repo.git.clean("-fd")
+
+
+async def _optimization_loop(history: History) -> None:
+    log = logging.getLogger("bfoptimizer")
+
+    r = await asyncio.to_thread(
+        configure, history.config.sources_dir, history.config.build_dir
+    )
+    if r.returncode != 0:
+        log.error(f"failed to configure bpfilter sources:\n{r.stderr}")
+        raise RuntimeError("failed to configure bpfilter sources")
+
+    with git.Repo(history.config.sources_dir) as repo:
+        for attempt in history.iter_attempts():
+            log.info("Starting attempt")
+            attempt.start()
+
+            # Every failure path resets to the attempt's start commit:
+            # an absolute ref stays correct even if the attempt died
+            # half-way through creating its commit.
+            start_sha = await asyncio.to_thread(lambda: repo.head.commit.hexsha)
+            try:
+                await query_proposal(history)
+
+                if not attempt.plan:
+                    log.error("proposal phase produced no plan, skipping attempt")
+                    await asyncio.to_thread(_reset_worktree, repo, start_sha)
+                    attempt.complete(AttemptResult.PLAN_FAILED)
+                    continue
+
+                failures: list[dict[str, Any]] = []
+                for _ in range(5):
+                    attempt.step = AttemptStep.IMPLEMENT
+                    await query_implementation(history, failures)
+
+                    for step, message, target, failure in _VALIDATION_STAGES:
+                        attempt.step = step
+                        log.info(message)
+                        (returncode, logs) = await make(
+                            history.config.build_dir, target
+                        )
+                        if returncode != 0:
+                            failures.append({"failure": failure, "reason": _tail(logs)})
+                            break
+                    else:
+                        break
+                else:
+                    await asyncio.to_thread(_reset_worktree, repo, start_sha)
+                    attempt.complete(failures[-1]["failure"])
+                    continue
+
+                log.info("Changes are valid, committing")
+
+                await asyncio.to_thread(repo.git.add, ".")
+                diff = await asyncio.to_thread(repo.git.diff, "--staged")
+                commit_msg = await asyncio.to_thread(
+                    generate_commit_message, attempt.plan, diff
+                )
+                log.info(f"Commit: {commit_msg}")
+                commit = await asyncio.to_thread(repo.index.commit, commit_msg)
+
+                subject, _, body = commit_msg.partition("\n")
+                attempt.commit = CommitInfo(
+                    sha=commit.hexsha,
+                    parent_sha=start_sha,
+                    subject=subject.strip(),
+                    body=body.strip(),
+                    diff=diff,
+                )
+
+                attempt.step = AttemptStep.EVALUATE
+                log.info("Running the benchmarks")
+                attempt.benchmark_results = await asyncio.to_thread(
+                    benchmark,
+                    history.config,
+                    "HEAD~1",
+                    "HEAD",
+                    lambda line: log.info(line, extra={"render_as": RenderAs.RICH}),
+                )
+
+                log.info(
+                    "",
+                    extra={
+                        "renderable": compare_table(
+                            attempt.benchmark_results, start_sha, commit.hexsha
+                        )
+                    },
+                )
+
+                result = (
+                    AttemptResult.SUCCESS
+                    if attempt.delta_pct < 0.0
+                    else AttemptResult.REGRESSION
+                )
+                if result == AttemptResult.REGRESSION:
+                    await asyncio.to_thread(_reset_worktree, repo, start_sha)
+
+                attempt.complete(result)
+
+                log.info(
+                    f"Completing attempt: {attempt.result} with {attempt.delta_pct:.3f}%"
+                )
+            except Exception:
+                # A failed attempt must not take down the run or leave an
+                # unvalidated commit at HEAD.
+                log.error(f"attempt failed:\n{traceback.format_exc()}")
+                if attempt.result == AttemptResult.IN_PROGRESS:
+                    await asyncio.to_thread(_reset_worktree, repo, start_sha)
+                    attempt.complete(AttemptResult.FAILED)
+
+        log.info("Optimization completed!")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="bfoptimizer",
+        description="LLM-driven BPF bytecode optimization loop for bpfilter.",
+    )
+
+    src_g = parser.add_argument_group("Sources")
+    _ = src_g.add_argument(
+        "--sources-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("."),
+        help="Path to the bpfilter source checkout (default: %(default)s).",
+    )
+    _ = src_g.add_argument(
+        "--build-dir",
+        type=pathlib.Path,
+        default=None,
+        help="Path to the bpfilter build directory (default: ${SOURCES_DIR}/build).",
+    )
+
+    ai_g = parser.add_argument_group("LLM / AI")
+    _ = ai_g.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of optimization attempts (default: %(default)s).",
+    )
+    _ = ai_g.add_argument(
+        "--proposal-model",
+        type=Model,
+        default=Model.CLAUDE_OPUS_4_8,
+        choices=list(Model),
+        help="Model for the proposal phase (default: %(default)s).",
+    )
+    _ = ai_g.add_argument(
+        "--impl-model",
+        type=Model,
+        default=Model.CLAUDE_OPUS_4_8,
+        choices=list(Model),
+        help="Model for the implementation phase (default: %(default)s).",
+    )
+    _ = ai_g.add_argument(
+        "--effort",
+        type=Effort,
+        default=Effort.MEDIUM,
+        choices=list(Effort),
+        help="Thinking effort level (default: %(default)s).",
+    )
+    _ = ai_g.add_argument(
+        "--hint",
+        default=None,
+        help="Free-text direction passed to the proposal model (default: %(default)s).",
+    )
+
+    bench_g = parser.add_argument_group("Benchmark")
+    _ = bench_g.add_argument(
+        "--benchmark-host",
+        type=str,
+        default=None,
+        help="Remote host to run benchmarks on (default: run locally).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-ssh-key",
+        type=pathlib.Path,
+        default=None,
+        metavar="PATH",
+        help="SSH private key used to authenticate to the benchmark host "
+        "(default: look up the host in the SSH agent).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-bind-node",
+        type=int,
+        default=None,
+        metavar="N",
+        help="NUMA node to bind the benchmark to (default: %(default)s).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-cpu-pin",
+        type=int,
+        default=None,
+        metavar="N",
+        help="CPU to pin the benchmark to (default: %(default)s).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-no-preempt",
+        action="store_true",
+        help="Use real-time scheduling (chrt) for benchmarks (default: %(default)s).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-slice",
+        type=str,
+        default=None,
+        metavar="SLICE",
+        help="systemd slice to run the benchmark in (default: %(default)s).",
+    )
+    _ = bench_g.add_argument(
+        "--benchmark-exclude",
+        action="append",
+        default=None,
+        dest="benchmark_exclude_flags",
+        metavar="FLAG",
+        help="Exclude benchmarks with this flag; replaces the default exclusions "
+        f"(repeatable; default: {', '.join(DEFAULT_EXCLUDE_FLAGS)}).",
+    )
+
+    args = parser.parse_args()
+
+    if args.build_dir is None:
+        args.build_dir = args.sources_dir / "build"
+    if args.benchmark_exclude_flags is None:
+        args.benchmark_exclude_flags = list(DEFAULT_EXCLUDE_FLAGS)
+
+    # The first benchmark runs long after startup; fail on a bad key path now
+    # rather than at the end of the first attempt.
+    if args.benchmark_ssh_key and not args.benchmark_ssh_key.expanduser().is_file():
+        print(f"SSH key not found: {args.benchmark_ssh_key}", file=sys.stderr)
+        sys.exit(1)
+
+    # The optimization loop commits with 'git add .' and reverts regressions
+    # with 'git reset --hard': uncommitted user changes would be folded into
+    # the first attempt's commit, then destroyed on revert.
+    with git.Repo(args.sources_dir) as repo:
+        if repo.is_dirty(untracked_files=True):
+            print(
+                "the working tree is dirty, commit or stash your changes first:",
+                file=sys.stderr,
+            )
+            print(repo.git.status("--short"), file=sys.stderr)
+            sys.exit(1)
+
+    history = History(Config(**vars(args)))
+    Optimizer(history, lambda: _optimization_loop(history)).run()
+
+
+main()

--- a/tools/bfoptimizer/ai.py
+++ b/tools/bfoptimizer/ai.py
@@ -1,0 +1,167 @@
+import functools
+import json
+import logging
+import pathlib
+
+import anthropic
+import claude_agent_sdk
+import jinja2
+
+from .log import log_message
+from .models import Attempt, History, Model
+
+_env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(pathlib.Path(__file__).parent / "templates"),
+    trim_blocks=True,
+    lstrip_blocks=True,
+    undefined=jinja2.StrictUndefined,
+)
+
+# Cap on conversation turns per agent query (ClaudeAgentOptions.max_turns).
+MAX_TOOL_ROUNDS = 100
+
+# The optimization scope: agents run from this directory, and both prompt
+# templates reference it as {{ cgen_dir }}.
+_CGEN_DIR = "src/libbpfilter/cgen"
+
+log = logging.getLogger("bfoptimizer")
+
+
+def proposal_system_prompt(history: History) -> str:
+    return _env.get_template("proposal.j2").render(cgen_dir=_CGEN_DIR, history=history)
+
+
+def implementation_system_prompt(history: History, failures) -> str:
+    return _env.get_template("implementation.j2").render(
+        cgen_dir=_CGEN_DIR, history=history, failures=failures
+    )
+
+
+@functools.cache
+def _anthropic_client() -> anthropic.Anthropic:
+    return anthropic.Anthropic()
+
+
+async def _query(
+    history: History,
+    prompt: str,
+    model: Model,
+    allowed_tools: list[str],
+    disallowed_tools: list[str] | None = None,
+) -> str | None:
+    """Run a claude_agent_sdk query, logging messages and accumulating cost.
+
+    Returns the final result text, or None if the query produced none.
+    """
+    attempt: Attempt | None = history.current_attempt
+    if not attempt:
+        raise RuntimeError("model queried, but no Attempt in progress")
+
+    result: str | None = None
+    async for message in claude_agent_sdk.query(
+        prompt=prompt,
+        options=claude_agent_sdk.ClaudeAgentOptions(
+            system_prompt={  # how it behaves, every turn
+                "type": "preset",
+                "preset": "claude_code",  # keep the coding persona
+                "append": "You are a performance engineer with a deep understanding "
+                "of the BPF bytecode and subsystem in the kernel, as well as packet "
+                "filtering and usual packet matching practices.",
+            },
+            cwd=str(history.config.sources_dir / _CGEN_DIR),
+            allowed_tools=allowed_tools,
+            disallowed_tools=disallowed_tools or [],
+            permission_mode="bypassPermissions",
+            max_turns=MAX_TOOL_ROUNDS,
+            model=model.value,
+            **model.agent_options(history.config.effort),
+            stderr=lambda line: log.debug(line),
+        ),
+    ):
+        log_message(message)
+
+        if isinstance(message, claude_agent_sdk.ResultMessage):
+            attempt.cost += message.total_cost_usd or 0.0
+            if not message.is_error:
+                result = message.result
+
+    return result
+
+
+async def query_proposal(history: History) -> None:
+    log.info("Requesting the proposal")
+
+    plan = await _query(
+        history,
+        proposal_system_prompt(history),
+        history.config.proposal_model,
+        allowed_tools=["Read", "Grep", "Glob", "Bash", "ToolSearch"],
+        disallowed_tools=["ScheduleWakeup"],
+    )
+
+    # An empty plan is left for the caller to handle: it aborts the attempt,
+    # not the run.
+    attempt = history.current_attempt
+    attempt.plan = plan or ""
+    if attempt.plan:
+        log.info(f"Proposal complete (total cost ${attempt.cost:.2f})")
+
+
+async def query_implementation(history: History, failures) -> None:
+    log.info("Requesting the implementation")
+
+    await _query(
+        history,
+        implementation_system_prompt(history, failures),
+        history.config.impl_model,
+        allowed_tools=["Read", "Grep", "Glob", "Bash", "Edit", "Write"],
+    )
+
+    cost = history.current_attempt.cost
+    log.info(f"Implementation completed (total cost ${cost:.2f})")
+
+
+def generate_commit_message(plan: str, diff: str) -> str:
+    response = _anthropic_client().messages.create(
+        model=Model.CLAUDE_HAIKU_4_5.value,
+        max_tokens=500,
+        output_config={
+            "format": {
+                "type": "json_schema",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "subject": {"type": "string"},
+                        "body": {"type": "string"},
+                    },
+                    "required": ["subject", "body"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        messages=[
+            {
+                "role": "user",
+                "content": f"""Generate a git commit message (subject and body) for this change to the bpfilter project.
+
+Subject: `component: subcomponent: short description`
+- Components: lib, cli, tests, build, tools, doc
+- Subcomponents examples: cgen, matcher, chain, rule, hook
+- Lowercase, imperative mood, no period, ≤72 chars total
+- Describe WHY the change improves things, not what lines changed
+
+Body: 2-4 sentences explaining the intent behind the change and why it
+improves the generated BPF programs. Wrap lines at 72 characters. Do not
+repeat the subject or describe the diff line by line.
+
+Plan (intent):
+{plan}
+
+Diff:
+{diff}
+""",
+            }
+        ],
+    )
+    message = json.loads(response.content[0].text)
+    return f"{message['subject'].strip()}\n\n{message['body'].strip()}"

--- a/tools/bfoptimizer/build.py
+++ b/tools/bfoptimizer/build.py
@@ -1,0 +1,117 @@
+import asyncio
+import enum
+import logging
+import pathlib
+import subprocess
+from collections.abc import Callable
+
+from tests.benchmarks.bfbencher import Renderer, Report, compare
+
+from .models import Config
+
+log = logging.getLogger("bfoptimizer")
+
+
+class MakeTarget(enum.StrEnum):
+    FIXSTYLE = "fixstyle"
+    BUILD = "all"
+    TEST_BIN = "test_bin"
+    TEST = "test"
+
+
+def configure(
+    sources: pathlib.Path, build_dir: pathlib.Path
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "cmake",
+            "-S",
+            str(sources),
+            "-B",
+            str(build_dir),
+            "-DNO_DOCS=1",
+            "-DCMAKE_BUILD_TYPE=release",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+async def make(
+    build_dir: pathlib.Path,
+    target: MakeTarget,
+) -> tuple[int, list[str]]:
+    logs = []
+
+    def emit(lines: list[bytes]) -> None:
+        # One log record per chunk, not per line: each record is rendered
+        # individually by the TUI, and a full build emits thousands of lines.
+        if not lines:
+            return
+        texts = [line.decode(errors="replace").rstrip() for line in lines]
+        logs.extend(texts)
+        log.info("\n".join(texts))
+
+    proc = await asyncio.create_subprocess_exec(
+        "make",
+        "-C",
+        str(build_dir),
+        str(target),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    # Read in chunks rather than lines: readline() raises on lines longer
+    # than the stream's 64KiB limit, which build output can exceed.
+    buffer = b""
+    while chunk := await proc.stdout.read(64 * 1024):
+        buffer += chunk
+        *lines, buffer = buffer.split(b"\n")
+        emit(lines)
+    emit([buffer] if buffer else [])
+
+    await proc.wait()
+
+    return (proc.returncode, logs)
+
+
+class _LoggingRenderer(Renderer):
+    def __init__(self, log_fn: Callable[[str], None]) -> None:
+        super().__init__()
+        self._log_fn = log_fn
+
+    def log(self, message: str) -> None:
+        self._log_fn(message)
+
+
+def benchmark(
+    config: Config,
+    base_sha: str,
+    ref_sha: str,
+    log_fn: Callable[[str], None] | None = None,
+) -> list[Report.CompareRow]:
+    kwargs = dict(
+        sources=config.sources_dir,
+        cache_dir=config.sources_dir / ".cache" / "bfbencher",
+        ssh_key=config.benchmark_ssh_key,
+        bind_node=config.benchmark_bind_node,
+        no_preempt=config.benchmark_no_preempt,
+        cpu_pin=config.benchmark_cpu_pin,
+        slice=config.benchmark_slice,
+        # Re-benchmark both commits instead of reusing the base's cached
+        # result: measuring base and ref back-to-back keeps the comparison
+        # immune to machine drift between attempts, at the cost of running
+        # the benchmarks twice.
+        retry=["all"],
+    )
+
+    if config.benchmark_host:
+        kwargs["host"] = config.benchmark_host
+
+    if log_fn is not None:
+        kwargs["renderer"] = _LoggingRenderer(log_fn)
+
+    results = compare(base_sha, ref_sha, **kwargs)
+
+    exclude = set(config.benchmark_exclude_flags)
+    return [r for r in results if not any(getattr(r, f, False) for f in exclude)]

--- a/tools/bfoptimizer/log.py
+++ b/tools/bfoptimizer/log.py
@@ -1,0 +1,84 @@
+"""Translation of claude_agent_sdk messages into bfoptimizer log records."""
+
+import enum
+import logging
+
+import claude_agent_sdk
+
+log = logging.getLogger("bfoptimizer")
+
+
+class RenderAs(enum.StrEnum):
+    PLAIN = "plain"
+    MARKDOWN = "markdown"
+    RICH = "rich"
+
+
+# Input keys to log for tool-use blocks: a curated subset for tools whose
+# input is too noisy to show in full (Write's content, Edit's old/new
+# strings), None to hide the block entirely. Tools not listed here log
+# their full input.
+_BLOCK_KV: dict[str, list[str] | None] = {
+    "Read": ["file_path"],
+    "Write": ["file_path"],
+    "Edit": ["file_path"],
+    "Agent": [],
+    "Grep": ["path", "pattern"],
+    "ToolSearch": ["query"],
+    "Glob": ["pattern"],
+    "Bash": ["command"],
+    "ExitPlanMode": None,
+}
+
+
+def log_message(message: claude_agent_sdk.Message) -> None:
+    """Log a claude_agent_sdk message to the bfoptimizer logger."""
+    if isinstance(message, claude_agent_sdk.AssistantMessage):
+        for block in message.content:
+            _log_block(block)
+    elif isinstance(message, claude_agent_sdk.ResultMessage):
+        if message.is_error:
+            log.error(f"API error: {message.result}")
+    elif isinstance(
+        message,
+        (
+            claude_agent_sdk.TaskProgressMessage,
+            claude_agent_sdk.TaskNotificationMessage,
+            claude_agent_sdk.TaskUpdatedMessage,
+            claude_agent_sdk.TaskStartedMessage,
+        ),
+    ):
+        # Subagent lifecycle events. These subclass SystemMessage, so they
+        # must be matched before the SystemMessage branch below, which would
+        # otherwise catch them and log their repr.
+        pass
+    elif isinstance(message, claude_agent_sdk.SystemMessage):
+        if message.subtype not in ["init", "thinking_tokens"]:
+            log.info(message)
+    elif isinstance(message, claude_agent_sdk.UserMessage):
+        pass
+    else:
+        log.info(f"Unsupported message: {message}")
+
+
+def _log_block(block: claude_agent_sdk.ContentBlock) -> None:
+    if isinstance(block, claude_agent_sdk.ThinkingBlock):
+        if not block.thinking:
+            # Some models return empty thinking blocks
+            return
+        log.info(block.thinking, extra={"render_as": RenderAs.MARKDOWN})
+    elif isinstance(block, claude_agent_sdk.ToolUseBlock):
+        keys = _BLOCK_KV.get(block.name, list(block.input))
+        if keys is None:
+            return
+
+        log.info(
+            block.name,
+            extra={"kv": {key: block.input.get(key, "<NONE>") for key in keys}},
+        )
+    elif isinstance(block, claude_agent_sdk.ToolResultBlock):
+        log.info(f"ToolResultBlock {block}")
+    elif isinstance(block, claude_agent_sdk.TextBlock):
+        log.info(block.text, extra={"render_as": RenderAs.MARKDOWN})
+    else:
+        log.info(block)

--- a/tools/bfoptimizer/models.py
+++ b/tools/bfoptimizer/models.py
@@ -184,14 +184,18 @@ class History:
     def duration(self) -> float:
         return sum(attempt.duration for attempt in self.attempts)
 
-    def cumulative_progress(self) -> float:
+    def cumulative_progress(self, up_to: int | None = None) -> float:
         """Δtime% from the original baseline to the current best commit.
+
+        Only attempts up to index up_to (inclusive) are considered when
+        provided, giving the progress as of that attempt.
 
         Returns 0.0 when there are no successful attempts with benchmark data.
         """
+        attempts = self.attempts if up_to is None else self.attempts[: up_to + 1]
         successes = [
             attempt
-            for attempt in self.attempts
+            for attempt in attempts
             if attempt.result == AttemptResult.SUCCESS
         ]
         if not successes:

--- a/tools/bfoptimizer/models.py
+++ b/tools/bfoptimizer/models.py
@@ -1,0 +1,216 @@
+"""Data models for the bfoptimizer package."""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import pathlib
+import random
+import string
+import time
+from collections.abc import Generator
+
+import git
+
+from tests.benchmarks.bfbencher import Report
+
+
+class Model(enum.StrEnum):
+    CLAUDE_FABLE_5 = "claude-fable-5"
+    CLAUDE_OPUS_4_8 = "claude-opus-4-8"
+    CLAUDE_SONNET_4_6 = "claude-sonnet-4-6"
+    CLAUDE_HAIKU_4_5 = "claude-haiku-4-5"
+
+    def agent_options(self, effort: "Effort") -> dict:
+        """Return kwargs to unpack into ClaudeAgentOptions for this model and effort."""
+        if self == Model.CLAUDE_HAIKU_4_5:
+            return {}
+        return {"effort": effort.value, "thinking": {"type": "adaptive"}}
+
+
+class Effort(enum.StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    MAX = "max"
+
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    """Optimizer configuration."""
+
+    sources_dir: pathlib.Path
+    build_dir: pathlib.Path
+
+    iterations: int
+    proposal_model: Model
+    impl_model: Model
+    effort: Effort
+    hint: str | None
+    benchmark_host: str | None
+    benchmark_ssh_key: pathlib.Path | None
+    benchmark_bind_node: int | None
+    benchmark_no_preempt: bool
+    benchmark_cpu_pin: int | None
+    benchmark_slice: str | None
+    benchmark_exclude_flags: list[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class CommitInfo:
+    """Commit produced by an attempt.
+
+    Kept on the attempt even when the commit is later reverted (regression):
+    parent_sha/sha stay valid for rendering even though the commit is no
+    longer reachable from HEAD.
+    """
+
+    sha: str
+    parent_sha: str
+    subject: str
+    body: str
+    diff: str
+
+
+class AttemptStep(enum.Enum):
+    READY = "ready"
+    PROPOSE = "propose"
+    IMPLEMENT = "implement"
+    BUILD = "build"
+    TEST = "test"
+    EVALUATE = "evaluate"
+    DONE = "done"
+
+
+class AttemptResult(enum.Enum):
+    IN_PROGRESS = "in_progress"
+    SUCCESS = "success"
+    PLAN_FAILED = "plan_failed"
+    BUILD_FAILED = "build_failed"
+    TEST_FAILED = "test_failed"
+    REGRESSION = "regression"
+    FAILED = "failed"
+
+
+class Attempt:
+    """Single optimization attempt within a run."""
+
+    def __init__(self) -> None:
+        self._step = AttemptStep.READY
+        self._start_time: float | None = None
+        self._stop_time: float | None = None
+        self.result = AttemptResult.IN_PROGRESS
+        self.plan: str | None = None
+        self.benchmark_results: list[Report.CompareRow] = []
+        self.cost = 0.0
+        self.commit: CommitInfo | None = None
+
+    @property
+    def step(self) -> AttemptStep:
+        return self._step
+
+    @step.setter
+    def step(self, step: AttemptStep) -> None:
+        boundaries = (AttemptStep.READY, AttemptStep.DONE)
+        if self._step in boundaries or step in boundaries:
+            raise RuntimeError(
+                "READY and DONE transitions go through start()/complete()"
+            )
+        self._step = step
+
+    @property
+    def duration(self) -> float:
+        if self._start_time is None:
+            return 0.0
+        end = self._stop_time if self._stop_time is not None else time.time()
+        return end - self._start_time
+
+    @property
+    def delta_pct(self) -> float:
+        """Mean Δtime% across this attempt's benchmarks (negative = faster)."""
+        return (
+            sum(r.delta_time_pct for r in self.benchmark_results)
+            / len(self.benchmark_results)
+            if self.benchmark_results
+            else 0.0
+        )
+
+    def start(self) -> None:
+        self._step = AttemptStep.PROPOSE
+        self._start_time = time.time()
+
+    def complete(self, result: AttemptResult) -> None:
+        self.result = result
+        self._step = AttemptStep.DONE
+        self._stop_time = time.time()
+
+
+class History:
+    """Per-run history of optimization attempts."""
+
+    def __init__(self, config: Config) -> None:
+        self.id = "".join(random.choices(string.ascii_lowercase + string.digits, k=8))
+        self.config = config
+        self.baseline_sha = git.Repo(config.sources_dir).head.commit.hexsha
+        self.attempts: list[Attempt] = []
+
+    @property
+    def current_attempt(self) -> Attempt | None:
+        return self.attempts[-1] if self.attempts else None
+
+    @property
+    def attempts_kept(self) -> int:
+        return sum(
+            1 for attempt in self.attempts if attempt.result == AttemptResult.SUCCESS
+        )
+
+    @property
+    def attempts_complete(self) -> int:
+        return sum(
+            1
+            for attempt in self.attempts
+            if attempt.result != AttemptResult.IN_PROGRESS
+        )
+
+    @property
+    def attempts_rejected(self) -> int:
+        return self.attempts_complete - self.attempts_kept
+
+    @property
+    def cost(self) -> float:
+        return sum(attempt.cost for attempt in self.attempts)
+
+    @property
+    def duration(self) -> float:
+        return sum(attempt.duration for attempt in self.attempts)
+
+    def cumulative_progress(self) -> float:
+        """Δtime% from the original baseline to the current best commit.
+
+        Returns 0.0 when there are no successful attempts with benchmark data.
+        """
+        successes = [
+            attempt
+            for attempt in self.attempts
+            if attempt.result == AttemptResult.SUCCESS
+        ]
+        if not successes:
+            return 0.0
+
+        first = successes[0]
+        last = successes[-1]
+
+        base_by_name = {row.name: row.base_time_ns for row in first.benchmark_results}
+        ref_by_name = {row.name: row.ref_time_ns for row in last.benchmark_results}
+        deltas = [
+            (ref_by_name[name] - base_ns) / base_ns * 100
+            for name, base_ns in base_by_name.items()
+            if name in ref_by_name and base_ns > 0
+        ]
+
+        return sum(deltas) / len(deltas) if deltas else 0.0
+
+    def iter_attempts(self) -> Generator[Attempt, None, None]:
+        for _ in range(self.config.iterations):
+            self.attempts.append(Attempt())
+            yield self.attempts[-1]

--- a/tools/bfoptimizer/templates/_conventions.j2
+++ b/tools/bfoptimizer/templates/_conventions.j2
@@ -1,0 +1,13 @@
+## Register conventions
+
+r6  – header pointer, reloaded from the stack runtime context (l3_hdr/l4_hdr) for each matcher
+r7  – L3 protocol id (network-byte-order ethertype, e.g. htobe16(ETH_P_IP))
+r8  – L4 protocol id (e.g. IPPROTO_TCP)
+r10 – frame pointer (BPF stack base)
+r1–r5 – scratch / function args (clobbered by every kfunc/helper call)
+r9  – callee-saved, currently unused
+
+Do not clobber r7 or r8 inside matcher code. Protocol checks are deduplicated per rule (`checked_layers` in `_bf_program_generate_rule()`); r6 is reloaded from the runtime context for each matcher, so do not assume it stays valid across matchers or rules.
+
+Never target cgroup_sock_addr programs — no benchmarks exist for them.
+

--- a/tools/bfoptimizer/templates/implementation.j2
+++ b/tools/bfoptimizer/templates/implementation.j2
@@ -1,0 +1,32 @@
+You are implementing a BPF bytecode optimization in the bpfilter project.
+
+{% include "_conventions.j2" %}
+
+## Scope
+
+Only modify files under {{ cgen_dir }}/. You may read anywhere in the tree (including tests/, src/ headers, etc.) to understand context.
+
+## Plan
+
+{{ history.current_attempt.plan }}
+
+## Style
+
+See CLAUDE.md for the complete guide. Key points: 4 spaces, 80-char line limit, `//` for single-line comments, `/* */` with aligned asterisks for multi-line.
+
+{% if failures %}
+## Failures
+
+Previous attempts at implementing this plan failed:
+
+{% for a in failures %}
+<failure kind="{{ a.failure.value }}">
+{{ a.reason }}
+</failure>
+{% endfor %}
+{% endif %}
+
+## Direction
+
+- Do not build, test or commit, this will be done in a different step
+- Stick to the plan, do not deviate from it

--- a/tools/bfoptimizer/templates/proposal.j2
+++ b/tools/bfoptimizer/templates/proposal.j2
@@ -1,0 +1,66 @@
+You are an expert BPF/eBPF engineer optimizing the BPF bytecode generation logic in the bpfilter project.
+
+bpfilter translates packet filtering rules into BPF programs that run in the Linux kernel for every packet. Every BPF instruction eliminated from generated programs reduces per-packet latency on the hot path.
+
+Baseline commit: {{ history.baseline_sha }}
+
+{% include "_conventions.j2" %}
+
+## BPF instruction cost (highest → lowest)
+
+1. kfunc / BPF helper calls  (bpf_dynptr_slice, map_lookup_elem, …)
+2. Stack loads / stores  (BPF_LDX_MEM / BPF_STX_MEM / BPF_ST_MEM via r10)
+3. Register ALU and MOV
+4. Branches  (not-taken ≈ free; mispredicted ≈ 15+ cycles)
+
+Eliminating stack accesses on the hot path is the highest-value target after reducing kfunc/helper calls.
+
+## cgen/ file inventory
+
+stub.c / stub.h      – packet-header parsing stubs (L2/L3/L4); primary hot-path target
+program.c / .h       – BPF program generation entry point, rule-emission loop
+packet.c / .h        – packet-based matcher payload access (header field loads via r6)
+swich.c / .h         – BPF dispatch-table (switch-case) code emitter
+jmp.c / .h           – forward-jump fixup management
+matcher/cmp.c        – comparison matchers (eq, range, bitfield, masked-address)
+matcher/meta.c       – meta matchers (iface, l3/l4 proto, sport/dport, probability)
+matcher/set.c        – set-lookup matchers (hash map and LPM trie)
+tc.c / xdp.c / nf.c / cgroup_skb.c  – flavor prologues and epilogues
+runtime.h            – bf_runtime stack layout (BF_PROG_CTX_OFF, BF_PROG_SCR_OFF)
+fixup.h              – fixup types (JMP_NEXT_RULE, map FDs, elfstub calls)
+
+This inventory is not exhaustive; list the directory for the full set.
+
+## Task
+
+Explore {{ cgen_dir }}/ to understand how BPF bytecode is generated, then
+reply with ONE concrete optimization as your final message. Focus on changes
+that reduce the cost of BPF instructions in the hot path. Use standard unix
+tools as you wish, but NEVER MODIFY THE FILES.
+
+{% if history.config.hint %}
+
+## Hint
+
+{{ history.config.hint }}
+
+This is a direction to explore, not a constraint.
+{% endif %}
+{% set failed_attempts = history.attempts | selectattr("plan") | rejectattr("result.value", "in", ["success", "in_progress"]) | list %}
+{% if failed_attempts %}
+
+## Previous failed attempts this run — do not repeat these ideas
+
+{% for a in failed_attempts %}
+<failed_attempt result="{{ a.result.value }}"{% if a.benchmark_results %} avg_delta_time="{{ "%+.1f" | format(a.delta_pct) }}%"{% endif %}>
+{{ a.plan.strip() }}
+</failed_attempt>
+{% endfor %}
+{% endif %}
+
+# direction
+
+- Your final message should only contain the plan, no message to the user or anything else, only THE CONTENT OF THE PLAN
+- DO NOT list the testing steps, only the implementation
+- Do not add performance improvement/regression to the final plan
+- Omit the title from the plan, each section should be a level-3 header (`###`), as the plan will be embeded into another file

--- a/tools/bfoptimizer/tui.py
+++ b/tools/bfoptimizer/tui.py
@@ -1,0 +1,291 @@
+"""Textual UI for bfoptimizer.
+
+Owns every widget and the App shell. The optimization loop itself is
+injected into Optimizer as a coroutine function: the UI renders a run, it
+doesn't drive it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import logging
+from collections.abc import Awaitable, Callable
+
+import rich.console
+import rich.markdown
+import rich.table
+import rich.text
+import textual.events
+import textual.widgets
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Header, Static
+
+from tests.benchmarks.bfbencher import SHORT_SHA_LEN
+
+from .log import RenderAs
+from .models import History
+
+
+class LogView(textual.widgets.RichLog):
+    DEFAULT_CSS = """
+    LogView {
+        height: 1fr;
+        border: round $primary;
+        background: $background;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        # RichLog retains rendered lines forever by default; bound the
+        # scrollback so an overnight run's build output and LLM messages
+        # don't grow memory without limit.
+        super().__init__(wrap=True, max_lines=10_000)
+
+    def on_mount(self) -> None:
+        self.border_title = "Logs"
+
+    def on_mouse_scroll_up(self, event: textual.events.MouseScrollUp) -> None:
+        self.auto_scroll = False
+
+    def on_mouse_scroll_down(self, event: textual.events.MouseScrollDown) -> None:
+        if self.is_vertical_scroll_end:
+            self.auto_scroll = True
+
+
+class LogHandler(logging.Handler):
+    def __init__(self, widget: LogView, history: History) -> None:
+        super().__init__()
+
+        self._widget = widget
+        self._history = history
+        self._loop = asyncio.get_running_loop()
+
+    def _write(self, renderable) -> None:
+        """Write to the widget from the app's event loop.
+
+        Textual widgets are not thread-safe, and emit() is also called from
+        worker threads (e.g. the benchmark renderer running in
+        asyncio.to_thread()).
+        """
+        try:
+            self._loop.call_soon_threadsafe(self._widget.write, renderable)
+        except RuntimeError:
+            # The loop is closed: a worker thread logged during app teardown,
+            # there is nowhere left to render to.
+            pass
+
+    def emit(self, record: logging.LogRecord) -> None:
+        time = datetime.datetime.fromtimestamp(record.created).strftime("%H:%M:%S")
+        attempt_id = len(self._history.attempts)
+        step = (
+            self._history.current_attempt.step.value
+            if self._history.current_attempt
+            else "-"
+        )
+
+        # A pre-built renderable (e.g. a compare table) is used as the
+        # message as-is, but still goes through the metadata grid below.
+        renderable = getattr(record, "renderable", None)
+        render_as = getattr(record, "render_as", RenderAs.PLAIN)
+        if renderable is not None:
+            message: rich.console.RenderableType = renderable
+        elif render_as == RenderAs.MARKDOWN:
+            message = rich.markdown.Markdown(
+                record.getMessage(),
+                code_theme="solarized-light",
+                inline_code_lexer="c",
+                inline_code_theme="solarized-light",
+            )
+        elif render_as == RenderAs.RICH:
+            message = rich.text.Text.from_markup(record.getMessage())
+        elif render_as == RenderAs.PLAIN:
+            message = rich.text.Text(record.getMessage())
+        else:
+            raise RuntimeError(f"Unsupported RenderAs.{render_as}")
+
+        kv: dict[str, str] | None = getattr(record, "kv", None)
+        if kv is not None and isinstance(message, rich.text.Text):
+            message.stylize("bold")
+            for k, v in kv.items():
+                message.append(f" {k}=", style="dim")
+                message.append(str(v), style="dim italic")
+
+        table = rich.table.Table.grid(padding=(0, 1))
+        table.add_column(width=8, no_wrap=True)
+        table.add_column(width=8, no_wrap=True)
+        table.add_column(width=12, no_wrap=True)
+        table.add_column(ratio=1)
+        table.add_row(
+            rich.text.Text(time, style="dim"),
+            rich.text.Text(
+                f"[{attempt_id}/{self._history.config.iterations}]",
+                style="bold cyan",
+            ),
+            rich.text.Text(step, style="yellow"),
+            message,
+        )
+
+        self._write(table)
+
+
+class StatColumn(Static):
+    """One column in the stats bar: label / value / sublabel."""
+
+    DEFAULT_CSS = """
+    StatColumn {
+        width: 1fr;
+        padding: 0 2;
+        border: round $primary;
+    }
+    """
+
+    def __init__(self, label: str, **kwargs) -> None:
+        super().__init__("", **kwargs)
+        self.border_title = label
+
+    def set(self, value: rich.text.Text | str, sublabel: str = "") -> None:
+        t = rich.table.Table.grid()
+        t.add_column()
+        t.add_row(
+            value
+            if isinstance(value, rich.text.Text)
+            else rich.text.Text(value, style="bold")
+        )
+        t.add_row(rich.text.Text(sublabel, style="dim"))
+        self.update(t)
+
+
+class MetaLine(Static):
+    DEFAULT_CSS = """
+    MetaLine {
+        height: 1;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, history: History) -> None:
+        super().__init__("")
+        self._history = history
+
+    def refresh_meta(self) -> None:
+        h = self._history
+        self.update(
+            rich.text.Text.assemble(
+                ("run ", "dim"),
+                (h.id, "dim bold"),
+                (" · base ", "dim"),
+                (h.baseline_sha[:SHORT_SHA_LEN], "dim bold"),
+                (" · prop model ", "dim"),
+                (h.config.proposal_model, "dim bold"),
+                (" · impl model ", "dim"),
+                (h.config.impl_model, "dim bold"),
+                (" · effort ", "dim"),
+                (h.config.effort, "dim bold"),
+                (" · sources ", "dim"),
+                (str(h.config.sources_dir), "dim bold"),
+                *(
+                    [(" · hint: ", "dim"), (h.config.hint, "dim italic")]
+                    if h.config.hint
+                    else []
+                ),
+            )
+        )
+
+
+class StatsBar(Vertical):
+    DEFAULT_CSS = """
+    StatsBar {
+        height: 5;
+    }
+    StatsBar Horizontal {
+        height: 5;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self, history: History) -> None:
+        super().__init__()
+        self._history = history
+
+    def compose(self) -> ComposeResult:
+        with Horizontal():
+            yield StatColumn("Attempts", id="stat-attempts")
+            yield StatColumn("Kept", id="stat-kept")
+            yield StatColumn("Rejected", id="stat-rejected")
+            yield StatColumn("Cumulative Δtime", id="stat-delta")
+            yield StatColumn("Cost", id="stat-cost")
+            yield StatColumn("Wall", id="stat-wall")
+
+    def refresh_stats(self) -> None:
+        h = self._history
+
+        n = len(h.attempts)
+        kept = h.attempts_kept
+        delta_pct = h.cumulative_progress()
+        secs = int(h.duration)
+        accept = (
+            f"{kept / h.attempts_complete * 100:.0f}% accept"
+            if h.attempts_complete
+            else "—"
+        )
+        step = h.current_attempt.step.value if h.current_attempt else "—"
+        delta_style = (
+            "bold green"
+            if delta_pct < 0
+            else ("bold red" if delta_pct > 0 else "bold dim")
+        )
+
+        self.query_one("#stat-attempts", StatColumn).set(
+            f"{n}/{h.config.iterations}", step
+        )
+        self.query_one("#stat-kept", StatColumn).set(str(kept), accept)
+        self.query_one("#stat-rejected", StatColumn).set(
+            str(h.attempts_rejected), "build / test / bench"
+        )
+        self.query_one("#stat-delta", StatColumn).set(
+            rich.text.Text(f"{delta_pct:+.2f}%", style=delta_style),
+            f"vs baseline {h.baseline_sha[:SHORT_SHA_LEN]}",
+        )
+        self.query_one("#stat-cost", StatColumn).set(f"${h.cost:.2f}", "total run cost")
+        self.query_one("#stat-wall", StatColumn).set(
+            f"{secs // 60}m {secs % 60}s", "elapsed · live"
+        )
+
+
+class Optimizer(App):
+    TITLE = "bfoptimizer"
+
+    def __init__(self, history: History, worker: Callable[[], Awaitable[None]]) -> None:
+        super().__init__()
+
+        self._history = history
+        self._worker = worker
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static()
+        yield MetaLine(self._history)
+        yield Static()
+        yield StatsBar(self._history)
+        yield LogView()
+
+    def on_mount(self) -> None:
+        self.theme = "solarized-light"
+
+        handler = LogHandler(self.query_one(LogView), self._history)
+        handler.setLevel(logging.DEBUG)
+
+        logger = logging.getLogger("bfoptimizer")
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+
+        # The meta line only shows immutable run metadata: render it once,
+        # only the stats need the periodic refresh.
+        self.query_one(MetaLine).refresh_meta()
+        self.query_one(StatsBar).refresh_stats()
+        self.set_interval(1, self.query_one(StatsBar).refresh_stats)
+
+        self.run_worker(self._worker(), exclusive=True)

--- a/tools/bfoptimizer/tui.py
+++ b/tools/bfoptimizer/tui.py
@@ -22,6 +22,7 @@ import rich.table
 import rich.text
 import textual.events
 import textual.widgets
+import textual_plot
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Header, Static, TabbedContent, TabPane
@@ -430,6 +431,78 @@ class AttemptsPane(Horizontal):
             self.query_one(AttemptSummary).show(index, self._history.attempts[index])
 
 
+class ProgressPane(Vertical):
+    DEFAULT_CSS = """
+    ProgressPane {
+        height: 1fr;
+    }
+    ProgressPane PlotWidget {
+        height: 1fr;
+        border: round $primary;
+        background: $background;
+    }
+    """
+
+    def __init__(self, history: History) -> None:
+        super().__init__()
+        self._history = history
+
+    def compose(self) -> ComposeResult:
+        yield textual_plot.PlotWidget()
+
+    def on_mount(self) -> None:
+        plot = self.query_one(textual_plot.PlotWidget)
+        plot.border_title = "Progress"
+        plot.show_legend(textual_plot.LegendLocation.BOTTOMLEFT)
+
+    def refresh_progress(self) -> None:
+        attempts = self._history.attempts
+
+        kept: list[tuple[int, float]] = []
+        rejected: list[tuple[int, float]] = []
+        # The overall line starts at the run baseline and only moves on kept
+        # attempts: regressions are reverted, so progress stays flat through
+        # them.
+        overall: list[tuple[int, float]] = [(0, 0.0)]
+        for i, attempt in enumerate(attempts):
+            if attempt.result == AttemptResult.IN_PROGRESS:
+                continue
+            overall.append((i + 1, self._history.cumulative_progress(up_to=i)))
+            if not attempt.benchmark_results:
+                continue
+            marks = kept if attempt.result == AttemptResult.SUCCESS else rejected
+            marks.append((i + 1, attempt.delta_pct))
+
+        plot = self.query_one(textual_plot.PlotWidget)
+        plot.clear()
+        plot.set_xlabel("attempt")
+        plot.set_ylabel("Δtime %")
+        plot.set_xlimits(0, self._history.config.iterations)
+        plot.plot(
+            [x for x, _ in overall],
+            [y for _, y in overall],
+            line_style="blue",
+            hires_mode=textual_plot.HiResMode.BRAILLE,
+            label="overall",
+        )
+        if kept:
+            plot.scatter(
+                [x for x, _ in kept],
+                [y for _, y in kept],
+                marker="●",
+                marker_style="green",
+                label="kept",
+            )
+        if rejected:
+            plot.scatter(
+                [x for x, _ in rejected],
+                [y for _, y in rejected],
+                marker="x",
+                marker_style="red",
+                label="regression",
+            )
+
+
 class StatColumn(Static):
     """One column in the stats bar: label / value / sublabel."""
 
@@ -579,6 +652,8 @@ class Optimizer(App):
                 yield LogView()
             with TabPane("Attempts", id="tab-attempts"):
                 yield AttemptsPane(self._history)
+            with TabPane("Progress", id="tab-progress"):
+                yield ProgressPane(self._history)
 
     def on_mount(self) -> None:
         self.theme = "solarized-light"
@@ -601,3 +676,4 @@ class Optimizer(App):
     def _refresh(self) -> None:
         self.query_one(StatsBar).refresh_stats()
         self.query_one(AttemptsPane).refresh_attempts()
+        self.query_one(ProgressPane).refresh_progress()

--- a/tools/bfoptimizer/tui.py
+++ b/tools/bfoptimizer/tui.py
@@ -8,24 +8,65 @@ doesn't drive it.
 from __future__ import annotations
 
 import asyncio
+import collections
 import datetime
 import logging
 from collections.abc import Awaitable, Callable
 
+import rich.box
 import rich.console
 import rich.markdown
+import rich.panel
+import rich.syntax
 import rich.table
 import rich.text
 import textual.events
 import textual.widgets
 from textual.app import App, ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.widgets import Header, Static
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Header, Static, TabbedContent, TabPane
+from textual.widgets.option_list import Option
 
-from tests.benchmarks.bfbencher import SHORT_SHA_LEN
+from tests.benchmarks.bfbencher import SHORT_SHA_LEN, compare_table
 
 from .log import RenderAs
-from .models import History
+from .models import Attempt, AttemptResult, CommitInfo, History
+
+# Attempt result colors, shared by the attempt list and summary. Results
+# not listed here are failures.
+_RESULT_STYLES = {
+    AttemptResult.IN_PROGRESS: "yellow",
+    AttemptResult.SUCCESS: "green",
+}
+
+
+def _result_style(result: AttemptResult) -> str:
+    return _RESULT_STYLES.get(result, "red")
+
+
+def _delta_style(delta_pct: float) -> str:
+    return "green" if delta_pct < 0 else ("red" if delta_pct > 0 else "dim")
+
+
+# Background for code blocks in the attempt summary: solarized base2, one
+# step darker than the app's base3 background, so the block reads as a
+# full-width surface instead of a per-character highlight.
+_CODE_BACKGROUND = "#eee8d5"
+
+
+def _section(title: str) -> rich.text.Text:
+    return rich.text.Text(title.upper(), style="bold dim")
+
+
+def _stat_box(label: str, value: rich.text.Text | str) -> rich.panel.Panel:
+    if isinstance(value, str):
+        value = rich.text.Text(value, style="bold")
+    return rich.panel.Panel(
+        rich.console.Group(rich.text.Text(label, style="dim"), value),
+        box=rich.box.ROUNDED,
+        padding=(0, 1),
+        expand=False,
+    )
 
 
 class LogView(textual.widgets.RichLog):
@@ -44,8 +85,37 @@ class LogView(textual.widgets.RichLog):
         # don't grow memory without limit.
         super().__init__(wrap=True, max_lines=10_000)
 
-    def on_mount(self) -> None:
-        self.border_title = "Logs"
+        # RichLog.write() renders into fixed-width strips immediately, and
+        # while the Attempts tab is active this widget's content region is
+        # zero-wide, so records logged in the meantime would be wrapped at
+        # RichLog.min_width for good. Buffer them until the view is shown
+        # again, bounded like the scrollback.
+        self._pending: collections.deque[rich.console.RenderableType] = (
+            collections.deque(maxlen=10_000)
+        )
+
+    def log_write(self, renderable: rich.console.RenderableType) -> None:
+        # Also buffer while a backlog exists: a record arriving between Show
+        # and the _flush() that follows it must not jump ahead of the
+        # buffered ones.
+        if self._pending or not self.scrollable_content_region.width:
+            self._pending.append(renderable)
+        else:
+            self.write(renderable)
+
+    def clear(self) -> LogView:
+        self._pending.clear()
+        super().clear()
+        return self
+
+    def on_show(self) -> None:
+        # Flush after the layout pass: the content region is still
+        # zero-wide when Show is dispatched.
+        self.call_after_refresh(self._flush)
+
+    def _flush(self) -> None:
+        while self._pending and self.scrollable_content_region.width:
+            self.write(self._pending.popleft())
 
     def on_mouse_scroll_up(self, event: textual.events.MouseScrollUp) -> None:
         self.auto_scroll = False
@@ -62,24 +132,41 @@ class LogHandler(logging.Handler):
         self._widget = widget
         self._history = history
         self._loop = asyncio.get_running_loop()
+        self._last_attempt = 0
 
-    def _write(self, renderable) -> None:
-        """Write to the widget from the app's event loop.
+    def _call(self, fn, *args) -> None:
+        """Invoke fn on the app's event loop.
 
         Textual widgets are not thread-safe, and emit() is also called from
         worker threads (e.g. the benchmark renderer running in
         asyncio.to_thread()).
         """
         try:
-            self._loop.call_soon_threadsafe(self._widget.write, renderable)
+            self._loop.call_soon_threadsafe(fn, *args)
         except RuntimeError:
             # The loop is closed: a worker thread logged during app teardown,
             # there is nowhere left to render to.
             pass
 
+    def _write(self, renderable) -> None:
+        self._call(self._widget.log_write, renderable)
+
+    def _clear(self) -> None:
+        self._widget.clear()
+        # Re-arm auto-scroll: the user may have scrolled up during the
+        # previous attempt, which would leave the new one's log stuck.
+        self._widget.auto_scroll = True
+
     def emit(self, record: logging.LogRecord) -> None:
         time = datetime.datetime.fromtimestamp(record.created).strftime("%H:%M:%S")
         attempt_id = len(self._history.attempts)
+
+        # The Logs tab only shows the current attempt: past attempts are
+        # summarized in the Attempts tab. Handler.handle() serializes emit(),
+        # and call_soon_threadsafe() preserves the clear/write order.
+        if attempt_id != self._last_attempt:
+            self._last_attempt = attempt_id
+            self._call(self._clear)
         step = (
             self._history.current_attempt.step.value
             if self._history.current_attempt
@@ -129,6 +216,218 @@ class LogHandler(logging.Handler):
         )
 
         self._write(table)
+
+
+class AttemptList(textual.widgets.OptionList):
+    DEFAULT_CSS = """
+    AttemptList {
+        width: 34;
+        height: 1fr;
+        border: round $primary;
+        background: $background;
+    }
+    """
+
+    def __init__(self, history: History) -> None:
+        super().__init__()
+        self._history = history
+
+    def on_mount(self) -> None:
+        self.border_title = "Attempts"
+
+    def _prompt(self, index: int, attempt: Attempt) -> rich.table.Table:
+        status = rich.text.Text(no_wrap=True)
+        status.append(f"#{index + 1:<3}", style="bold cyan")
+        if attempt.result == AttemptResult.IN_PROGRESS:
+            status.append(attempt.step.value, style="yellow")
+        else:
+            status.append(attempt.result.value, style=_result_style(attempt.result))
+
+        if attempt.benchmark_results:
+            delta = rich.text.Text(
+                f"{attempt.delta_pct:+.2f}%",
+                style=_delta_style(attempt.delta_pct),
+                no_wrap=True,
+            )
+        else:
+            delta = rich.text.Text("—", style="dim", no_wrap=True)
+
+        # An expanded two-column grid pins the result to the right edge of
+        # the list, so the deltas line up across attempts.
+        prompt = rich.table.Table.grid(expand=True)
+        prompt.add_column(no_wrap=True)
+        prompt.add_column(justify="right", no_wrap=True)
+        prompt.add_row(status, delta)
+        return prompt
+
+    def refresh_attempts(self) -> None:
+        attempts = self._history.attempts
+
+        # Follow the newest attempt unless the user moved the cursor away
+        # from it, mirroring LogView's auto-scroll semantics.
+        follow = self.highlighted is None or self.highlighted == self.option_count - 1
+
+        # Prompts are replaced in place: rebuilding the list would reset the
+        # highlighted option under the user.
+        for i in range(self.option_count):
+            self.replace_option_prompt_at_index(i, self._prompt(i, attempts[i]))
+        for i in range(self.option_count, len(attempts)):
+            self.add_option(Option(self._prompt(i, attempts[i]), id=str(i)))
+
+        if follow and self.option_count:
+            self.highlighted = self.option_count - 1
+
+
+class AttemptSummary(VerticalScroll):
+    DEFAULT_CSS = """
+    AttemptSummary {
+        width: 1fr;
+        height: 1fr;
+        border: round $primary;
+        background: $background;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._shown: tuple[int, AttemptResult] | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="summary-body")
+
+    def on_mount(self) -> None:
+        self.border_title = "Summary"
+
+    def show(self, index: int, attempt: Attempt) -> None:
+        # Completed attempts are rendered once: rebuilding the diff Syntax
+        # every second would be wasteful and disturb the user's scroll
+        # position. In-progress attempts re-render on every tick so the
+        # step/duration metrics stay live.
+        key = (index, attempt.result)
+        if key == self._shown and attempt.result != AttemptResult.IN_PROGRESS:
+            return
+        self._shown = key
+
+        self.border_title = f"Attempt {index + 1}" + (
+            f" · {attempt.commit.subject}" if attempt.commit else ""
+        )
+        self.query_one("#summary-body", Static).update(self._summary(attempt))
+
+    # Not named _render(): Widget._render() is part of Textual's rendering
+    # pipeline.
+    def _summary(self, attempt: Attempt) -> rich.console.Group:
+        parts: list[rich.console.RenderableType] = [
+            self._headline(attempt),
+            rich.text.Text(),
+            self._metrics(attempt),
+            rich.text.Text(),
+        ]
+
+        if attempt.commit:
+            parts.append(_section("commit"))
+            parts.append(self._commit(attempt.commit))
+            rows = [
+                r
+                for r in attempt.benchmark_results
+                if r.delta_time_pct != 0 or r.delta_insn not in (None, 0)
+            ]
+            if rows:
+                parts.append(rich.text.Text())
+                parts.append(_section("benchmarks"))
+                parts.append(
+                    compare_table(rows, attempt.commit.parent_sha, attempt.commit.sha)
+                )
+            parts.append(rich.text.Text())
+            parts.append(_section("diff"))
+            parts.append(
+                rich.syntax.Syntax(
+                    attempt.commit.diff,
+                    "diff",
+                    theme="solarized-light",
+                    background_color=_CODE_BACKGROUND,
+                )
+            )
+        elif attempt.result == AttemptResult.IN_PROGRESS:
+            parts.append(rich.text.Text("attempt in progress", style="dim italic"))
+        else:
+            parts.append(
+                rich.text.Text(
+                    "no commit: the attempt did not reach the commit stage",
+                    style="dim italic",
+                )
+            )
+
+        return rich.console.Group(*parts)
+
+    def _headline(self, attempt: Attempt) -> rich.text.Text:
+        text = rich.text.Text(no_wrap=True)
+        text.append(
+            attempt.result.value, style=f"bold {_result_style(attempt.result)}"
+        )
+        if attempt.result == AttemptResult.IN_PROGRESS:
+            text.append(" · ", style="dim")
+            text.append(attempt.step.value, style="yellow")
+        if attempt.commit:
+            text.append(" · commit ", style="dim")
+            text.append(attempt.commit.sha[:SHORT_SHA_LEN], style="bold yellow")
+        return text
+
+    def _metrics(self, attempt: Attempt) -> rich.table.Table:
+        secs = int(attempt.duration)
+
+        row = rich.table.Table.grid(padding=(0, 1))
+        row.add_row(
+            _stat_box(
+                "ΔTime",
+                rich.text.Text(
+                    f"{attempt.delta_pct:+.2f}%",
+                    style=f"bold {_delta_style(attempt.delta_pct)}",
+                ),
+            ),
+            _stat_box("Duration", f"{secs // 60}m {secs % 60}s"),
+            _stat_box("Cost", f"${attempt.cost:.2f}"),
+        )
+        return row
+
+    def _commit(self, commit: CommitInfo) -> rich.text.Text:
+        text = rich.text.Text()
+        text.append(f"{commit.sha[:SHORT_SHA_LEN]} ", style="bold yellow")
+        text.append(commit.subject, style="bold")
+        if commit.body:
+            text.append("\n\n")
+            text.append(commit.body, style="dim")
+        return text
+
+
+class AttemptsPane(Horizontal):
+    DEFAULT_CSS = """
+    AttemptsPane {
+        height: 1fr;
+    }
+    """
+
+    def __init__(self, history: History) -> None:
+        super().__init__()
+        self._history = history
+
+    def compose(self) -> ComposeResult:
+        yield AttemptList(self._history)
+        yield AttemptSummary()
+
+    def on_option_list_option_highlighted(
+        self, event: textual.widgets.OptionList.OptionHighlighted
+    ) -> None:
+        self.query_one(AttemptSummary).show(
+            event.option_index, self._history.attempts[event.option_index]
+        )
+
+    def refresh_attempts(self) -> None:
+        self.query_one(AttemptList).refresh_attempts()
+
+        index = self.query_one(AttemptList).highlighted
+        if index is not None:
+            self.query_one(AttemptSummary).show(index, self._history.attempts[index])
 
 
 class StatColumn(Static):
@@ -257,6 +556,11 @@ class StatsBar(Vertical):
 
 class Optimizer(App):
     TITLE = "bfoptimizer"
+    CSS = """
+    TabbedContent {
+        height: 1fr;
+    }
+    """
 
     def __init__(self, history: History, worker: Callable[[], Awaitable[None]]) -> None:
         super().__init__()
@@ -270,7 +574,11 @@ class Optimizer(App):
         yield MetaLine(self._history)
         yield Static()
         yield StatsBar(self._history)
-        yield LogView()
+        with TabbedContent(initial="tab-logs"):
+            with TabPane("Logs", id="tab-logs"):
+                yield LogView()
+            with TabPane("Attempts", id="tab-attempts"):
+                yield AttemptsPane(self._history)
 
     def on_mount(self) -> None:
         self.theme = "solarized-light"
@@ -283,9 +591,13 @@ class Optimizer(App):
         logger.setLevel(logging.DEBUG)
 
         # The meta line only shows immutable run metadata: render it once,
-        # only the stats need the periodic refresh.
+        # only the stats and attempts need the periodic refresh.
         self.query_one(MetaLine).refresh_meta()
-        self.query_one(StatsBar).refresh_stats()
-        self.set_interval(1, self.query_one(StatsBar).refresh_stats)
+        self._refresh()
+        self.set_interval(1, self._refresh)
 
         self.run_worker(self._worker(), exclusive=True)
+
+    def _refresh(self) -> None:
+        self.query_one(StatsBar).refresh_stats()
+        self.query_one(AttemptsPane).refresh_attempts()


### PR DESCRIPTION
Add `bfoptimizer` tool to iterate over bpfilter's source code and optimize the bytecode generation logic. This tool is designed to improve bpfilter's sources, it's not used at runtime.

`bfoptimizer` uses Python Textual module to create a TUI and track the AI iterations (`--iterations`) over the bpfilter codebase. Each run of the optimizer will:
- Use Claude to draft a plan, with general instructions and run-specific instructions (using `--hint`)
- Use Claude to implement the optimization according to the plan defined in the previous step
- Commit the changes (Claude creates the commit subject and body)
- Fix the code style, build, and test
- Run `bfbencher` (all `bfbencher` options are accessible), ignoring irrelevant/volatile tests (bfcli tests which are not affected by the optimizer, logs and set tests which are more volatile). If the optimization provides better results than the baseline, the commit is kept; otherwise it is discarded.

Only Claude is supported for now, reading `ANTHROPIC_API_KEY` from the environment variables.

The TUI will show the overall run progress (cumulative progress, time, cost...) as well as three tabs:
- Logs: logs of the current attempt
- Attempts: all the attempts from this run, with the metrics, summary of the plan, benchmark results (if any), and diff (if any)
- Progress: plot of the attempts results over time and cumulative progress

It's worth noting that benchmarking results used to decide on whether to keep an optimization or not are only relevant if run on a dedicate host, that can ensure benchmark results are isolated and reproducible.

