### PR TITLE
lib: matcher: add gre to the known IP protocol names

### DIFF
--- a/src/libbpfilter/matcher.c
+++ b/src/libbpfilter/matcher.c
@@ -1615,9 +1615,9 @@ static const char *_bf_ipproto_strs[UINT8_MAX + 1] = {
     [IPPROTO_HOPOPTS] = "hop",   [IPPROTO_ICMP] = "icmp",
     [IPPROTO_IGMP] = "igmp",     [IPPROTO_TCP] = "tcp",
     [IPPROTO_UDP] = "udp",       [IPPROTO_ROUTING] = "routing",
-    [IPPROTO_FRAGMENT] = "frag", [IPPROTO_AH] = "ah",
-    [IPPROTO_DSTOPTS] = "dst",   [IPPROTO_ICMPV6] = "icmpv6",
-    [IPPROTO_MH] = "mh",
+    [IPPROTO_FRAGMENT] = "frag", [IPPROTO_GRE] = "gre",
+    [IPPROTO_AH] = "ah",         [IPPROTO_DSTOPTS] = "dst",
+    [IPPROTO_ICMPV6] = "icmpv6", [IPPROTO_MH] = "mh",
 };
 
 const char *bf_ipproto_to_str(uint8_t ipproto)

--- a/tests/e2e/CMakeLists.txt
+++ b/tests/e2e/CMakeLists.txt
@@ -135,6 +135,7 @@ bf_add_e2e_shell_test(e2e parsing/udp_dport.sh)
 bf_add_e2e_shell_test(e2e parsing/udp_sport.sh)
 
 bf_add_e2e_shell_test(e2e rules/action_order.sh ROOT)
+bf_add_e2e_shell_test(e2e rules/gre.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/icmp_tc.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/icmp_xdp.sh ROOT)
 bf_add_e2e_shell_test(e2e rules/log.sh ROOT)

--- a/tests/e2e/e2e_test_util.sh
+++ b/tests/e2e/e2e_test_util.sh
@@ -123,5 +123,13 @@ trap 'cleanup 1; exit 1' INT TERM
 #
 ################################################################################
 
+# Print the packet counter of rule INDEX in chain NAME, read from the chain's
+# pinned counters map.
+#
+# Usage: get_counter NAME INDEX
+get_counter() {
+    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
+}
+
 cleanup
 mkdir -p ${WORKDIR}

--- a/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
@@ -68,10 +68,6 @@ udp4_connect() {
     ${FROM_NS} bash -c "echo \$\$ > ${CGROUP_PATH}/cgroup.procs && echo > /dev/udp/$1/$2" 2>/dev/null
 }
 
-get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
-}
-
 # meta.l3_proto
 ${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 log counter DROP"
 (! tcp4_connect ${HOST_IP_ADDR} 9990)

--- a/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
@@ -78,10 +78,6 @@ s.close()
 "
 }
 
-get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
-}
-
 # meta.l3_proto
 ${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 log counter DROP"
 (! tcp6_connect ${HOST_IP6_ADDR} 9990)

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
@@ -61,10 +61,6 @@ s.close()
 "
 }
 
