### PR TITLE
lib: logger: snapshot the error code before logging it

### DIFF
--- a/src/libbpfilter/include/bpfilter/logger.h
+++ b/src/libbpfilter/include/bpfilter/logger.h
@@ -117,12 +117,13 @@ enum bf_log_level
  */
 #define _bf_log_code_impl(level, color, code, fmt, ...)                        \
     ({                                                                         \
+        const int __code = (code);                                             \
         if ((level) >= bf_log_get_level()) {                                   \
             (void)fprintf(stderr, _bf_logger_prefix_fmt fmt ": %s\n",          \
                           _bf_logger_prefix_fmt_args(level, color),            \
-                          ##__VA_ARGS__, bf_strerror(code));                   \
+                          ##__VA_ARGS__, bf_strerror(__code));                 \
         }                                                                      \
-        (code) < 0 ? (code) : -(code);                                         \
+        __code < 0 ? __code : -__code;                                         \
     })
 
 #define bf_err_r(code, fmt, ...)                                               \


### PR DESCRIPTION
`_bf_log_code_impl()` evaluates its code argument after the `fprintf()` call: when a caller passes errno and the write to stderr fails, the macro returns the errno set by `fprintf()` instead of the original error. With stderr connected to a pipe whose reader is gone (and SIGPIPE ignored), every `bf_err_r(errno, ...)` call site returns `-EPIPE`, masking the actual failure. `bf_strerror()` can clobber errno the same way through `strerror_r()`.

Snapshot the code into a local before logging so it is evaluated exactly once, before anything that could modify errno.