### PR TITLE
lib: set: support port ranges in set elements

### DIFF
--- a/src/libbpfilter/set.c
+++ b/src/libbpfilter/set.c
@@ -6,7 +6,9 @@
 #include "bpfilter/set.h"
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -161,9 +163,15 @@ int bf_set_add_elem_raw(struct bf_set *set, const char *raw_elem)
 {
     _cleanup_free_ void *elem = NULL;
     _cleanup_free_ char *_raw_elem = NULL;
+    const struct bf_matcher_ops *range_in_ops = NULL;
     char *tmp, *saveptr, *token;
     size_t elem_offset = 0;
     size_t comp_idx = 0;
+    size_t range_offset = 0;
+    enum bf_matcher_type range_type = 0;
+    uint16_t range_start = 0;
+    uint16_t range_end = 0;
+    bool has_range = false;
     int r;
 
     assert(set);
@@ -183,6 +191,7 @@ int bf_set_add_elem_raw(struct bf_set *set, const char *raw_elem)
     tmp = _raw_elem;
     while ((token = strtok_r(tmp, ",", &saveptr))) {
         const struct bf_matcher_ops *ops;
+        const struct bf_matcher_ops *range_ops;
 
         if (comp_idx >= set->n_comps) {
             return bf_err_r(
@@ -199,11 +208,41 @@ int bf_set_add_elem_raw(struct bf_set *set, const char *raw_elem)
                             bf_matcher_type_to_str(set->key[comp_idx]));
         }
 
-        r = ops->parse(set->key[comp_idx], BF_MATCHER_IN, elem + elem_offset,
-                       token);
-        if (r) {
-            return bf_err_r(r, "failed to parse set element component '%s'",
-                            token);
+        /* A component is treated as a range if it contains a '-' and its matcher
+         * type supports the RANGE operator (ports today). This defers writing
+         * the component's slot until the range is expanded below. */
+        range_ops = bf_matcher_get_ops(set->key[comp_idx], BF_MATCHER_RANGE);
+        if (strchr(token, '-') && range_ops) {
+            uint16_t bounds[2];
+
+            if (has_range) {
+                return bf_err_r(
+                    -EINVAL,
+                    "set element '%s' has more than one ranged component, only one is supported",
+                    raw_elem);
+            }
+
+            r = range_ops->parse(set->key[comp_idx], BF_MATCHER_RANGE, bounds,
+                                 token);
+            if (r) {
+                return bf_err_r(
+                    r, "failed to parse set element range component '%s'",
+                    token);
+            }
+
+            has_range = true;
+            range_offset = elem_offset;
+            range_type = set->key[comp_idx];
+            range_in_ops = ops;
+            range_start = bounds[0];
+            range_end = bounds[1];
+        } else {
+            r = ops->parse(set->key[comp_idx], BF_MATCHER_IN,
+                           elem + elem_offset, token);
+            if (r) {
+                return bf_err_r(r, "failed to parse set element component '%s'",
+                                token);
+            }
         }
 
         elem_offset += ops->ref_payload_size;
@@ -216,11 +255,43 @@ int bf_set_add_elem_raw(struct bf_set *set, const char *raw_elem)
                         raw_elem);
     }
 
-    r = bf_hashset_add(&set->elems, &elem);
-    if (r == -EEXIST)
+    if (!has_range) {
+        r = bf_hashset_add(&set->elems, &elem);
+        if (r == -EEXIST)
+            return 0;
+        if (r)
+            return bf_err_r(r, "failed to insert element into set");
+
         return 0;
-    if (r)
-        return bf_err_r(r, "failed to insert element into set");
+    }
+
+    /* Expand the ranged component into one element per value in [start, end].
+     * A uint32_t counter is used so a range ending at UINT16_MAX terminates. */
+    for (uint32_t value = range_start; value <= range_end; ++value) {
+        _cleanup_free_ void *row = NULL;
+        char valbuf[16];
+
+        (void)snprintf(valbuf, sizeof(valbuf), "%" PRIu32, value);
+
+        r = range_in_ops->parse(range_type, BF_MATCHER_IN, elem + range_offset,
+                                valbuf);
+        if (r) {
+            return bf_err_r(r, "failed to parse expanded range value '%s'",
+                            valbuf);
+        }
+
+        row = malloc(set->elem_size);
+        if (!row)
+            return bf_err_r(-ENOMEM, "failed to allocate a new set element");
+
+        memcpy(row, elem, set->elem_size);
+
+        r = bf_hashset_add(&set->elems, &row);
+        if (r == -EEXIST)
+            continue;
+        if (r)
+            return bf_err_r(r, "failed to insert element into set");
+    }
 
     return 0;
 }

--- a/tests/unit/libbpfilter/set.c
+++ b/tests/unit/libbpfilter/set.c
@@ -277,6 +277,82 @@ static void new_from_raw_multiple_keys(void **state)
     assert_int_equal(bf_hashset_size(&set->elems), 2);
 }
 
