### PR TITLE
cli: don't return an error code on `bfcli --usage`

### DIFF
--- a/src/bfcli/opts.c
+++ b/src/bfcli/opts.c
@@ -297,7 +297,6 @@ static void _bfc_opts_help(struct argp_state *state, const char *arg,
     (void)opts;
 
     argp_state_help(state, state->out_stream, ARGP_HELP_STD_HELP);
-    exit(0);
 };
 
 static void _bfc_opts_usage(struct argp_state *state, const char *arg,
@@ -306,8 +305,8 @@ static void _bfc_opts_usage(struct argp_state *state, const char *arg,
     (void)arg;
     (void)opts;
 
-    argp_state_help(state, state->out_stream, ARGP_HELP_STD_USAGE);
-    exit(0);
+    argp_state_help(state, state->out_stream,
+                    ARGP_HELP_SHORT_USAGE | ARGP_HELP_EXIT_OK);
 };
 
 static void _bfc_opts_version(struct argp_state *state, const char *arg,


### PR DESCRIPTION
## Summary

`argp_state_help()` calls `exit()` with a non-zero value when `ARGP_HELP_STD_USAGE` is used. Leading to an extra log line suggesting the user to use `--help` or `--usage`. This is due to the fact we manually trigger `arpg_state_help()` (instead of relying on argp's default behaviour).

Replace `ARGP_HELP_STD_USAGE` with `ARGP_HELP_SHORT_USAGE | ARGP_HELP_EXIT_OK` to `exit(0)`. Only the usage message will be printed, and bfcli will return cleanly.

## Related issue

N/A

## Testing

Before:
```shell
$ bfcli --usage
Usage: bfcli [OPTION...] OBJECT ACTION
Try `bfcli --help' or `bfcli --usage' for more information.
```

After:
```shell
$ bfcli --usage
Usage: bfcli [OPTION...] OBJECT ACTION
```

## Notes for the reviewer

N/A

## AI disclosure

AI wasn't used.

## Checklist

- [x] I understand every line in this PR and can explain why it is correct
- [x] I built the project and ran the tests covering this change
- [x] `make -C $BUILD test_bin test` passes and the code follows the style guide
- [x] Commits are formatted as `component: subcomponent: short description`
- [x] I have disclosed any AI usage above
