### PR TITLE
build: fix Fedora Rawhide build in CI

### DIFF
--- a/.github/fedora-rawhide.Dockerfile
+++ b/.github/fedora-rawhide.Dockerfile
@@ -2,6 +2,8 @@ FROM fedora:rawhide
 
 # Rawhide does not have an `updates` repo (it is the rolling development
 # branch; all updates land directly in `fedora`).
+# Rawhide only ships versioned libgit2 packages, hence libgit2_1.9-devel
+# instead of libgit2-devel.
 RUN dnf --disablerepo=* --enablerepo=fedora --nodocs --setopt=install_weak_deps=False -y install \
     autoconf \
     automake \
@@ -25,7 +27,7 @@ RUN dnf --disablerepo=* --enablerepo=fedora --nodocs --setopt=install_weak_deps=
     lcov \
     libbpf-devel \
     libcmocka-devel \
-    libgit2-devel \
+    libgit2_1.9-devel \
     libpfm-devel \
     libtool \
     pipx \
@@ -34,12 +36,15 @@ RUN dnf --disablerepo=* --enablerepo=fedora --nodocs --setopt=install_weak_deps=
     python3-dateutil \
     python3-furo \
     python3-GitPython \
-    python3-linuxdoc \
+    python3-pip \
     python3-scapy \
     python3-sphinx \
     sed \
     xxd && \
     dnf clean all -y
 
-RUN pipx install --global ast-grep-cli && \
+# python3-linuxdoc is not installable until it is rebuilt against rawhide's
+# current Python, install it from PyPI instead.
+RUN pip install --break-system-packages linuxdoc && \
+    pipx install --global ast-grep-cli && \
     ast-grep --version


### PR DESCRIPTION
## Summary

Fedora Rawhide build fails in CI due to missing libgit2-devel and python3-linuxdoc in the repositories.

libgit2-devel is now a versioned package: libgit2_1.9-devel, and python3-linuxdoc hasn't been built yet, so we install it through pip.

## Related issue

Failed Fedora Rawhide build in CI.

## Testing

None (need to run CI).