+static void new_from_raw_port_range(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // A range component expands into one element per value in [start, end].
+    // Elements are separated by ';' (',' separates components within an
+    // element), so the third element '33-44' expands to 12 ports.
+    assert_ok(bf_set_new_from_raw(&set, "test_range", "(tcp.dport)",
+                                  "{11; 22; 33-44}"));
+    assert_non_null(set);
+    assert_int_equal(set->n_comps, 1);
+    assert_int_equal(set->key[0], BF_MATCHER_TCP_DPORT);
+    assert_int_equal(bf_hashset_size(&set->elems), 14); // 11, 22, 33..44
+}
+
+static void new_from_raw_port_range_boundaries(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // Smallest range: 0 and 1.
+    assert_ok(bf_set_new_from_raw(&set, "test_low", "(tcp.dport)", "{0-1}"));
+    assert_int_equal(bf_hashset_size(&set->elems), 2);
+    bf_set_free(&set);
+
+    // Degenerate single-value range at the upper bound.
+    assert_ok(bf_set_new_from_raw(&set, "test_high", "(tcp.dport)",
+                                  "{65535-65535}"));
+    assert_int_equal(bf_hashset_size(&set->elems), 1);
+}
+
+static void new_from_raw_port_range_invalid(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // End before start.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{44-33}"));
+
+    // Missing end bound.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{33-}"));
+
+    // Missing start bound.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{-44}"));
+}
+
+static void new_from_raw_range_multi_comp(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // A range in one component of a multi-component key expands that component
+    // while the others stay fixed.
+    assert_ok(bf_set_new_from_raw(&set, "test_multi_range",
+                                  "(ip4.daddr, tcp.sport)", "{1.2.3.4, 80-82}"));
+    assert_non_null(set);
+    assert_int_equal(set->n_comps, 2);
+    assert_int_equal(bf_hashset_size(&set->elems), 3); // ports 80, 81, 82
+}
+
+static void new_from_raw_range_multi_comp_both(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // Only one ranged component per element is supported.
+    assert_err(bf_set_new_from_raw(&set, "test_both_ranges",
+                                   "(tcp.sport, tcp.dport)", "{1-2, 3-4}"));
+}
+
 static void new_from_raw_invalid(void **state)
 {
     _free_bf_set_ struct bf_set *set = NULL;
@@ -472,6 +548,11 @@ int main(void)
         cmocka_unit_test(dump_empty),
         cmocka_unit_test(new_from_raw),
         cmocka_unit_test(new_from_raw_multiple_keys),
+        cmocka_unit_test(new_from_raw_port_range),
+        cmocka_unit_test(new_from_raw_port_range_boundaries),
+        cmocka_unit_test(new_from_raw_port_range_invalid),
+        cmocka_unit_test(new_from_raw_range_multi_comp),
+        cmocka_unit_test(new_from_raw_range_multi_comp_both),
         cmocka_unit_test(new_from_raw_invalid),
         cmocka_unit_test(add_many_basic),
         cmocka_unit_test(add_many_mismatched_key_count),

--- a/tests/unit/libbpfilter/set.c
+++ b/tests/unit/libbpfilter/set.c
@@ -277,6 +277,83 @@ static void new_from_raw_multiple_keys(void **state)
     assert_int_equal(bf_hashset_size(&set->elems), 2);
 }
 