-get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
-}
-
 # meta.l3_proto
 ${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG4{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv4 log counter DROP"
 (! udp4_sendmsg ${HOST_IP_ADDR} 9990)

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
@@ -65,10 +65,6 @@ s.close()
 "
 }
 
-get_counter() {
-    ${FROM_NS} bpftool map dump pinned ${WORKDIR}/bpf/bpfilter/$1/bf_cmap | jq ".[$2].values | map(.value.count) | add"
-}
-
 # meta.l3_proto
 ${FROM_NS} ${BFCLI} chain set --from-str "chain c BF_HOOK_CGROUP_SOCK_ADDR_SENDMSG6{cgpath=${CGROUP_PATH}} ACCEPT rule meta.l3_proto eq ipv6 log counter DROP"
 (! udp6_sendmsg ${HOST_IP6_ADDR} 9990)

--- a/tests/e2e/namespace/host_to_netns.sh
+++ b/tests/e2e/namespace/host_to_netns.sh
@@ -8,5 +8,5 @@ make_sandbox
 ping -c 1 -W 0.1 ${NS_IP_ADDR}
 ${FROM_NS} ${BFCLI} ruleset set --from-str "chain xdp BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp counter DROP"
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-${FROM_NS} ${BFCLI} chain get --name xdp | awk '/ip4.proto eq icmp/{getline; print $2}' | grep -q "^1$" && exit 0 || exit 1
+test "$(get_counter xdp 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/namespace/netns_to_host.sh
+++ b/tests/e2e/namespace/netns_to_host.sh
@@ -8,5 +8,5 @@ make_sandbox
 ${FROM_NS} ping -c 1 -W 0.1 ${HOST_IP_ADDR}
 ${FROM_NS} ${BFCLI} ruleset set --from-str "chain tc BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp log link,internet counter DROP"
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-${FROM_NS} ${BFCLI} chain get --name tc | awk '/log link,internet/{getline; print $2}' | grep -q "^1$"
+test "$(get_counter tc 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/parsing/ip4_proto.sh
+++ b/tests/e2e/parsing/ip4_proto.sh
@@ -4,6 +4,7 @@
 
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq icmp counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq ICMPv6 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq gre counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq 0 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq 17 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto eq 255 counter DROP"
@@ -16,6 +17,7 @@ ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4
 
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not icmp counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not ICMPv6 counter DROP"
+${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not gre counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not 0 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not 17 counter DROP"
 ${BFCLI} ruleset set --dry-run --from-str "chain xdp BF_HOOK_XDP ACCEPT rule ip4.proto not 255 counter DROP"

--- a/tests/e2e/rules/gre.sh
+++ b/tests/e2e/rules/gre.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+. "$(dirname "$0")"/../e2e_test_util.sh
+
+GRE_HOST="gre_h_${_SHORT_ID}"
+GRE_NS="gre_n_${_SHORT_ID}"
+GRE_HOST_IP="172.16.0.1/30"
+GRE_NS_IP="172.16.0.2/30"
+GRE_NS_IP_ADDR="172.16.0.2"
+
+# The host-side tunnel device lives in the host namespace and is not removed
+# with the sandbox, delete it explicitly.
+cleanup() {
+    ip link del ${GRE_HOST} 2>/dev/null || true
+    destroy_sandbox
+}
+
+make_sandbox
+
+# GRE tunnel over the veth pair: inner traffic is encapsulated in IPv4
+# protocol 47 packets between HOST_IP_ADDR and NS_IP_ADDR.
+ip link del ${GRE_HOST} 2>/dev/null || true
+ip link add ${GRE_HOST} type gre local ${HOST_IP_ADDR} remote ${NS_IP_ADDR}
+ip addr add ${GRE_HOST_IP} dev ${GRE_HOST}
+ip link set ${GRE_HOST} up
+
+${FROM_NS} ip link add ${GRE_NS} type gre local ${NS_IP_ADDR} remote ${HOST_IP_ADDR}
+${FROM_NS} ip addr add ${GRE_NS_IP} dev ${GRE_NS}
+${FROM_NS} ip link set ${GRE_NS} up
+
+# The tunnel carries traffic before any filtering is applied
+ping -c 1 -W 0.5 ${GRE_NS_IP_ADDR}
+
+# Drop GRE (IPv4 protocol 47) entering the namespace
+${FROM_NS} ${BFCLI} ruleset set --from-str "chain xdp BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto eq gre counter DROP"
+
+# Encapsulated traffic is dropped, non-GRE traffic still goes through
+(! ping -c 1 -W 0.5 ${GRE_NS_IP_ADDR})
+ping -c 1 -W 0.5 ${NS_IP_ADDR}
+
+# Exactly one GRE packet (the dropped echo request) hit the rule
+test "$(get_counter xdp 0)" = "1"
+
+${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/rules/icmp_tc.sh
+++ b/tests/e2e/rules/icmp_tc.sh
@@ -7,5 +7,5 @@ make_sandbox
 ${FROM_NS} ping -c 1 -W 0.1 ${NS_IP_ADDR}
 ${FROM_NS} ${BFCLI} ruleset set --from-str "chain xdp BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule icmp.type eq echo-request icmp.code eq 0 counter DROP"
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-${FROM_NS} ${BFCLI} chain get --name xdp | awk '/icmp.code eq 0/{getline; print $2}' | grep -q "^1$" && exit 0 || exit 1
+test "$(get_counter xdp 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/rules/icmp_xdp.sh
+++ b/tests/e2e/rules/icmp_xdp.sh
@@ -7,5 +7,5 @@ make_sandbox
 ${FROM_NS} ping -c 1 -W 0.1 ${NS_IP_ADDR}
 ${FROM_NS} ${BFCLI} ruleset set --from-str "chain xdp BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT rule icmp.type eq echo-request icmp.code eq 0 log transport,internet counter DROP"
 (! ping -c 1 -W 0.1 ${NS_IP_ADDR})
-${FROM_NS} ${BFCLI} chain get --name xdp | awk '/log internet,transport/{getline; print $2}' | grep -q "^1$" && exit 0 || exit 1
+test "$(get_counter xdp 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush

--- a/tests/e2e/rules/redirect.sh
+++ b/tests/e2e/rules/redirect.sh
@@ -2,10 +2,6 @@
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 
-get_counter() {
-    ${FROM_NS} ${BFCLI} chain get --name "$1" | awk '/counters [0-9]+ packets/{print $2}'
-}
-
 make_sandbox
 
 # Invalid: REDIRECT not supported for NF/cgroup_skb hooks, and XDP only supports 'out'
@@ -30,25 +26,25 @@ REDIR1_IFINDEX=$(${FROM_NS} ip -o link show redir1 | awk '{print $1}' | cut -d: 
 # XDP redirect: packets on veth_ns redirected out redir0, counted at redir1
 ${FROM_NS} ${BFCLI} chain set --from-str "chain cnt BF_HOOK_XDP{ifindex=${REDIR1_IFINDEX}} ACCEPT rule ip4.proto icmp counter ACCEPT"
 ${FROM_NS} ${BFCLI} chain set --from-str "chain redir BF_HOOK_XDP{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp REDIRECT ${REDIR0_IFINDEX} out"
-test "$(get_counter cnt)" = "0"
+test "$(get_counter cnt 0)" = "0"
 ping -c 1 -W 1 ${NS_IP_ADDR} || true
-test "$(get_counter cnt)" = "1"
+test "$(get_counter cnt 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush
 
 # TC ingress redirect: packets redirected to redir0's ingress
 ${FROM_NS} ${BFCLI} chain set --from-str "chain cnt BF_HOOK_TC_INGRESS{ifindex=${REDIR0_IFINDEX}} ACCEPT rule ip4.proto icmp counter ACCEPT"
 ${FROM_NS} ${BFCLI} chain set --from-str "chain redir BF_HOOK_TC_INGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp REDIRECT ${REDIR0_IFINDEX} in"
-test "$(get_counter cnt)" = "0"
+test "$(get_counter cnt 0)" = "0"
 ping -c 1 -W 1 ${NS_IP_ADDR} || true
-test "$(get_counter cnt)" = "1"
+test "$(get_counter cnt 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush
 
 # TC egress redirect with interface name: packets redirected out redir0, counted at redir1
 ${FROM_NS} ${BFCLI} chain set --from-str "chain cnt BF_HOOK_TC_INGRESS{ifindex=${REDIR1_IFINDEX}} ACCEPT rule ip4.proto icmp counter ACCEPT"
 ${FROM_NS} ${BFCLI} chain set --from-str "chain redir BF_HOOK_TC_EGRESS{ifindex=${NS_IFINDEX}} ACCEPT rule ip4.proto icmp REDIRECT redir0 out"
-test "$(get_counter cnt)" = "0"
+test "$(get_counter cnt 0)" = "0"
 ping -c 1 -W 1 ${NS_IP_ADDR} || true
-test "$(get_counter cnt)" = "1"
+test "$(get_counter cnt 0)" = "1"
 ${FROM_NS} ${BFCLI} ruleset flush
 
 ${FROM_NS} ip link del redir0

--- a/tests/unit/libbpfilter/matcher.c
+++ b/tests/unit/libbpfilter/matcher.c
@@ -434,6 +434,7 @@ static void ipproto_conversions(void **state)
     assert_non_null(bf_ipproto_to_str(6)); // TCP
     assert_non_null(bf_ipproto_to_str(17)); // UDP
     assert_non_null(bf_ipproto_to_str(1)); // ICMP
+    assert_string_equal(bf_ipproto_to_str(47), "gre");
 
     // Test from string
     assert_ok(bf_ipproto_from_str("tcp", &ipproto));
@@ -441,6 +442,9 @@ static void ipproto_conversions(void **state)
 
     assert_ok(bf_ipproto_from_str("udp", &ipproto));
     assert_int_equal(ipproto, 17);
+
+    assert_ok(bf_ipproto_from_str("gre", &ipproto));
+    assert_int_equal(ipproto, 47);
 
     // Test invalid
     assert_err(bf_ipproto_from_str("invalid", &ipproto));


### PR DESCRIPTION
GRE traffic can only be matched by its protocol number (ip4.proto eq 47). Add "gre" to the known IP protocol names so rules can refer to it by name through `ip4.proto`, `ip6.nexthdr`, and `meta.l4_proto`, and bfcli prints it back as such, with the matching unit-test round-trip and bfcli parsing assertions.

The new end-to-end test validates GRE filtering against real traffic: it creates a GRE tunnel over the sandbox veth pair, verifies the tunnel carries pings, then attaches an XDP chain dropping `ip4.proto eq gre` on the namespace interface. Encapsulated traffic is dropped while plain traffic still goes through, and the rule counter accounts for exactly the
dropped echo request.

Asserting on that counter surfaced some duplication: the four `cgroup_sock_addr` hook tests each define the same bpftool-based `get_counter()` helper reading the chain's pinned counters map, while other tests parse bfcli's output with ad-hoc awk pipelines that must match the last line printed before the counters and break if the rule's printed form changes. The first commit moves the bpftool-based helper to `e2e_test_util.sh` and converts every test asserting on rule counters to
use it.
