### PR TITLE
tests: add missing copyright headers

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 {
   stdenv,
   lib,

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 {
   description = "bpfilter - eBPF-based packet filtering framework";
 

--- a/tests/benchmarks/bfbencher/__main__.py
+++ b/tests/benchmarks/bfbencher/__main__.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 from . import main
 
 main()

--- a/tests/benchmarks/results.html.j2
+++ b/tests/benchmarks/results.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 <!DOCTYPE html>
 <html lang="en">
 

--- a/tests/benchmarks/summary.html.j2
+++ b/tests/benchmarks/summary.html.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 {#
   Modular benchmark table template.
 

--- a/tests/coverage.css
+++ b/tests/coverage.css
@@ -1,3 +1,4 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
 /* Modern LCOV Coverage Report Styles
    Matching the bfbencher benchmark results design */
 

--- a/tests/e2e/cli/chain_attach.sh
+++ b/tests/e2e/cli/chain_attach.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/chain_get_no_set_content.sh
+++ b/tests/e2e/cli/chain_get_no_set_content.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/chain_load.sh
+++ b/tests/e2e/cli/chain_load.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/chain_set.sh
+++ b/tests/e2e/cli/chain_set.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/chain_update.sh
+++ b/tests/e2e/cli/chain_update.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/chain_update_set.sh
+++ b/tests/e2e/cli/chain_update_set.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/hookopts.sh
+++ b/tests/e2e/cli/hookopts.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/nf_inet_dual_stack.sh
+++ b/tests/e2e/cli/nf_inet_dual_stack.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/options_error.sh
+++ b/tests/e2e/cli/options_error.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/cli/ruleset.sh
+++ b/tests/e2e/cli/ruleset.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/e2e_test_util.sh
+++ b/tests/e2e/e2e_test_util.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 set -eux
 

--- a/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect4.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_connect6.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg4.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
+++ b/tests/e2e/hooks/cgroup_sock_addr_sendmsg6.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/namespace/host_to_netns.sh
+++ b/tests/e2e/namespace/host_to_netns.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/namespace/netns_to_host.sh
+++ b/tests/e2e/namespace/netns_to_host.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/icmp_code.sh
+++ b/tests/e2e/parsing/icmp_code.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/icmp_type.sh
+++ b/tests/e2e/parsing/icmp_type.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/icmpv6_code.sh
+++ b/tests/e2e/parsing/icmpv6_code.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/icmpv6_type.sh
+++ b/tests/e2e/parsing/icmpv6_type.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_daddr.sh
+++ b/tests/e2e/parsing/ip4_daddr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_dnet.sh
+++ b/tests/e2e/parsing/ip4_dnet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_dscp.sh
+++ b/tests/e2e/parsing/ip4_dscp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_proto.sh
+++ b/tests/e2e/parsing/ip4_proto.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_saddr.sh
+++ b/tests/e2e/parsing/ip4_saddr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip4_snet.sh
+++ b/tests/e2e/parsing/ip4_snet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_daddr.sh
+++ b/tests/e2e/parsing/ip6_daddr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_dnet.sh
+++ b/tests/e2e/parsing/ip6_dnet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_dscp.sh
+++ b/tests/e2e/parsing/ip6_dscp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_nexthdr.sh
+++ b/tests/e2e/parsing/ip6_nexthdr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_saddr.sh
+++ b/tests/e2e/parsing/ip6_saddr.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/ip6_snet.sh
+++ b/tests/e2e/parsing/ip6_snet.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_dport.sh
+++ b/tests/e2e/parsing/meta_dport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_flow_hash.sh
+++ b/tests/e2e/parsing/meta_flow_hash.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_flow_probability.sh
+++ b/tests/e2e/parsing/meta_flow_probability.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 set -eux
 set -o pipefail

--- a/tests/e2e/parsing/meta_iface.sh
+++ b/tests/e2e/parsing/meta_iface.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_l3_proto.sh
+++ b/tests/e2e/parsing/meta_l3_proto.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_l4_proto.sh
+++ b/tests/e2e/parsing/meta_l4_proto.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_mark.sh
+++ b/tests/e2e/parsing/meta_mark.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_probability.sh
+++ b/tests/e2e/parsing/meta_probability.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/meta_sport.sh
+++ b/tests/e2e/parsing/meta_sport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/named_set.sh
+++ b/tests/e2e/parsing/named_set.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/set.sh
+++ b/tests/e2e/parsing/set.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/set_empty_index.sh
+++ b/tests/e2e/parsing/set_empty_index.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 # Regression test for set index mismatch when empty sets precede non-empty sets.
 #

--- a/tests/e2e/parsing/tcp_dport.sh
+++ b/tests/e2e/parsing/tcp_dport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/tcp_flags.sh
+++ b/tests/e2e/parsing/tcp_flags.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/tcp_sport.sh
+++ b/tests/e2e/parsing/tcp_sport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/udp_dport.sh
+++ b/tests/e2e/parsing/udp_dport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/parsing/udp_sport.sh
+++ b/tests/e2e/parsing/udp_sport.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/persistence/pin_updated_chain.sh
+++ b/tests/e2e/persistence/pin_updated_chain.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/persistence/restore_attached.sh
+++ b/tests/e2e/persistence/restore_attached.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/persistence/restore_non_attached.sh
+++ b/tests/e2e/persistence/restore_non_attached.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/action_order.sh
+++ b/tests/e2e/rules/action_order.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/gre.sh
+++ b/tests/e2e/rules/gre.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/icmp_tc.sh
+++ b/tests/e2e/rules/icmp_tc.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/icmp_xdp.sh
+++ b/tests/e2e/rules/icmp_xdp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/log.sh
+++ b/tests/e2e/rules/log.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/mark.sh
+++ b/tests/e2e/rules/mark.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/next_tc.sh
+++ b/tests/e2e/rules/next_tc.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/redirect.sh
+++ b/tests/e2e/rules/redirect.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rules/set_grouping.sh
+++ b/tests/e2e/rules/set_grouping.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rulesets/cgroup_skb_egress.bf
+++ b/tests/e2e/rulesets/cgroup_skb_egress.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain cgroup_skb_egress BF_HOOK_CGROUP_SKB_EGRESS ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/cgroup_skb_ingress.bf
+++ b/tests/e2e/rulesets/cgroup_skb_ingress.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain cgroup_skb_ingress BF_HOOK_CGROUP_SKB_INGRESS ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/cgroup_sock_addr_connect4.bf
+++ b/tests/e2e/rulesets/cgroup_sock_addr_connect4.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain cgroup_sock_addr_connect4 BF_HOOK_CGROUP_SOCK_ADDR_CONNECT4 ACCEPT
     rule
         meta.l3_proto eq ipv4

--- a/tests/e2e/rulesets/cgroup_sock_addr_connect6.bf
+++ b/tests/e2e/rulesets/cgroup_sock_addr_connect6.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain cgroup_sock_addr_connect6 BF_HOOK_CGROUP_SOCK_ADDR_CONNECT6 ACCEPT
     rule
         meta.l3_proto eq ipv6

--- a/tests/e2e/rulesets/nf_forward.bf
+++ b/tests/e2e/rulesets/nf_forward.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain nf_forward BF_HOOK_NF_FORWARD ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/nf_local_in.bf
+++ b/tests/e2e/rulesets/nf_local_in.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain nf_local_in BF_HOOK_NF_LOCAL_IN ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/nf_local_out.bf
+++ b/tests/e2e/rulesets/nf_local_out.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain nf_local_out BF_HOOK_NF_LOCAL_OUT ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/nf_post_routing.bf
+++ b/tests/e2e/rulesets/nf_post_routing.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain nf_post_routing BF_HOOK_NF_POST_ROUTING ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/nf_pre_routing.bf
+++ b/tests/e2e/rulesets/nf_pre_routing.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain nf_pre_routing BF_HOOK_NF_PRE_ROUTING ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/rulesets.sh
+++ b/tests/e2e/rulesets/rulesets.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 . "$(dirname "$0")"/../e2e_test_util.sh
 

--- a/tests/e2e/rulesets/tc_egress.bf
+++ b/tests/e2e/rulesets/tc_egress.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain tc_egress BF_HOOK_TC_EGRESS ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/tc_ingress.bf
+++ b/tests/e2e/rulesets/tc_ingress.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain tc_ingress BF_HOOK_TC_INGRESS ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/e2e/rulesets/xdp.bf
+++ b/tests/e2e/rulesets/xdp.bf
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 chain xdp BF_HOOK_XDP ACCEPT
     set my_custom_set (ip4.saddr, ip4.proto) in {
         192.168.1.1, tcp

--- a/tests/fuzz/keywords.dict
+++ b/tests/fuzz/keywords.dict
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # Keywords
 "chain"
 "rule"

--- a/tests/harness/mock.c
+++ b/tests/harness/mock.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
 #include "mock.h"
 
 void bft_mock_clean(bft_mock *mock)

--- a/tests/harness/mock/btf__load_vmlinux_btf.c
+++ b/tests/harness/mock/btf__load_vmlinux_btf.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>

--- a/tests/harness/mock/isatty.c
+++ b/tests/harness/mock/isatty.c
@@ -1,3 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ */
+
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>

--- a/tests/integration/pedantic_c.sh
+++ b/tests/integration/pedantic_c.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 set -eux
 set -o pipefail

--- a/tests/integration/pedantic_cpp.sh
+++ b/tests/integration/pedantic_cpp.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 
 set -eux
 set -o pipefail

--- a/tools/bfoptimizer/__main__.py
+++ b/tools/bfoptimizer/__main__.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 """Argument parser, optimization loop, and main entry point for bfoptimizer."""
 
 from __future__ import annotations

--- a/tools/bfoptimizer/ai.py
+++ b/tools/bfoptimizer/ai.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 import functools
 import json
 import logging

--- a/tools/bfoptimizer/build.py
+++ b/tools/bfoptimizer/build.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 import asyncio
 import enum
 import logging

--- a/tools/bfoptimizer/log.py
+++ b/tools/bfoptimizer/log.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 """Translation of claude_agent_sdk messages into bfoptimizer log records."""
 
 import enum

--- a/tools/bfoptimizer/models.py
+++ b/tools/bfoptimizer/models.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 """Data models for the bfoptimizer package."""
 
 from __future__ import annotations

--- a/tools/bfoptimizer/templates/_conventions.j2
+++ b/tools/bfoptimizer/templates/_conventions.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 ## Register conventions
 
 r6  – header pointer, reloaded from the stack runtime context (l3_hdr/l4_hdr) for each matcher

--- a/tools/bfoptimizer/templates/implementation.j2
+++ b/tools/bfoptimizer/templates/implementation.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 You are implementing a BPF bytecode optimization in the bpfilter project.
 
 {% include "_conventions.j2" %}

--- a/tools/bfoptimizer/templates/proposal.j2
+++ b/tools/bfoptimizer/templates/proposal.j2
@@ -1,3 +1,4 @@
+{# Copyright (c) Meta Platforms, Inc. and affiliates. #}
 You are an expert BPF/eBPF engineer optimizing the BPF bytecode generation logic in the bpfilter project.
 
 bpfilter translates packet filtering rules into BPF programs that run in the Linux kernel for every packet. Every BPF instruction eliminated from generated programs reduces per-packet latency on the hot path.

--- a/tools/bfoptimizer/tui.py
+++ b/tools/bfoptimizer/tui.py
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 """Textual UI for bfoptimizer.
 
 Owns every widget and the App shell. The optimization loop itself is

--- a/tools/bpfilter.tape
+++ b/tools/bpfilter.tape
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # VHS script to generate the demo GIFs
 #
 # Uses https://github.com/charmbracelet/vhs

--- a/tools/bpfilter_dark.tape
+++ b/tools/bpfilter_dark.tape
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # See bpfilter.tape for details
 
 Output doc/_static/demo_dark.gif

--- a/tools/bpfilter_light.tape
+++ b/tools/bpfilter_light.tape
@@ -1,3 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 # See bpfilter.tape for details
 
 Output doc/_static/demo_light.gif


### PR DESCRIPTION
## Summary

Meta requires a specific copyright header to be in the source files, add the missing ones.

## Testing

Full build, tests, and document generation.