+static void new_from_raw_port_range(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // A range component expands into one element per value in [start, end].
+    // Elements are separated by ';' (',' separates components within an
+    // element), so the third element '33-44' expands to 12 ports.
+    assert_ok(bf_set_new_from_raw(&set, "test_range", "(tcp.dport)",
+                                  "{11; 22; 33-44}"));
+    assert_non_null(set);
+    assert_int_equal(set->n_comps, 1);
+    assert_int_equal(set->key[0], BF_MATCHER_TCP_DPORT);
+    assert_int_equal(bf_hashset_size(&set->elems), 14); // 11, 22, 33..44
+}
+
+static void new_from_raw_port_range_boundaries(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // Smallest range: 0 and 1.
+    assert_ok(bf_set_new_from_raw(&set, "test_low", "(tcp.dport)", "{0-1}"));
+    assert_int_equal(bf_hashset_size(&set->elems), 2);
+    bf_set_free(&set);
+
+    // Degenerate single-value range at the upper bound.
+    assert_ok(
+        bf_set_new_from_raw(&set, "test_high", "(tcp.dport)", "{65535-65535}"));
+    assert_int_equal(bf_hashset_size(&set->elems), 1);
+}
+
+static void new_from_raw_port_range_invalid(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // End before start.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{44-33}"));
+
+    // Missing end bound.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{33-}"));
+
+    // Missing start bound.
+    assert_err(bf_set_new_from_raw(&set, "test", "(tcp.dport)", "{-44}"));
+}
+
+static void new_from_raw_range_multi_comp(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // A range in one component of a multi-component key expands that component
+    // while the others stay fixed.
+    assert_ok(bf_set_new_from_raw(&set, "test_multi_range",
+                                  "(ip4.daddr, tcp.sport)",
+                                  "{1.2.3.4, 80-82}"));
+    assert_non_null(set);
+    assert_int_equal(set->n_comps, 2);
+    assert_int_equal(bf_hashset_size(&set->elems), 3); // ports 80, 81, 82
+}
+
+static void new_from_raw_range_multi_comp_both(void **state)
+{
+    _free_bf_set_ struct bf_set *set = NULL;
+
+    (void)state;
+
+    // Only one ranged component per element is supported.
+    assert_err(bf_set_new_from_raw(&set, "test_both_ranges",
+                                   "(tcp.sport, tcp.dport)", "{1-2, 3-4}"));
+}
+
 static void new_from_raw_invalid(void **state)
 {
     _free_bf_set_ struct bf_set *set = NULL;
@@ -472,6 +549,11 @@ int main(void)
         cmocka_unit_test(dump_empty),
         cmocka_unit_test(new_from_raw),
         cmocka_unit_test(new_from_raw_multiple_keys),
+        cmocka_unit_test(new_from_raw_port_range),
+        cmocka_unit_test(new_from_raw_port_range_boundaries),
+        cmocka_unit_test(new_from_raw_port_range_invalid),
+        cmocka_unit_test(new_from_raw_range_multi_comp),
+        cmocka_unit_test(new_from_raw_range_multi_comp_both),
         cmocka_unit_test(new_from_raw_invalid),
         cmocka_unit_test(add_many_basic),
         cmocka_unit_test(add_many_mismatched_key_count),


### PR DESCRIPTION
## Summary

Implements port ranges in set elements (#562).

`bf_set_add_elem_raw()` now recognises range syntax (`START-END`) in a set
element's components and expands it into individual set elements. For example:

```
(tcp.dport) in { 11; 22; 33-44 }
```

produces a set containing `{ 11, 22, 33, 34, …, 44 }` (14 elements).

Range detection reuses the `BF_MATCHER_RANGE` parsing that already backs the
standalone `range` matcher operator — a component is treated as a range only
when the token contains a `-` and the component's matcher type registers
`BF_MATCHER_RANGE` ops. This scopes the feature to the matcher types that
already support ranges (ports today) without hardcoding anything port-specific,
and non-range / multi-component parsing is unchanged.

## Behaviour

- Each value in `[start, end]` is expanded into its own element and inserted
  into the set's hashset, deduplicated like any other element.
- Expanded values are re-parsed through the existing single-value
  (`BF_MATCHER_IN`) path, so their in-memory representation is byte-identical to
  an element written as a plain value.
- Range bounds are validated by the existing `_bf_parse_l4_port_range()`:
  both bounds must be valid decimal ports `<= 65535`, and `start <= end`.
  `44-33`, `33-`, and `-44` are rejected.

## Scope / limitations

A couple of things are intentionally left out to keep this a minimal, focused
change — flagging them for maintainer input:

- **Printing is unchanged.** Expanded ranges are printed element-by-element,
  not re-factored back into a `START-END` range. This is the open question
  raised in #562; happy to add range factorization on `ruleset get` in a
  follow-up if that's the preferred direction.
- **One ranged component per element.** A set element with more than one ranged
  component (e.g. `(tcp.sport, tcp.dport) in { 1-2, 3-4 }`) returns `-EINVAL`
  rather than performing a Cartesian expansion. This avoids surprising blow-up
  in element count; can revisit if Cartesian expansion is wanted.

## A note on element separators

The issue's example is written as `{ 11, 22, 33-44 }`, but bpfilter separates
set **elements** with `;` and **components within an element** with `,`
(e.g. `{ 80; 443 }` vs `(ip4.daddr, tcp.sport) in { 1.2.3.4, 80 }`). So the
range form is `{ 11; 22; 33-44 }`. This PR does not change the grammar, so the
comma-separated form from the issue's example still parses as multiple
components. If treating `,` as an element separator for single-component sets
is desired, that's a separate grammar change and I'm glad to take it on
separately.

## Tests

Added unit tests in `tests/unit/libbpfilter/set.c`:

- single-component range expansion (`{11; 22; 33-44}` → 14 elements)
- range boundaries (`0-1`, degenerate `65535-65535`)
- invalid ranges (`44-33`, `33-`, `-44`)
- a range in one component of a two-component key (`{1.2.3.4, 80-82}` → 3)
- ranges in both components of an element (rejected)

All `unit.libbpfilter.set` tests pass (28/28).
